### PR TITLE
Harden processing and add structural recall

### DIFF
--- a/ollama_sentinel/__init__.py
+++ b/ollama_sentinel/__init__.py
@@ -2,7 +2,7 @@
 Ollama Sentinel - Continuous code review with Ollama.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from .config import load_config
 from .models import SentinelConfig

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -21,6 +21,26 @@ from watchfiles import Change
 app = typer.Typer()
 console = Console()
 
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"ollama-sentinel {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _main(
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+) -> None:
+    pass
+
 # Configure rich console and logging
 logging.basicConfig(
     level=logging.INFO,

--- a/ollama_sentinel/config.py
+++ b/ollama_sentinel/config.py
@@ -55,21 +55,16 @@ def create_default_config(directory: str, output_dir: str = ".ollama_reviews") -
         "watch": {
             "directory": directory,
             "recursive": True,
+            # Built-in patterns (dotdirs, binaries, lock files) are always active.
+            # List only project-specific extras here.
             "ignore_patterns": [
                 "*.md",
                 "*.log",
-                "**/.git/**",
-                "**/node_modules/**",
-                "**/__pycache__/**",
-                "**/.planning/intel/.watcher_heartbeat",
-                "**/*.db",
-                "**/*.sqlite",
-                "**/*.sqlite3",
-                "**/*.mdb",
-                "**/*.lock",
-                f"**/{output_dir}/**"
+                f"**/{output_dir}/**",
             ],
-            "debounce_ms": 1500
+            "debounce_ms": 1500,
+            "max_file_size_kb": 512,
+            "disable_builtin_ignores": False,
         },
         "ollama": {
             "host": "http://localhost:11434",

--- a/ollama_sentinel/config.py
+++ b/ollama_sentinel/config.py
@@ -61,12 +61,19 @@ def create_default_config(directory: str, output_dir: str = ".ollama_reviews") -
                 "**/.git/**",
                 "**/node_modules/**",
                 "**/__pycache__/**",
+                "**/.planning/intel/.watcher_heartbeat",
+                "**/*.db",
+                "**/*.sqlite",
+                "**/*.sqlite3",
+                "**/*.mdb",
+                "**/*.lock",
                 f"**/{output_dir}/**"
             ],
             "debounce_ms": 1500
         },
         "ollama": {
             "host": "http://localhost:11434",
+            "request_timeout": 180,
             "models": {
                 "default": {
                     "name": "gemma3:4b",
@@ -89,8 +96,8 @@ def create_default_config(directory: str, output_dir: str = ".ollama_reviews") -
             }
         },
         "processing": {
-            "max_concurrent_reviews": 3,
-            "max_concurrent_chunks_per_file": 2,
+            "max_concurrent_reviews": 1,
+            "max_concurrent_chunks_per_file": 1,
             "git_diff_mode": False,
         },
         "output": {

--- a/ollama_sentinel/extractor.py
+++ b/ollama_sentinel/extractor.py
@@ -37,6 +37,41 @@ def _strip_code_fences(text: str) -> str:
     return text
 
 
+def _loads_findings_json(text: str):
+    """Parse finding JSON from model output.
+
+    Accepts either a raw array or an object containing a ``findings`` array.
+    If the model emits prose around JSON, tries to recover the first JSON-ish
+    array/object before falling back.
+    """
+    cleaned = _strip_code_fences(text)
+    candidates = [cleaned]
+
+    array_start = cleaned.find("[")
+    array_end = cleaned.rfind("]")
+    if array_start != -1 and array_end > array_start:
+        candidates.append(cleaned[array_start:array_end + 1])
+
+    object_start = cleaned.find("{")
+    object_end = cleaned.rfind("}")
+    if object_start != -1 and object_end > object_start:
+        candidates.append(cleaned[object_start:object_end + 1])
+
+    last_error = None
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, TypeError) as e:
+            last_error = e
+            continue
+        if isinstance(parsed, dict) and isinstance(parsed.get("findings"), list):
+            return parsed["findings"]
+        return parsed
+    if last_error:
+        raise last_error
+    raise json.JSONDecodeError("No JSON object or array found", cleaned, 0)
+
+
 def _parse_finding(raw: dict, file_path: str) -> Finding | None:
     """Validate a raw dict and return a Finding, or None if malformed."""
     if not isinstance(raw, dict):
@@ -159,15 +194,18 @@ async def extract_findings(
     prompt = _EXTRACTION_PROMPT.format(review_text=review_text)
 
     try:
-        response = await ollama_client.generate_review(model_role, prompt)
+        response = await ollama_client.generate_review(
+            model_role,
+            prompt,
+            response_format="json",
+        )
     except Exception:
         log.warning("Ollama API error during finding extraction; trying regex fallback")
         return _extract_from_markdown(review_text, file_path)
 
-    cleaned = _strip_code_fences(response)
 
     try:
-        parsed = json.loads(cleaned)
+        parsed = _loads_findings_json(response)
     except (json.JSONDecodeError, TypeError):
         log.warning("Malformed JSON from extraction model; trying regex fallback")
         return _extract_from_markdown(review_text, file_path)

--- a/ollama_sentinel/models.py
+++ b/ollama_sentinel/models.py
@@ -148,6 +148,10 @@ class MemoryConfig(BaseModel):
     db_path: str = ".ollama_reviews/memory.db"
     neighbor_k: int = 10
     semantic_recall: bool = True
+    # Augment recall with 1-hop import-graph neighbors so a finding on a
+    # frequently-imported util surfaces when editing its callers (and vice
+    # versa). Python-only; degrades silently to single-file recall otherwise.
+    structural_recall: bool = True
 
 
 class SentinelConfig(BaseModel):

--- a/ollama_sentinel/models.py
+++ b/ollama_sentinel/models.py
@@ -72,6 +72,8 @@ class WatchConfig(BaseModel):
     recursive: bool = True
     ignore_patterns: List[str] = []
     debounce_ms: int = 1500
+    max_file_size_kb: int = 512
+    disable_builtin_ignores: bool = False
 
 
 class ProcessingConfig(BaseModel):

--- a/ollama_sentinel/processor.py
+++ b/ollama_sentinel/processor.py
@@ -204,6 +204,20 @@ class FileProcessor:
                 self.embedder = None
                 self.retriever = NullRetriever()
 
+        # Structural recall: lazy AST-based import resolver to surface findings
+        # from a file's 1-hop import neighbors. The resolver lives in
+        # research_agent.tools but only depends on stdlib + research_agent.core.logging,
+        # so importing it does not pull in the [research] extras.
+        self._import_resolver = None
+        if config.memory.structural_recall:
+            try:
+                from research_agent.tools.import_resolver import ImportResolver
+                self._import_resolver = ImportResolver(str(self.watch_dir))
+            except Exception as e:
+                log.warning(
+                    "Structural recall unavailable (%s); falling back without it.", e,
+                )
+
         # Token budget for review prompts.
         default_model = config.ollama.models["default"]
         self.total_budget = max(
@@ -300,27 +314,107 @@ class FileProcessor:
     async def _get_ranked_prior_violations(
         self, file_path: pathlib.Path, *, file_content: Optional[str]
     ) -> Optional[List[dict]]:
-        """Fetch prior violations, ranked semantically when possible."""
+        """Fetch prior violations through three layered recall strategies.
+
+        Tries each in order and returns the first non-empty result:
+          1. Semantic recall — cosine similarity of file content against all
+             unresolved findings, top-k.
+          2. Structural recall — findings from this file's 1-hop import
+             neighbors (callers and callees), Python-only.
+          3. Single-file recall — unresolved findings for this file alone.
+
+        Each layer is independently gated by config and degrades silently on
+        failure so review generation is never blocked by a recall error.
+        """
         if not self.violation_db:
             return None
-        try:
-            if (self.config.memory.semantic_recall
-                    and self.embedder is not None
-                    and file_content):
+
+        rel = str(file_path.relative_to(self.watch_dir))
+
+        # Layer 1: semantic recall.
+        if (self.config.memory.semantic_recall
+                and self.embedder is not None
+                and file_content):
+            try:
                 violations = await self.violation_db.get_neighbors_by_similarity(
                     query_text=file_content,
                     embedder=self.embedder,
                     k=self.config.memory.neighbor_k,
                 )
-            else:
-                rel = str(file_path.relative_to(self.watch_dir))
-                violations = await asyncio.to_thread(
-                    self.violation_db.get_unresolved, rel,
-                )
+                if violations:
+                    return violations
+            except Exception as e:
+                log.warning("Semantic recall failed (%s); falling through.", e)
+
+        # Layer 2: structural recall via 1-hop import graph.
+        if self._import_resolver is not None:
+            try:
+                neighbors = await self._resolve_import_neighbors(file_path)
+                if neighbors:
+                    violations = await asyncio.to_thread(
+                        self.violation_db.get_neighbors_unresolved, neighbors,
+                    )
+                    if violations:
+                        return violations
+            except Exception as e:
+                log.warning("Structural recall failed (%s); falling through.", e)
+
+        # Layer 3: single-file recall (always tried last).
+        try:
+            violations = await asyncio.to_thread(
+                self.violation_db.get_unresolved, rel,
+            )
             return violations if violations else None
         except Exception as e:
-            log.warning("Failed to query prior violations (%s); continuing without them.", e)
+            log.warning(
+                "Single-file recall failed (%s); continuing without prior violations.", e,
+            )
             return None
+
+    async def _resolve_import_neighbors(
+        self, file_path: pathlib.Path,
+    ) -> List[str]:
+        """Return relative paths for *file_path* and its 1-hop import neighbors.
+
+        Resolves both directions:
+          - Files imported by *file_path* (callees).
+          - Files in the repo that import *file_path* (callers).
+
+        Paths are returned relative to ``self.watch_dir`` to match
+        ``ViolationDB``'s storage convention. Files outside ``watch_dir`` are
+        silently dropped. Returns ``[]`` if the resolver is unavailable or
+        *file_path* is not Python — letting Layer 3 take over for those cases.
+        """
+        # Resolver is Python-only; non-Python files skip Layer 2 entirely.
+        if self._import_resolver is None or file_path.suffix != ".py":
+            return []
+
+        rel = str(file_path.relative_to(self.watch_dir))
+
+        def _scan() -> List[str]:
+            try:
+                imports = self._import_resolver.resolve_imports(str(file_path))
+                dependents = self._import_resolver.resolve_dependents(str(file_path))
+            except Exception:
+                # Any resolver error — return self only so Layer 2 still gives
+                # us at least the file's own findings.
+                return [rel]
+
+            all_abs = {str(file_path)}
+            all_abs.update(imports)
+            all_abs.update(dependents)
+
+            result: List[str] = []
+            for p in all_abs:
+                try:
+                    r = str(pathlib.Path(p).relative_to(self.watch_dir))
+                    result.append(r)
+                except ValueError:
+                    # Path lives outside watch_dir; ViolationDB won't have rows for it.
+                    pass
+            return result
+
+        return await asyncio.to_thread(_scan)
 
     async def generate_review(self, file_change: FileChange, model_role: str = "default") -> str:
         """

--- a/ollama_sentinel/processor.py
+++ b/ollama_sentinel/processor.py
@@ -57,7 +57,13 @@ class OllamaClient:
         stop=stop_after_attempt(5),
         reraise=True,
     )
-    async def generate_with_model(self, model_config, prompt: str) -> str:
+    async def generate_with_model(
+        self,
+        model_config,
+        prompt: str,
+        *,
+        response_format: Optional[str] = None,
+    ) -> str:
         """Send `prompt` to Ollama using an explicit model config.
 
         `model_config` is either an OllamaModelConfig-compatible dict
@@ -78,6 +84,13 @@ class OllamaClient:
         max_tokens = _get("max_tokens", None)
 
         url = f"{self.config['host']}/api/chat"
+        options = {
+            "temperature": temperature,
+            "top_p": top_p,
+        }
+        if max_tokens is not None:
+            options["num_predict"] = max_tokens
+
         payload = {
             "model": name,
             "messages": [
@@ -85,11 +98,10 @@ class OllamaClient:
                 {"role": "user", "content": prompt},
             ],
             "stream": False,
-            "temperature": temperature,
-            "top_p": top_p,
+            "options": options,
         }
-        if max_tokens is not None:
-            payload["max_tokens"] = max_tokens
+        if response_format is not None:
+            payload["format"] = response_format
 
         headers = {"Content-Type": "application/json"}
         try:
@@ -97,15 +109,30 @@ class OllamaClient:
             response.raise_for_status()
             return response.json()["message"]["content"]
         except httpx.HTTPError as e:
-            log.error(f"Ollama API error: {str(e)}")
+            log.error(
+                "Ollama API error (%s): %s",
+                type(e).__name__,
+                str(e) or "(no message)",
+                exc_info=True,
+            )
             raise
 
-    async def generate_review(self, model_role: str, prompt: str) -> str:
+    async def generate_review(
+        self,
+        model_role: str,
+        prompt: str,
+        *,
+        response_format: Optional[str] = None,
+    ) -> str:
         """Send `prompt` to Ollama using a role name looked up in config."""
         if model_role not in self.config["models"]:
             log.warning(f"Model role '{model_role}' not found, falling back to default")
             model_role = "default"
-        return await self.generate_with_model(self.config["models"][model_role], prompt)
+        return await self.generate_with_model(
+            self.config["models"][model_role],
+            prompt,
+            response_format=response_format,
+        )
 
 
 class _DiskcacheAdapter:

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -2,6 +2,7 @@
 SQLite persistence layer for tracking code review findings.
 """
 import sqlite3
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import List
@@ -39,29 +40,33 @@ class ViolationDB:
     """
 
     def __init__(self, db_path: str) -> None:
-        self._conn = sqlite3.connect(db_path)
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute(self._CREATE_TABLE)
-        self._conn.commit()
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        with self._lock:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA busy_timeout=5000")
+            self._conn.execute(self._CREATE_TABLE)
+            self._conn.commit()
         self._migrate()
 
     def _migrate(self) -> None:
         """Idempotent migration: add the embed_text column and backfill values."""
         try:
-            cur = self._conn.execute("PRAGMA table_info(findings)")
-            cols = {row[1] for row in cur.fetchall()}
-            if "embed_text" not in cols:
-                self._conn.execute("ALTER TABLE findings ADD COLUMN embed_text TEXT")
-                self._conn.execute(
-                    """
-                    UPDATE findings
-                    SET embed_text =
-                        '[' || severity || '] ' || category || ' at ' ||
-                        file_path || ':' || line_start || ': ' || description
-                    WHERE embed_text IS NULL
-                    """
-                )
-                self._conn.commit()
+            with self._lock:
+                cur = self._conn.execute("PRAGMA table_info(findings)")
+                cols = {row[1] for row in cur.fetchall()}
+                if "embed_text" not in cols:
+                    self._conn.execute("ALTER TABLE findings ADD COLUMN embed_text TEXT")
+                    self._conn.execute(
+                        """
+                        UPDATE findings
+                        SET embed_text =
+                            '[' || severity || '] ' || category || ' at ' ||
+                            file_path || ':' || line_start || ': ' || description
+                        WHERE embed_text IS NULL
+                        """
+                    )
+                    self._conn.commit()
         except sqlite3.DatabaseError as e:
             import logging
             logging.getLogger("ollama-sentinel").error("ViolationDB migration failed: %s", e)
@@ -81,66 +86,68 @@ class ViolationDB:
             return
 
         now = datetime.now(timezone.utc).isoformat()
-        cur = self._conn.cursor()
-        try:
-            for f in findings:
-                cur.execute(
-                    """
-                    SELECT id FROM findings
-                    WHERE file_path  = ?
-                      AND line_start = ?
-                      AND line_end   = ?
-                      AND category   = ?
-                      AND resolved   = 0
-                    """,
-                    (f.file_path, f.line_start, f.line_end, f.category),
-                )
-                row = cur.fetchone()
-                if row:
+        with self._lock:
+            cur = self._conn.cursor()
+            try:
+                for f in findings:
                     cur.execute(
                         """
-                        UPDATE findings
-                        SET occurrence_count = occurrence_count + 1,
-                            last_seen       = ?
-                        WHERE id = ?
+                        SELECT id FROM findings
+                        WHERE file_path  = ?
+                          AND line_start = ?
+                          AND line_end   = ?
+                          AND category   = ?
+                          AND resolved   = 0
                         """,
-                        (now, row[0]),
+                        (f.file_path, f.line_start, f.line_end, f.category),
                     )
-                else:
-                    embed_text = (
-                        f"[{f.severity}] {f.category} at {f.file_path}:{f.line_start}: {f.description}"
-                    )
-                    cur.execute(
-                        """
-                        INSERT INTO findings
-                            (file_path, line_start, line_end, category,
-                             severity, description, first_seen, last_seen, embed_text)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            f.file_path,
-                            f.line_start,
-                            f.line_end,
-                            f.category,
-                            f.severity,
-                            f.description,
-                            now,
-                            now,
-                            embed_text,
-                        ),
-                    )
-            self._conn.commit()
-        except Exception:
-            self._conn.rollback()
-            raise
+                    row = cur.fetchone()
+                    if row:
+                        cur.execute(
+                            """
+                            UPDATE findings
+                            SET occurrence_count = occurrence_count + 1,
+                                last_seen       = ?
+                            WHERE id = ?
+                            """,
+                            (now, row[0]),
+                        )
+                    else:
+                        embed_text = (
+                            f"[{f.severity}] {f.category} at {f.file_path}:{f.line_start}: {f.description}"
+                        )
+                        cur.execute(
+                            """
+                            INSERT INTO findings
+                                (file_path, line_start, line_end, category,
+                                 severity, description, first_seen, last_seen, embed_text)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                            (
+                                f.file_path,
+                                f.line_start,
+                                f.line_end,
+                                f.category,
+                                f.severity,
+                                f.description,
+                                now,
+                                now,
+                                embed_text,
+                            ),
+                        )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
 
     def mark_resolved(self, finding_id: int) -> None:
         """Set *resolved=1* for the given finding."""
-        self._conn.execute(
-            "UPDATE findings SET resolved = 1 WHERE id = ?",
-            (finding_id,),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE findings SET resolved = 1 WHERE id = ?",
+                (finding_id,),
+            )
+            self._conn.commit()
 
     # ------------------------------------------------------------------
     # Read operations
@@ -148,40 +155,44 @@ class ViolationDB:
 
     def get_unresolved(self, file_path: str) -> List[dict]:
         """Return all unresolved findings for *file_path*."""
-        cur = self._conn.execute(
-            "SELECT * FROM findings WHERE file_path = ? AND resolved = 0",
-            (file_path,),
-        )
-        return self._rows_to_dicts(cur)
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM findings WHERE file_path = ? AND resolved = 0",
+                (file_path,),
+            )
+            return self._rows_to_dicts(cur)
 
     def get_all_unresolved(self) -> List[dict]:
         """Return every unresolved finding across all files."""
-        cur = self._conn.execute("SELECT * FROM findings WHERE resolved = 0")
-        return self._rows_to_dicts(cur)
+        with self._lock:
+            cur = self._conn.execute("SELECT * FROM findings WHERE resolved = 0")
+            return self._rows_to_dicts(cur)
 
     def get_neighbors_unresolved(self, file_paths: List[str]) -> List[dict]:
         """Return all unresolved findings for multiple *file_paths*."""
         if not file_paths:
             return []
         placeholders = ", ".join("?" * len(file_paths))
-        cur = self._conn.execute(
-            f"SELECT * FROM findings WHERE file_path IN ({placeholders}) AND resolved = 0",
-            file_paths,
-        )
-        return self._rows_to_dicts(cur)
+        with self._lock:
+            cur = self._conn.execute(
+                f"SELECT * FROM findings WHERE file_path IN ({placeholders}) AND resolved = 0",
+                file_paths,
+            )
+            return self._rows_to_dicts(cur)
 
     def get_recurring(self, min_count: int = 2, limit: int = 20) -> List[dict]:
         """Return findings with occurrence_count >= *min_count*, ordered desc."""
-        cur = self._conn.execute(
-            """
-            SELECT * FROM findings
-            WHERE occurrence_count >= ?
-            ORDER BY occurrence_count DESC
-            LIMIT ?
-            """,
-            (min_count, limit),
-        )
-        return self._rows_to_dicts(cur)
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                SELECT * FROM findings
+                WHERE occurrence_count >= ?
+                ORDER BY occurrence_count DESC
+                LIMIT ?
+                """,
+                (min_count, limit),
+            )
+            return self._rows_to_dicts(cur)
 
     async def get_neighbors_by_similarity(
         self,
@@ -241,7 +252,8 @@ class ViolationDB:
 
     def close(self) -> None:
         """Close the underlying database connection."""
-        self._conn.close()
+        with self._lock:
+            self._conn.close()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/ollama_sentinel/watcher.py
+++ b/ollama_sentinel/watcher.py
@@ -18,6 +18,84 @@ from .violation_db import ViolationDB
 
 log = logging.getLogger("ollama-sentinel")
 
+# Always-on noise filters applied regardless of user config.
+# Covers dotdirs, build artifacts, lock files, binaries, and media.
+# Set watch.disable_builtin_ignores: true in config to opt out.
+_BUILTIN_IGNORE_PATTERNS: list[str] = [
+    # VCS / IDE dotdirs
+    "**/.git/**",
+    "**/.claude/**",
+    "**/.planning/**",
+    "**/.build/**",
+    "**/.idea/**",
+    "**/.vscode/**",
+    "**/.pytest_cache/**",
+    "**/.mypy_cache/**",
+    "**/.ruff_cache/**",
+    "**/.tox/**",
+    "**/.venv/**",
+    "**/venv/**",
+    "**/.next/**",
+    "**/.nuxt/**",
+    "**/.cache/**",
+    # Build output dirs
+    "**/node_modules/**",
+    "**/__pycache__/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/target/**",
+    "**/.gradle/**",
+    "**/DerivedData/**",
+    "**/.ollama_reviews/**",
+    # Lock / DB / binary extensions
+    "**/*.mdb",
+    "**/*.lock",
+    "**/*.lockb",
+    "**/*.db",
+    "**/*.sqlite",
+    "**/*.sqlite3",
+    "**/*.so",
+    "**/*.dylib",
+    "**/*.dll",
+    "**/*.exe",
+    "**/*.o",
+    "**/*.a",
+    "**/*.class",
+    "**/*.jar",
+    "**/*.pyc",
+    "**/*.pyo",
+    "**/*.pyd",
+    "**/*.zip",
+    "**/*.tar",
+    "**/*.gz",
+    "**/*.bz2",
+    "**/*.png",
+    "**/*.jpg",
+    "**/*.jpeg",
+    "**/*.gif",
+    "**/*.ico",
+    "**/*.pdf",
+    "**/*.woff",
+    "**/*.woff2",
+    "**/*.ttf",
+    "**/*.eot",
+    "**/*.mp4",
+    "**/*.mp3",
+    "**/*.mov",
+    # Hidden heartbeat / meta files
+    "**/.DS_Store",
+    "**/.watcher_heartbeat",
+]
+
+
+def _is_likely_binary(path: pathlib.Path, peek_bytes: int = 8192) -> bool:
+    """Return True if the file appears to be binary (contains a null byte in the first peek_bytes)."""
+    try:
+        with open(path, "rb") as fh:
+            return b"\x00" in fh.read(peek_bytes)
+    except OSError:
+        return False
+
 
 class FileSentinel:
     """Main sentinel class that watches for file changes and coordinates processing."""
@@ -54,37 +132,59 @@ class FileSentinel:
     
     def _initialize_ignore_spec(self):
         """Initialize PathSpec for proper gitignore-style pattern matching."""
-        patterns = self.config.watch.ignore_patterns.copy()
-        
+        patterns: list[str] = []
+
+        # Prepend built-in noise filters unless explicitly disabled
+        if not self.config.watch.disable_builtin_ignores:
+            patterns.extend(_BUILTIN_IGNORE_PATTERNS)
+            log.info(
+                "%d built-in ignore patterns active; "
+                "set watch.disable_builtin_ignores: true to opt out",
+                len(_BUILTIN_IGNORE_PATTERNS),
+            )
+
         # Add patterns from .gitignore if git repository is available
         if hasattr(self.processor, 'repo') and self.processor.repo:
             try:
                 gitignore_path = pathlib.Path(self.processor.repo.working_dir) / '.gitignore'
                 if gitignore_path.exists():
                     with open(gitignore_path, 'r') as f:
-                        gitignore_patterns = [line.strip() for line in f 
+                        gitignore_patterns = [line.strip() for line in f
                                              if line.strip() and not line.startswith('#')]
                     patterns.extend(gitignore_patterns)
             except Exception as e:
                 log.warning(f"Failed to load .gitignore: {e}")
-        
+
+        # Append user-configured patterns last so they can override/extend
+        patterns.extend(self.config.watch.ignore_patterns)
+
         # Create PathSpec object
         self._ignore_spec = pathspec.PathSpec.from_lines('gitwildmatch', patterns)
     
     def _should_ignore(self, path: pathlib.Path) -> bool:
         """
         Check if a file should be ignored.
-        
+
         Args:
             path: Path to check
-            
+
         Returns:
             True if the file should be ignored, False otherwise
         """
         # Always ignore the output directory
         if self.config.output.directory in path.parts:
             return True
-        
+
+        # Enforce size limit (protect Ollama context window and skip large binaries).
+        # OSError means the file vanished — skip the size check and let the
+        # is_file() guard in the caller handle it.
+        max_bytes = self.config.watch.max_file_size_kb * 1024
+        try:
+            if path.stat().st_size > max_bytes:
+                return True
+        except OSError:
+            pass
+
         # Use PathSpec for matching
         try:
             rel_path = str(path.relative_to(self.processor.watch_dir))
@@ -105,6 +205,10 @@ class FileSentinel:
         rel_path = path.relative_to(self.processor.watch_dir)
 
         if not path.is_file() or self._should_ignore(path):
+            return
+
+        if _is_likely_binary(path):
+            log.debug("Skipping binary file %s", rel_path)
             return
 
         log.info(f"Processing {rel_path}")
@@ -172,7 +276,11 @@ class FileSentinel:
         # Debounce parameters
         debounce_base = self.config.watch.debounce_ms / 1000
         
-        async for changes in awatch(watch_dir, recursive=self.config.watch.recursive):
+        async for changes in awatch(
+            watch_dir,
+            recursive=self.config.watch.recursive,
+            watch_filter=lambda _, path_str: not self._should_ignore(pathlib.Path(path_str)),
+        ):
             now = time.monotonic()
             
             # Process new events

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ollama-sentinel"
-version = "0.1.0"
+version = "0.1.1"
 description = "Continuous code review with Ollama and a multi-step research agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -148,6 +148,42 @@ class TestExtractFindingsHappyPath:
         assert len(results) == 1
         assert results[0].description == "Trailing whitespace"
 
+    async def test_object_wrapped_findings_array(
+        self, ollama_config, httpx_mock: HTTPXMock
+    ):
+        """Model returning {"findings": [...]} is accepted."""
+        response_json = json.dumps({
+            "findings": [
+                {
+                    "line_start": 7,
+                    "line_end": 9,
+                    "category": "bug",
+                    "severity": "medium",
+                    "description": "Bounds check is missing",
+                },
+            ],
+        })
+
+        httpx_mock.add_response(
+            url=OLLAMA_CHAT_URL,
+            json={"message": {"content": response_json}},
+        )
+
+        client = OllamaClient(ollama_config)
+        try:
+            results = await extract_findings(
+                review_text="review text",
+                file_path="src/bounds.py",
+                ollama_client=client,
+            )
+        finally:
+            await client.close()
+
+        assert len(results) == 1
+        assert results[0].line_start == 7
+        request_body = json.loads(httpx_mock.get_requests()[0].content)
+        assert request_body["format"] == "json"
+
 
 # ---------------------------------------------------------------------------
 # Edge-case tests

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -529,11 +529,15 @@ class TestConfigLoading:
 
     def test_create_default_config_uses_safe_local_ollama_defaults(self):
         """Generated configs avoid local Ollama overload and generated artifacts."""
+        from ollama_sentinel.watcher import _BUILTIN_IGNORE_PATTERNS
         result = create_default_config("/some/dir")
         assert result["ollama"]["request_timeout"] == 180
         assert result["processing"]["max_concurrent_reviews"] == 1
         assert result["processing"]["max_concurrent_chunks_per_file"] == 1
-        assert "**/*.mdb" in result["watch"]["ignore_patterns"]
+        # .mdb and other binary extensions are covered by built-in patterns,
+        # not by the init template — verify built-ins include them instead.
+        assert "**/*.mdb" in _BUILTIN_IGNORE_PATTERNS
+        assert result["watch"]["disable_builtin_ignores"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -527,6 +527,14 @@ class TestConfigLoading:
         default_model = result["ollama"]["models"]["default"]["name"]
         assert default_model == "gemma3:4b"
 
+    def test_create_default_config_uses_safe_local_ollama_defaults(self):
+        """Generated configs avoid local Ollama overload and generated artifacts."""
+        result = create_default_config("/some/dir")
+        assert result["ollama"]["request_timeout"] == 180
+        assert result["processing"]["max_concurrent_reviews"] == 1
+        assert result["processing"]["max_concurrent_chunks_per_file"] == 1
+        assert "**/*.mdb" in result["watch"]["ignore_patterns"]
+
 
 # ---------------------------------------------------------------------------
 # OllamaClient.generate_with_model tests
@@ -575,6 +583,27 @@ class TestGenerateWithModel:
         finally:
             await client.close()
         assert out == "default output"
+
+    async def test_generate_review_can_request_json_format(self, ollama_config, httpx_mock):
+        """Passing response_format sends Ollama's structured-output format flag."""
+        httpx_mock.add_response(
+            url=OLLAMA_CHAT_URL,
+            json={"message": {"content": "[]"}},
+        )
+        client = OllamaClient(ollama_config)
+        try:
+            out = await client.generate_review(
+                "default",
+                "extract findings",
+                response_format="json",
+            )
+        finally:
+            await client.close()
+        assert out == "[]"
+        import json as _json
+        body = _json.loads(httpx_mock.get_requests()[0].content)
+        assert body["format"] == "json"
+        assert body["options"]["temperature"] == 0.1
 
     async def test_generate_with_model_config_object(self, ollama_config, httpx_mock):
         """Passing an OllamaModelConfig object (not dict) also works."""

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -13,6 +13,7 @@ from watchfiles import Change
 from ollama_sentinel.config import create_default_config, load_config
 from ollama_sentinel.models import (
     HistoryConfig,
+    MemoryConfig,
     OllamaConfig,
     OllamaModelConfig,
     OutputConfig,
@@ -627,3 +628,202 @@ class TestGenerateWithModel:
         body = _json.loads(httpx_mock.get_requests()[0].content)
         assert body["model"] == "obj-model"
         assert body["messages"][0]["content"] == "obj prompt"
+
+
+# ---------------------------------------------------------------------------
+# Structural recall (import-graph neighbor recall) tests
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralRecall:
+    """Tests for the import-graph fallback layer in _get_ranked_prior_violations."""
+
+    @staticmethod
+    def _config(tmp_path, *, structural_recall=True):
+        """Config with semantic recall disabled to deterministically exercise
+        the structural / single-file paths without an Ollama dependency."""
+        return SentinelConfig(
+            watch=WatchConfig(directory=str(tmp_path)),
+            ollama=OllamaConfig(
+                host="http://localhost:11434",
+                models={
+                    "default": OllamaModelConfig(
+                        name="test-model", system_prompt="Review code."
+                    ),
+                },
+            ),
+            memory=MemoryConfig(
+                enabled=True,
+                db_path=".ollama_reviews/memory.db",
+                semantic_recall=False,
+                structural_recall=structural_recall,
+            ),
+        )
+
+    @staticmethod
+    def _make_db(tmp_path):
+        """Create a ViolationDB rooted in tmp_path."""
+        from ollama_sentinel.violation_db import ViolationDB
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        return ViolationDB(str(db_path))
+
+    async def test_resolves_findings_from_imported_file(self, tmp_path):
+        """A finding on `utils.py` surfaces when reviewing `app.py` (which imports it)."""
+        from ollama_sentinel.violation_db import Finding
+
+        (tmp_path / "utils.py").write_text("def helper():\n    return 1\n")
+        app = tmp_path / "app.py"
+        app.write_text("from utils import helper\nprint(helper())\n")
+
+        db = self._make_db(tmp_path)
+        try:
+            db.persist_findings("utils.py", [Finding(
+                file_path="utils.py", line_start=1, line_end=2,
+                category="bug", severity="high",
+                description="helper returns wrong type",
+            )])
+
+            fp = FileProcessor(self._config(tmp_path), violation_db=db)
+            try:
+                violations = await fp._get_ranked_prior_violations(
+                    app, file_content=app.read_text(),
+                )
+            finally:
+                await fp.close()
+
+            assert violations is not None
+            paths = {v["file_path"] for v in violations}
+            assert "utils.py" in paths
+        finally:
+            db.close()
+
+    async def test_resolves_findings_from_dependent_file(self, tmp_path):
+        """A finding on `app.py` surfaces when reviewing `utils.py` (which it imports)."""
+        from ollama_sentinel.violation_db import Finding
+
+        utils = tmp_path / "utils.py"
+        utils.write_text("def helper():\n    return 1\n")
+        (tmp_path / "app.py").write_text(
+            "from utils import helper\nprint(helper())\n"
+        )
+
+        db = self._make_db(tmp_path)
+        try:
+            db.persist_findings("app.py", [Finding(
+                file_path="app.py", line_start=1, line_end=1,
+                category="security", severity="high",
+                description="unvalidated input",
+            )])
+
+            fp = FileProcessor(self._config(tmp_path), violation_db=db)
+            try:
+                violations = await fp._get_ranked_prior_violations(
+                    utils, file_content=utils.read_text(),
+                )
+            finally:
+                await fp.close()
+
+            assert violations is not None
+            paths = {v["file_path"] for v in violations}
+            assert "app.py" in paths
+        finally:
+            db.close()
+
+    async def test_falls_back_to_single_file_for_non_python(self, tmp_path):
+        """Non-Python files bypass Layer 2 — the resolver is Python-only."""
+        from ollama_sentinel.violation_db import Finding
+
+        target = tmp_path / "page.html"
+        target.write_text("<html></html>\n")
+        # Unrelated Python file with a finding to verify it does NOT leak in.
+        (tmp_path / "other.py").write_text("x = 1\n")
+
+        db = self._make_db(tmp_path)
+        try:
+            db.persist_findings("page.html", [Finding(
+                file_path="page.html", line_start=1, line_end=1,
+                category="style", severity="low",
+                description="missing doctype",
+            )])
+            db.persist_findings("other.py", [Finding(
+                file_path="other.py", line_start=1, line_end=1,
+                category="bug", severity="high",
+                description="should not surface for an HTML file",
+            )])
+
+            fp = FileProcessor(self._config(tmp_path), violation_db=db)
+            try:
+                violations = await fp._get_ranked_prior_violations(
+                    target, file_content=target.read_text(),
+                )
+            finally:
+                await fp.close()
+
+            assert violations is not None
+            paths = {v["file_path"] for v in violations}
+            assert paths == {"page.html"}
+        finally:
+            db.close()
+
+    async def test_handles_syntax_error_gracefully(self, tmp_path):
+        """A file with a SyntaxError still gets its own findings via Layer 2/3."""
+        from ollama_sentinel.violation_db import Finding
+
+        broken = tmp_path / "broken.py"
+        broken.write_text("def f(:\n  pass\n")  # intentional syntax error
+
+        db = self._make_db(tmp_path)
+        try:
+            db.persist_findings("broken.py", [Finding(
+                file_path="broken.py", line_start=1, line_end=1,
+                category="bug", severity="high",
+                description="prior finding from earlier review",
+            )])
+
+            fp = FileProcessor(self._config(tmp_path), violation_db=db)
+            try:
+                violations = await fp._get_ranked_prior_violations(
+                    broken, file_content=broken.read_text(),
+                )
+            finally:
+                await fp.close()
+
+            assert violations is not None
+            paths = {v["file_path"] for v in violations}
+            assert "broken.py" in paths
+        finally:
+            db.close()
+
+    async def test_disabled_via_config_skips_neighbor_lookup(self, tmp_path):
+        """structural_recall: false suppresses Layer 2 entirely."""
+        from ollama_sentinel.violation_db import Finding
+
+        (tmp_path / "utils.py").write_text("def helper():\n    return 1\n")
+        app = tmp_path / "app.py"
+        app.write_text("from utils import helper\nprint(helper())\n")
+
+        db = self._make_db(tmp_path)
+        try:
+            # Finding only on utils.py — only structural recall would surface
+            # it when reviewing app.py. With structural disabled and no
+            # findings on app.py itself, the result must be None.
+            db.persist_findings("utils.py", [Finding(
+                file_path="utils.py", line_start=1, line_end=2,
+                category="bug", severity="high",
+                description="never surfaces",
+            )])
+
+            fp = FileProcessor(
+                self._config(tmp_path, structural_recall=False), violation_db=db,
+            )
+            try:
+                violations = await fp._get_ranked_prior_violations(
+                    app, file_content=app.read_text(),
+                )
+            finally:
+                await fp.close()
+
+            assert violations is None
+        finally:
+            db.close()

--- a/tests/test_research_agent.py
+++ b/tests/test_research_agent.py
@@ -149,7 +149,7 @@ class TestResearchSession:
 # 2. SearchResult.__post_init__ domain extraction
 # ===================================================================
 
-@pytest.mark.skipif(not HAS_SEARCH, reason="langchain_core not installed")
+@pytest.mark.skipif(not HAS_SEARCH, reason="research search dependencies unavailable")
 class TestSearchResultDomainExtraction:
     """Tests for SearchResult automatic domain extraction from URL."""
 
@@ -211,7 +211,7 @@ class TestSearchResultDomainExtraction:
 #     stdlib urllib.parse, so we replicate it locally.
 # ===================================================================
 
-@pytest.mark.skipif(HAS_SEARCH, reason="Only runs when langchain_core is NOT installed")
+@pytest.mark.skipif(HAS_SEARCH, reason="Fallback test — only runs when research search dependencies are unavailable")
 class TestSearchResultDomainExtractionFallback:
     """Inline replica of SearchResult so the domain-extraction logic
     is tested even without langchain_core."""
@@ -367,7 +367,7 @@ class TestCache:
 # 4. BrowserTool._validate_url
 # ===================================================================
 
-@pytest.mark.skipif(not HAS_BROWSER, reason="playwright not installed")
+@pytest.mark.skipif(not HAS_BROWSER, reason="research browser dependencies unavailable")
 class TestBrowserToolValidateUrl:
     """Tests for BrowserTool._validate_url SSRF protection."""
 
@@ -414,7 +414,7 @@ class TestBrowserToolValidateUrl:
 # 4b. _validate_url — fallback when browser.py can't be imported
 # ===================================================================
 
-@pytest.mark.skipif(HAS_BROWSER, reason="Only runs when playwright is NOT installed")
+@pytest.mark.skipif(HAS_BROWSER, reason="Fallback test — only runs when research browser dependencies are unavailable")
 class TestValidateUrlFallback:
     """Re-implement _validate_url inline so we can still test the
     SSRF-protection logic even when playwright is not installed."""

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -1,6 +1,7 @@
 """Tests for ollama_sentinel.violation_db persistence layer."""
 
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -37,6 +38,24 @@ class TestDBCreation:
         db = ViolationDB(str(db_path))
         try:
             assert db_path.exists()
+        finally:
+            db.close()
+
+    def test_duplicate_finding_can_persist_from_worker_threads(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "memory.db"))
+        finding = _make_finding()
+        try:
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futures = [
+                    pool.submit(db.persist_findings, "src/app.py", [finding])
+                    for _ in range(8)
+                ]
+                for future in futures:
+                    future.result()
+
+            rows = db.get_unresolved("src/app.py")
+            assert len(rows) == 1
+            assert rows[0]["occurrence_count"] == 8
         finally:
             db.close()
 

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -346,3 +346,69 @@ class TestGetNeighborsBySimilarity:
         )
         assert rows == []
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    """ViolationDB must be usable from multiple threads (asyncio.to_thread pattern)."""
+
+    def test_concurrent_persist_from_threads(self, tmp_path):
+        """Two threads can persist findings concurrently without raising."""
+        import threading
+
+        db = ViolationDB(str(tmp_path / "threads.db"))
+        errors: list[Exception] = []
+
+        def worker(start: int) -> None:
+            try:
+                for i in range(50):
+                    db.persist_findings(
+                        "a.py",
+                        [_make_finding(line_start=start + i, line_end=start + i)],
+                    )
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(s,)) for s in (0, 100)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Thread errors: {errors}"
+        rows = db.get_all_unresolved()
+        assert len(rows) == 100
+        db.close()
+
+    def test_read_from_different_thread(self, tmp_path):
+        """get_unresolved can be called from a thread other than the one that created the DB."""
+        import threading
+
+        db = ViolationDB(str(tmp_path / "xthread.db"))
+        db.persist_findings("b.py", [_make_finding(file_path="b.py")])
+
+        result: list = []
+        errors: list[Exception] = []
+
+        def reader() -> None:
+            try:
+                result.extend(db.get_unresolved("b.py"))
+            except Exception as exc:
+                errors.append(exc)
+
+        t = threading.Thread(target=reader)
+        t.start()
+        t.join()
+
+        assert errors == [], f"Thread errors: {errors}"
+        assert len(result) == 1
+        db.close()
+
+    def test_close_is_idempotent(self, tmp_path):
+        """Calling close() twice must not raise."""
+        db = ViolationDB(str(tmp_path / "close.db"))
+        db.close()
+        db.close()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -7,7 +7,7 @@ import textwrap
 import pytest
 import yaml
 
-from ollama_sentinel.watcher import FileSentinel
+from ollama_sentinel.watcher import FileSentinel, _BUILTIN_IGNORE_PATTERNS, _is_likely_binary
 
 
 # ---------------------------------------------------------------------------
@@ -171,3 +171,180 @@ class TestShouldIgnore:
         # __pycache__/*.log matches both patterns
         path = tmp_path / "__pycache__" / "trace.log"
         assert sentinel._should_ignore(path) is True
+
+
+# ---------------------------------------------------------------------------
+# Built-in ignore patterns (always-on regardless of user config)
+# ---------------------------------------------------------------------------
+
+MINIMAL_YAML_NO_PATTERNS = textwrap.dedent("""\
+    watch:
+      directory: "{watch_dir}"
+      ignore_patterns: []
+    ollama:
+      host: "http://localhost:11434"
+      models:
+        default:
+          name: "gemma3:4b"
+          system_prompt: "Review this code."
+    output:
+      directory: ".ollama_reviews"
+""")
+
+
+def _sentinel_no_patterns(tmp_path: pathlib.Path) -> FileSentinel:
+    config_path = tmp_path / "ollama-sentinel.yaml"
+    config_path.write_text(MINIMAL_YAML_NO_PATTERNS.format(watch_dir=str(tmp_path)))
+    return FileSentinel(config_path)
+
+
+class TestBuiltinIgnores:
+    """Built-in patterns catch noise files even when user ignore_patterns is empty."""
+
+    def test_claude_dotdir_ignored(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(tmp_path / ".claude" / "x.py") is True
+
+    def test_planning_dotdir_ignored(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(tmp_path / ".planning" / "intel" / ".watcher_heartbeat") is True
+
+    def test_build_dotdir_ignored(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(
+            tmp_path / ".build" / "index-build" / "arm64-apple-macosx" / "debug" / "lock.mdb"
+        ) is True
+
+    def test_node_modules_ignored(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(tmp_path / "node_modules" / "lodash" / "index.js") is True
+
+    def test_mdb_extension_ignored(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(tmp_path / "data" / "store.mdb") is True
+
+    def test_lock_extension_ignored(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(tmp_path / "poetry.lock") is True
+
+    def test_watcher_heartbeat_ignored(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(tmp_path / ".watcher_heartbeat") is True
+
+    def test_python_file_not_ignored(self, tmp_path):
+        """A regular .py file must still pass through with empty user patterns."""
+        s = _sentinel_no_patterns(tmp_path)
+        assert s._should_ignore(tmp_path / "main.py") is False
+
+    def test_builtin_patterns_list_not_empty(self):
+        assert len(_BUILTIN_IGNORE_PATTERNS) > 0
+
+
+# ---------------------------------------------------------------------------
+# Size limit
+# ---------------------------------------------------------------------------
+
+class TestSizeLimit:
+    """Files exceeding max_file_size_kb are ignored."""
+
+    def _make_sentinel(self, tmp_path: pathlib.Path, max_kb: int) -> FileSentinel:
+        config_path = tmp_path / "ollama-sentinel.yaml"
+        cfg = yaml.safe_load(MINIMAL_YAML_NO_PATTERNS.format(watch_dir=str(tmp_path)))
+        cfg["watch"]["max_file_size_kb"] = max_kb
+        config_path.write_text(yaml.dump(cfg))
+        return FileSentinel(config_path)
+
+    def test_oversized_file_ignored(self, tmp_path):
+        s = self._make_sentinel(tmp_path, max_kb=1)
+        big = tmp_path / "big.py"
+        big.write_bytes(b"x" * 2048)  # 2 KB > 1 KB limit
+        assert s._should_ignore(big) is True
+
+    def test_undersized_file_not_ignored(self, tmp_path):
+        s = self._make_sentinel(tmp_path, max_kb=10)
+        small = tmp_path / "small.py"
+        small.write_bytes(b"x" * 100)
+        assert s._should_ignore(small) is False
+
+    def test_nonexistent_file_skips_size_check(self, tmp_path):
+        """_should_ignore should not raise on a non-existent path (size check skips)."""
+        s = self._make_sentinel(tmp_path, max_kb=1)
+        missing = tmp_path / "ghost.py"
+        # Should not raise; falls through to pattern matching
+        result = s._should_ignore(missing)
+        assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# Binary content sniff
+# ---------------------------------------------------------------------------
+
+class TestBinarySniff:
+    """_is_likely_binary detects null bytes in first 8 KB."""
+
+    def test_text_file_not_binary(self, tmp_path):
+        f = tmp_path / "source.py"
+        f.write_text("def hello(): pass\n")
+        assert _is_likely_binary(f) is False
+
+    def test_file_with_null_byte_is_binary(self, tmp_path):
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"some data\x00more data")
+        assert _is_likely_binary(f) is True
+
+    def test_null_byte_beyond_peek_ignored(self, tmp_path):
+        """Null byte beyond peek_bytes window is not detected."""
+        f = tmp_path / "almost_text.dat"
+        f.write_bytes(b"a" * 8192 + b"\x00")
+        assert _is_likely_binary(f) is False
+
+    def test_missing_file_returns_false(self, tmp_path):
+        assert _is_likely_binary(tmp_path / "nonexistent.bin") is False
+
+
+# ---------------------------------------------------------------------------
+# disable_builtin_ignores opt-out
+# ---------------------------------------------------------------------------
+
+class TestDisableBuiltins:
+    """Setting disable_builtin_ignores: true suppresses the built-in list."""
+
+    def _sentinel_no_builtins(self, tmp_path: pathlib.Path) -> FileSentinel:
+        config_path = tmp_path / "ollama-sentinel.yaml"
+        cfg = yaml.safe_load(MINIMAL_YAML_NO_PATTERNS.format(watch_dir=str(tmp_path)))
+        cfg["watch"]["disable_builtin_ignores"] = True
+        cfg["watch"]["ignore_patterns"] = []
+        config_path.write_text(yaml.dump(cfg))
+        return FileSentinel(config_path)
+
+    def test_claude_dotdir_not_ignored_when_disabled(self, tmp_path):
+        s = self._sentinel_no_builtins(tmp_path)
+        # .claude/x.py is only blocked by builtins; with them off it passes
+        assert s._should_ignore(tmp_path / ".claude" / "x.py") is False
+
+    def test_mdb_not_ignored_when_disabled(self, tmp_path):
+        s = self._sentinel_no_builtins(tmp_path)
+        assert s._should_ignore(tmp_path / "store.mdb") is False
+
+
+# ---------------------------------------------------------------------------
+# watch_filter callable
+# ---------------------------------------------------------------------------
+
+class TestWatchFilterCallable:
+    """The watch_filter passed to awatch correctly gates on _should_ignore."""
+
+    def test_filter_rejects_builtin_noise(self, tmp_path):
+        """Paths that _should_ignore catches also fail the watch_filter."""
+        s = _sentinel_no_patterns(tmp_path)
+        from watchfiles import Change
+        # Simulate the lambda watchfiles will call
+        filter_fn = lambda _, p: not s._should_ignore(pathlib.Path(p))
+        assert filter_fn(Change.modified, str(tmp_path / ".planning" / ".watcher_heartbeat")) is False
+        assert filter_fn(Change.modified, str(tmp_path / "data" / "store.mdb")) is False
+
+    def test_filter_passes_source_file(self, tmp_path):
+        s = _sentinel_no_patterns(tmp_path)
+        from watchfiles import Change
+        filter_fn = lambda _, p: not s._should_ignore(pathlib.Path(p))
+        assert filter_fn(Change.modified, str(tmp_path / "app.py")) is True


### PR DESCRIPTION
## Summary
- Make violation memory SQLite access thread-safe for worker-thread persistence.
- Add Ollama JSON-mode support for structured finding extraction and more resilient JSON parsing.
- Lower generated local Ollama defaults to safer concurrency and add generated/binary artifact ignore patterns.
- Add structural recall as an optional memory layer for ranking prior violations via one-hop Python import relationships.
- Layer recall sources in order: semantic recall, structural recall, then single-file recall fallback.
- Add processor tests for import-neighbor recall, dependent-file recall, non-Python fallback, syntax-error resilience, and config-driven disabling.
- Clarify research-agent dependency fallback skip reasons.

## Validation
- `pytest tests/ -q` → 353 passed, 15 skipped

## Links
- Conversation: https://app.warp.dev/conversation/70e61a36-9b77-4ba6-b990-166c29d364c2

Co-Authored-By: Oz <oz-agent@warp.dev>