### PR TITLE
Phase A: hot-path swap to qwen3-embedding:4b + pre-registered role schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 All open backlog items from the last two sessions are closed. Remaining
 deferred work is low-priority and not blocking anything:
 
-1. **Sanity check first.** `pytest tests/ -q` should report 365 / 15 skip.
+1. **Sanity check first.** `pytest tests/ -q` should report 378 / 15 skip.
 2. **Remaining open items** (from `docs/superpowers/followups.md`):
    - CB-1 — dedupe impact-report formatters (harmless until `build_research_context` is reachable for impact data)
 ### Pickable next moves (ordered by leverage)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,9 +178,13 @@ Skip TR-3 — deliberate spec deviation, documented in followups.md.
   langchain, playwright, llama-index). Not installed by default.
 - `impact_scan` node tested with mocked logic only — needs integration
   test against real LangGraph compile with `OPENAI_API_KEY`.
-- `ollama-sentinel run` requires `ollama pull nomic-embed-text` once on
-  first use, or set `memory.semantic_recall: false` to fall back to the
-  legacy exact-path recall.
+- `ollama-sentinel run` requires `ollama pull qwen3-embedding:4b` once on
+  first use (~2.5 GB), or set `memory.semantic_recall: false` to fall back
+  to the legacy exact-path recall.
+- `embedding.models.consolidation` and `embedding.models.rerank` are
+  pre-registered in the schema but UNWIRED. Do NOT pull `qwen3-embedding:8b`
+  or any reranker model unless you're picking up Phase B or C — they sit
+  in the YAML so future phases don't need another config migration.
 - `_archive/` holds superseded snapshots
   (`ollama_sentinel_pre_memory_snapshot/`, `research_agent_orphans/`).
   Do not import from it. See `_archive/README.md` for provenance.
@@ -192,6 +196,15 @@ Skip TR-3 — deliberate spec deviation, documented in followups.md.
 
 ### Recent landings
 
+- 2026-05-01: Phase A landed. Hot-path embedder swapped from
+  nomic-embed-text to qwen3-embedding:4b. EmbeddingConfig refactored to a
+  named-role dict with extra='forbid'; consolidation and rerank roles
+  pre-registered (schema-property pre-registration via merge-in-validator)
+  but unwired. Legacy `embedding.model: foo` YAML auto-migrates with a
+  one-shot deprecation warning that threatens hard-error in v0.3. Plan:
+  `~/.claude/plans/yes-putting-both-moonlit-galaxy.md`. Spec:
+  `docs/superpowers/plans/2026-05-01-phase-a-qwen3-hot-path-swap.md`.
+  Phases B and C remain parked pending v0.2 Incident schema.
 - 2026-05-01: CB-3 closed (commit 821b6b0). `research_agent`'s analyze
   node now consults prior webpage neighbors via `find_similar_webpages_sync`,
   alongside the existing `find_similar_queries_sync` call. New leaf module

--- a/docs/superpowers/notes/qwen3-recall-diff.md
+++ b/docs/superpowers/notes/qwen3-recall-diff.md
@@ -1,0 +1,8 @@
+# Qwen3 recall diff (sparse)
+
+Before: `nomic-embed-text`
+After:  `qwen3-embedding:4b`
+
+Combined neighbor count across both snapshots: 0 (threshold 50).
+
+The violation DB is too sparse to produce a meaningful before/after comparison. This is acceptable for Phase A — the schema swap stands on its own — but capture a richer diff when the DB has accumulated more findings (e.g. after running the watcher against a real project for a few days).

--- a/ollama-sentinel.yaml
+++ b/ollama-sentinel.yaml
@@ -37,3 +37,14 @@ output:
 memory:
   enabled: true
   db_path: .ollama_reviews/memory.db
+embedding:
+  enabled: true
+  models:
+    hot: qwen3-embedding:4b
+    # The next two roles are pre-registered in the schema but UNWIRED.
+    # No consumer reads them today. They're here so future phases (Phase B
+    # consolidation, Phase C reranker) don't need another config migration.
+    # Leaving them at these defaults is fine; rerank: null means "role
+    # exists, no model assigned yet."
+    consolidation: qwen3-embedding:8b
+    rerank: null

--- a/ollama_sentinel/config.py
+++ b/ollama_sentinel/config.py
@@ -114,6 +114,10 @@ def create_default_config(directory: str, output_dir: str = ".ollama_reviews") -
         },
         "embedding": {
             "enabled": True,
-            "model": "nomic-embed-text",
+            "models": {
+                "hot": "qwen3-embedding:4b",
+                "consolidation": "qwen3-embedding:8b",
+                "rerank": None,
+            },
         },
     }

--- a/ollama_sentinel/context/embeddings.py
+++ b/ollama_sentinel/context/embeddings.py
@@ -31,7 +31,7 @@ class OllamaEmbedder:
     def __init__(
         self,
         host: str,
-        model: str = "nomic-embed-text",
+        model: str = "qwen3-embedding:4b",
         cache: Optional[_CacheLike] = None,
         client: Optional[httpx.AsyncClient] = None,
         timeout_seconds: float = 30.0,

--- a/ollama_sentinel/models.py
+++ b/ollama_sentinel/models.py
@@ -23,6 +23,14 @@ _NON_HOT_DEFAULTS = {
     "rerank": None,
 }
 
+# Closed set of role names recognized by the embedding schema. Mirrors the
+# top-level `extra="forbid"` policy at the role-dict level: typos in role
+# names like `consolitation` would otherwise silently get added as a new
+# custom role, with the merge-in-validator (Spec deviation §1) supplying
+# the default for the *intended* key — silently delivering the wrong model
+# to Phase B/C consumers. Spec deviation §5: enforce the closed set.
+_KNOWN_EMBEDDING_ROLES = {"hot", "consolidation", "rerank"}
+
 
 class ModelRole(str, Enum):
     """Roles for different Ollama models."""
@@ -155,6 +163,11 @@ class EmbeddingConfig(BaseModel):
     need a second config migration. `rerank` defaults to None because the
     canonical reranker model is not yet chosen.
 
+    Top-level unknown fields are rejected (`extra="forbid"`) and unknown
+    role names inside `models` are also rejected: typos in your YAML surface
+    immediately rather than being silently ignored or worse, masked by the
+    default-merge below.
+
     Pre-registration is a property of the *schema*: a user YAML supplying
     only `hot` still gets the other two roles populated from defaults.
 
@@ -197,6 +210,12 @@ class EmbeddingConfig(BaseModel):
     @field_validator("models")
     @classmethod
     def _validate_models(cls, v: Dict[str, Optional[str]]) -> Dict[str, Optional[str]]:
+        unknown = set(v) - _KNOWN_EMBEDDING_ROLES
+        if unknown:
+            raise ValueError(
+                f"embedding.models contains unrecognized role(s): {sorted(unknown)}. "
+                f"Known roles: {sorted(_KNOWN_EMBEDDING_ROLES)}"
+            )
         if "hot" not in v:
             raise ValueError("embedding.models must include a 'hot' role")
         hot = v["hot"]

--- a/ollama_sentinel/models.py
+++ b/ollama_sentinel/models.py
@@ -7,11 +7,21 @@ from typing import Dict, List, Optional
 
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 log = logging.getLogger("ollama-sentinel")
 
 _PROCESSING_DEPRECATION_LOGGED = False
+
+_EMBEDDING_DEPRECATION_LOGGED = False
+
+# Single source of truth for non-hot embedding role defaults. Used by the
+# field default, the legacy migrator, and the validator's merge step. If
+# Phase B/C ever change these, update only here.
+_NON_HOT_DEFAULTS = {
+    "consolidation": "qwen3-embedding:8b",
+    "rerank": None,
+}
 
 
 class ModelRole(str, Enum):
@@ -137,9 +147,74 @@ class NotificationsConfig(BaseModel):
 
 
 class EmbeddingConfig(BaseModel):
-    """Configuration for the Ollama embedding backend."""
+    """Configuration for the Ollama embedding backend.
+
+    `models` is a name->model-id map. The `hot` role is required and is
+    used on every file save. `consolidation` and `rerank` are pre-registered
+    in the schema but UNWIRED today — they exist so Phases B and C don't
+    need a second config migration. `rerank` defaults to None because the
+    canonical reranker model is not yet chosen.
+
+    Pre-registration is a property of the *schema*: a user YAML supplying
+    only `hot` still gets the other two roles populated from defaults.
+
+    The legacy flat-`model` field auto-migrates with a one-shot deprecation
+    warning. The legacy field WILL HARD-ERROR in v0.3 — fix configs now.
+    """
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = True
-    model: str = "nomic-embed-text"
+    models: Dict[str, Optional[str]] = {
+        "hot": "qwen3-embedding:4b",
+        **_NON_HOT_DEFAULTS,
+    }
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_model_field(cls, data):
+        if not isinstance(data, dict):
+            return data
+        has_legacy = "model" in data
+        has_new = "models" in data
+        if has_legacy and has_new:
+            raise ValueError(
+                "embedding.model and embedding.models are mutually exclusive; "
+                "remove the legacy 'model' field."
+            )
+        if has_legacy:
+            global _EMBEDDING_DEPRECATION_LOGGED
+            if not _EMBEDDING_DEPRECATION_LOGGED:
+                log.warning(
+                    "embedding.model is deprecated and will hard-error in v0.3; "
+                    "auto-migrating to embedding.models.hot for now."
+                )
+                _EMBEDDING_DEPRECATION_LOGGED = True
+            migrated = {"hot": data["model"], **_NON_HOT_DEFAULTS}
+            data = {k: v for k, v in data.items() if k != "model"}
+            data["models"] = migrated
+        return data
+
+    @field_validator("models")
+    @classmethod
+    def _validate_models(cls, v: Dict[str, Optional[str]]) -> Dict[str, Optional[str]]:
+        if "hot" not in v:
+            raise ValueError("embedding.models must include a 'hot' role")
+        hot = v["hot"]
+        if not isinstance(hot, str) or not hot.strip():
+            raise ValueError("embedding.models['hot'] must be a non-empty string")
+        for role, name in v.items():
+            if name is None:
+                continue
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(
+                    f"embedding.models[{role!r}] must be a non-empty string or None"
+                )
+        # Spec deviation §1: pre-registration is a schema property. Merge
+        # the defaults in so user-supplied keys win but missing keys are
+        # filled. Without this, a partial dict like {"hot": "x"} leaves
+        # consolidation/rerank absent and future B/C consumers see KeyError
+        # where they expect a model name.
+        return {**_NON_HOT_DEFAULTS, **v}
 
 
 class MemoryConfig(BaseModel):

--- a/ollama_sentinel/processor.py
+++ b/ollama_sentinel/processor.py
@@ -7,7 +7,7 @@ import json
 import logging
 import pathlib
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 import git
 import httpx
@@ -196,7 +196,7 @@ class FileProcessor:
             try:
                 self.embedder = OllamaEmbedder(
                     host=config.ollama.host,
-                    model=config.embedding.model,
+                    model=cast(str, config.embedding.models["hot"]),
                     cache=self._cache,
                 )
                 self.retriever = SemanticRetriever(embedder=self.embedder)

--- a/scripts/embedding_recall_diff.py
+++ b/scripts/embedding_recall_diff.py
@@ -1,0 +1,161 @@
+"""Capture before/after semantic-recall snapshots for a real codebase.
+
+Spec deviation §3 from docs/superpowers/plans/2026-05-01-phase-a-qwen3-
+hot-path-swap.md: the script accepts the embedder model as a CLI argument
+so before/after can both run on the post-Phase-A code without a stash
+dance, and so the script never depends on a particular EmbeddingConfig
+shape.
+
+Usage:
+    python scripts/embedding_recall_diff.py before nomic-embed-text
+    python scripts/embedding_recall_diff.py after  qwen3-embedding:4b
+    python scripts/embedding_recall_diff.py compare
+
+Writes:
+    /tmp/recall_diff_before.json
+    /tmp/recall_diff_after.json
+    docs/superpowers/notes/qwen3-recall-diff.md  (compare step)
+"""
+from __future__ import annotations
+import asyncio
+import json
+import pathlib
+import sys
+from typing import List
+
+from ollama_sentinel.context.embeddings import OllamaEmbedder
+from ollama_sentinel.violation_db import ViolationDB
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DB_PATH_RELATIVE = ".ollama_reviews/memory.db"
+
+TARGET_FILES: List[str] = [
+    "ollama_sentinel/processor.py",
+    "ollama_sentinel/watcher.py",
+    "ollama_sentinel/violation_db.py",
+    "ollama_sentinel/cli.py",
+    "ollama_sentinel/extractor.py",
+    "ollama_sentinel/dashboard.py",
+    "ollama_sentinel/context/recipes.py",
+    "ollama_sentinel/context/assembler.py",
+    "research_agent/core/workflow.py",
+    "research_agent/tools/memory.py",
+]
+
+_MIN_FINDINGS_FOR_DIFF = 50
+
+
+async def capture(out_path: pathlib.Path, model_name: str) -> None:
+    embedder = OllamaEmbedder(host="http://localhost:11434", model=model_name)
+    db_path = REPO_ROOT / DB_PATH_RELATIVE
+    if not db_path.exists():
+        out_path.write_text(json.dumps(
+            {"model": model_name, "files": {}, "note": f"no DB at {db_path}"},
+            indent=2,
+        ))
+        print(f"wrote {out_path} (no DB)")
+        await embedder.close()
+        return
+    db = ViolationDB(str(db_path))
+    try:
+        report = {"model": model_name, "files": {}}
+        for rel in TARGET_FILES:
+            path = REPO_ROOT / rel
+            if not path.exists():
+                continue
+            text = path.read_text(errors="replace")
+            try:
+                neighbors = await db.get_neighbors_by_similarity(
+                    query_text=text, embedder=embedder, k=5,
+                )
+            except Exception as e:
+                report["files"][rel] = {"error": str(e), "neighbors": []}
+                continue
+            report["files"][rel] = {
+                "neighbors": [
+                    {
+                        "file_path": n["file_path"],
+                        "lines": f"{n['line_start']}-{n['line_end']}",
+                        "category": n["category"],
+                        "severity": n["severity"],
+                        "description": n["description"][:80],
+                    }
+                    for n in neighbors
+                ]
+            }
+        out_path.write_text(json.dumps(report, indent=2))
+        print(f"wrote {out_path}")
+    finally:
+        db.close()
+        await embedder.close()
+
+
+def compare() -> None:
+    before = json.loads(pathlib.Path("/tmp/recall_diff_before.json").read_text())
+    after = json.loads(pathlib.Path("/tmp/recall_diff_after.json").read_text())
+    out = REPO_ROOT / "docs/superpowers/notes/qwen3-recall-diff.md"
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    total_neighbors = sum(
+        len(snapshot["files"].get(rel, {}).get("neighbors", []))
+        for snapshot in (before, after)
+        for rel in snapshot.get("files", {})
+    )
+    if total_neighbors < _MIN_FINDINGS_FOR_DIFF:
+        out.write_text(
+            f"# Qwen3 recall diff (sparse)\n\n"
+            f"Before: `{before['model']}`\n"
+            f"After:  `{after['model']}`\n\n"
+            f"Combined neighbor count across both snapshots: {total_neighbors} "
+            f"(threshold {_MIN_FINDINGS_FOR_DIFF}).\n\n"
+            f"The violation DB is too sparse to produce a meaningful "
+            f"before/after comparison. This is acceptable for Phase A — "
+            f"the schema swap stands on its own — but capture a richer "
+            f"diff when the DB has accumulated more findings (e.g. after "
+            f"running the watcher against a real project for a few days).\n"
+        )
+        print(f"wrote {out} (sparse-DB note)")
+        return
+
+    lines = [
+        "# Qwen3 recall diff",
+        "",
+        f"Before: `{before['model']}`",
+        f"After:  `{after['model']}`",
+        "",
+    ]
+    for rel in before["files"].keys():
+        lines.append(f"## `{rel}`")
+        lines.append("")
+        lines.append("**Before**")
+        for n in before["files"][rel].get("neighbors", []):
+            lines.append(f"- {n['file_path']}:{n['lines']} [{n['severity']}] {n['description']}")
+        lines.append("")
+        lines.append("**After**")
+        for n in after["files"][rel].get("neighbors", []):
+            lines.append(f"- {n['file_path']}:{n['lines']} [{n['severity']}] {n['description']}")
+        lines.append("")
+    out.write_text("\n".join(lines))
+    print(f"wrote {out}")
+
+
+def _usage() -> None:
+    sys.exit(
+        "usage: embedding_recall_diff.py {before|after} <model-name>\n"
+        "       embedding_recall_diff.py compare"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        _usage()
+    mode = sys.argv[1]
+    if mode == "compare":
+        compare()
+    elif mode in ("before", "after"):
+        if len(sys.argv) != 3:
+            _usage()
+        out = pathlib.Path(f"/tmp/recall_diff_{mode}.json")
+        asyncio.run(capture(out, sys.argv[2]))
+    else:
+        _usage()

--- a/tests/context/test_embeddings.py
+++ b/tests/context/test_embeddings.py
@@ -34,11 +34,11 @@ class TestOllamaEmbedder:
         finally:
             await emb.close()
         assert vec == [0.1, 0.2, 0.3]
-        assert cache.store["embed:nomic-embed-text:k1"] == [0.1, 0.2, 0.3]
+        assert cache.store["embed:qwen3-embedding:4b:k1"] == [0.1, 0.2, 0.3]
 
     async def test_cache_hit_skips_http(self, httpx_mock: HTTPXMock):
         cache = _FakeCache()
-        cache.store["embed:nomic-embed-text:k1"] = [0.9, 0.9, 0.9]
+        cache.store["embed:qwen3-embedding:4b:k1"] = [0.9, 0.9, 0.9]
         emb = OllamaEmbedder(host="http://localhost:11434", cache=cache)
         try:
             vec = await emb.embed("hello", cache_key="k1")
@@ -53,7 +53,7 @@ class TestOllamaEmbedder:
         cache = _FakeCache()
         # Pre-seed a value for a different model — must not be returned.
         cache.store["embed:other-model:k1"] = [0.0]
-        emb = OllamaEmbedder(host="http://localhost:11434", model="nomic-embed-text", cache=cache)
+        emb = OllamaEmbedder(host="http://localhost:11434", model="qwen3-embedding:4b", cache=cache)
         try:
             vec = await emb.embed("hello", cache_key="k1")
         finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,8 +87,35 @@ class TestCreateDefaultConfig:
     def test_emits_embedding_section(self):
         config = create_default_config(".")
         assert "embedding" in config
-        assert config["embedding"]["model"] == "nomic-embed-text"
         assert config["embedding"]["enabled"] is True
+        assert config["embedding"]["models"]["hot"] == "qwen3-embedding:4b"
+        assert config["embedding"]["models"]["consolidation"] == "qwen3-embedding:8b"
+        assert config["embedding"]["models"]["rerank"] is None
+
+    def test_legacy_yaml_model_migrates_on_load(self, tmp_path):
+        """A user YAML with the legacy embedding.model field loads and lifts to
+        models.hot, with consolidation/rerank filled from schema defaults."""
+        import yaml as _yaml
+        import ollama_sentinel.models as models_module
+        models_module._EMBEDDING_DEPRECATION_LOGGED = False
+        config_dict = {
+            "watch": {"directory": str(tmp_path)},
+            "ollama": {
+                "host": "http://localhost:11434",
+                "models": {"default": {"name": "m", "system_prompt": "p"}},
+            },
+            "embedding": {
+                "enabled": True,
+                "model": "legacy-embed-name",
+            },
+        }
+        cfg_path = tmp_path / "ollama-sentinel.yaml"
+        cfg_path.write_text(_yaml.dump(config_dict))
+        cfg = load_config(cfg_path)
+        assert cfg is not None
+        assert cfg.embedding.models["hot"] == "legacy-embed-name"
+        assert cfg.embedding.models["consolidation"] == "qwen3-embedding:8b"
+        assert cfg.embedding.models["rerank"] is None
 
     def test_default_model_has_context_window(self):
         config = create_default_config(".")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -258,7 +258,83 @@ class TestEmbeddingConfig:
     def test_defaults(self):
         cfg = EmbeddingConfig()
         assert cfg.enabled is True
-        assert cfg.model == "nomic-embed-text"
+        # See TestEmbeddingConfigMigration for full models-shape coverage.
+        assert cfg.models["hot"] == "qwen3-embedding:4b"
+
+
+class TestEmbeddingConfigMigration:
+    """Phase A: EmbeddingConfig is a named-role dict with legacy migration."""
+
+    def test_default_models_shape(self):
+        cfg = EmbeddingConfig()
+        assert set(cfg.models.keys()) == {"hot", "consolidation", "rerank"}
+        assert cfg.models["hot"] == "qwen3-embedding:4b"
+        assert cfg.models["consolidation"] == "qwen3-embedding:8b"
+        assert cfg.models["rerank"] is None
+
+    def test_partial_models_dict_fills_defaults(self):
+        """Spec deviation §1: pre-registration is a schema property, not an
+        input property. Supplying only `hot` must still populate the other
+        two roles from defaults so future Phase B/C consumers don't see None
+        where they expect a model name."""
+        cfg = EmbeddingConfig(models={"hot": "my-custom-hot"})
+        assert cfg.models["hot"] == "my-custom-hot"
+        assert cfg.models["consolidation"] == "qwen3-embedding:8b"
+        assert cfg.models["rerank"] is None
+
+    def test_models_must_include_hot_role(self):
+        with pytest.raises(ValidationError, match="hot"):
+            EmbeddingConfig(models={"consolidation": "x"})
+
+    def test_hot_role_must_be_non_empty_string(self):
+        with pytest.raises(ValidationError, match="non-empty"):
+            EmbeddingConfig(models={"hot": "  "})
+
+    def test_other_roles_may_be_none(self):
+        cfg = EmbeddingConfig(models={"hot": "h", "rerank": None})
+        assert cfg.models["rerank"] is None
+
+    def test_other_roles_must_be_non_empty_string_when_set(self):
+        with pytest.raises(ValidationError, match="non-empty"):
+            EmbeddingConfig(models={"hot": "h", "consolidation": "  "})
+
+    def test_extra_top_level_field_is_forbidden(self):
+        # Phase A locks the schema with extra="forbid" so typos in YAML
+        # surface loudly rather than silently being ignored.
+        with pytest.raises(ValidationError):
+            EmbeddingConfig(enabled=True, models={"hot": "h"}, oops=True)
+
+    def test_legacy_model_field_migrates_to_models_hot(self, caplog):
+        import ollama_sentinel.models as models_module
+        models_module._EMBEDDING_DEPRECATION_LOGGED = False
+        with caplog.at_level("WARNING"):
+            cfg = EmbeddingConfig(model="legacy-embed-name")
+        assert cfg.models["hot"] == "legacy-embed-name"
+        assert cfg.models["consolidation"] == "qwen3-embedding:8b"
+        assert cfg.models["rerank"] is None
+        assert "v0.3" in caplog.text or "0.3" in caplog.text
+        assert "deprecated" in caplog.text.lower()
+
+    def test_legacy_model_with_extra_field_still_rejects(self):
+        """Spec deviation §1 corollary: legacy migrator strips the recognized
+        `model` key; any unrecognized siblings still trigger extra='forbid'."""
+        with pytest.raises(ValidationError):
+            EmbeddingConfig(model="legacy-embed-name", oops="typo")
+
+    def test_both_model_and_models_rejected(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            EmbeddingConfig(model="x", models={"hot": "y"})
+
+    def test_deprecation_warning_logs_only_once(self, caplog):
+        """Spec deviation §2: mirror ProcessingConfig's one-shot guard so
+        repeat config loads don't spam stderr."""
+        import ollama_sentinel.models as models_module
+        models_module._EMBEDDING_DEPRECATION_LOGGED = False
+        with caplog.at_level("WARNING"):
+            EmbeddingConfig(model="legacy-1")
+            caplog.clear()
+            EmbeddingConfig(model="legacy-2")
+        assert "deprecated" not in caplog.text.lower()
 
 
 class TestOllamaModelConfigTokenFields:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -326,15 +326,21 @@ class TestEmbeddingConfigMigration:
             EmbeddingConfig(model="x", models={"hot": "y"})
 
     def test_deprecation_warning_logs_only_once(self, caplog):
-        """Spec deviation §2: mirror ProcessingConfig's one-shot guard so
-        repeat config loads don't spam stderr."""
+        """Spec deviation §2 + §4: mirror ProcessingConfig's one-shot guard
+        so repeat config loads don't spam stderr. The first call must log;
+        the second must not. The positive assertion on the first call is
+        what makes this test fail correctly when the guard is missing — a
+        negative-only assertion would pass vacuously when no warning fires
+        at all."""
         import ollama_sentinel.models as models_module
         models_module._EMBEDDING_DEPRECATION_LOGGED = False
         with caplog.at_level("WARNING"):
             EmbeddingConfig(model="legacy-1")
-            caplog.clear()
+        assert "deprecated" in caplog.text.lower()  # first call must log
+        caplog.clear()
+        with caplog.at_level("WARNING"):
             EmbeddingConfig(model="legacy-2")
-        assert "deprecated" not in caplog.text.lower()
+        assert "deprecated" not in caplog.text.lower()  # second call must not log
 
 
 class TestOllamaModelConfigTokenFields:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -304,6 +304,16 @@ class TestEmbeddingConfigMigration:
         with pytest.raises(ValidationError):
             EmbeddingConfig(enabled=True, models={"hot": "h"}, oops=True)
 
+    def test_unknown_role_name_is_rejected(self):
+        """Spec deviation §5: role names inside `models` are a closed set
+        (hot, consolidation, rerank). Typos like `consolitation` would
+        otherwise silently get added as a custom role while the merge-in-
+        validator quietly fills the intended key with the default,
+        delivering the wrong model to Phase B/C consumers. Reject typos
+        loudly at config load time."""
+        with pytest.raises(ValidationError, match="unrecognized role"):
+            EmbeddingConfig(models={"hot": "h", "consolitation": "x"})
+
     def test_legacy_model_field_migrates_to_models_hot(self, caplog):
         import ollama_sentinel.models as models_module
         models_module._EMBEDDING_DEPRECATION_LOGGED = False


### PR DESCRIPTION
## Summary

Refactor `EmbeddingConfig` from a flat `model: str` to a named-role `models: Dict[str, Optional[str]]` mirroring `OllamaConfig.models`. Default flips to `qwen3-embedding:4b` on the hot path. Pre-registers `consolidation` (`qwen3-embedding:8b`) and `rerank` (`None`) keys in the schema even though no consumer reads them today, so Phases B and C don't need another config migration when they land.

Smoke-tested against live Ollama: `qwen3-embedding:4b` produces dim=2560 vectors. Cache keys (`embed:{model}:{key}`) keep old `nomic-embed-text` vectors as orphans rather than collisions.

## Changes

- `EmbeddingConfig`: `models: Dict[str, Optional[str]]` with `extra="forbid"`
- `model_validator(mode="before")`: legacy `embedding.model` → `models.hot` migration with one-shot deprecation warning that threatens v0.3 hard-error
- `field_validator("models")`: requires non-empty `hot`; allows None for other roles; **rejects unknown role names** (closed-set policy); **merges `_NON_HOT_DEFAULTS`** so pre-registration is a schema property
- `OllamaEmbedder` default model: `qwen3-embedding:4b`
- `FileProcessor` reads `config.embedding.models["hot"]` (with explicit `cast(str, ...)` for type safety)
- `create_default_config()` writes the new shape
- `ollama-sentinel.yaml` gains an explicit `embedding:` block with all three roles
- Docs: `CLAUDE.md`, `README.md`, `docs/GUIDE.md` updated; new "Recent landings" entry; "Persistent gotchas" notes the parked roles

## Spec deviations

The plan applies five corrections to the canonical spec at `docs/superpowers/plans/2026-05-01-phase-a-qwen3-hot-path-swap.md`. The spec's stated **intent** is preserved in every case; the spec's **code** is corrected:

1. **§1 (load-bearing) — `_validate_models` merges defaults.** Spec returned `v` unchanged; partial-input dicts like `{"hot": "x"}` left consolidation/rerank absent, defeating pre-registration. Fix: `return {**_NON_HOT_DEFAULTS, **v}`. Locked by `test_partial_models_dict_fills_defaults`.
2. **§2 — One-shot deprecation warning.** Spec emitted on every load → stderr spam in CI loops. Fix: `_EMBEDDING_DEPRECATION_LOGGED` module flag (mirrors existing `_PROCESSING_DEPRECATION_LOGGED` pattern). Locked by `test_deprecation_warning_logs_only_once`.
3. **§3 — Recall-diff script CLI-parameterized.** Spec required a stash-dance workflow that couldn't actually run (script reads `cfg.embedding.models["hot"]` which only exists after the schema refactor; script file itself was in the stash). Fix: script accepts model name as a CLI argument; sparse-DB early-out (<50 combined neighbors) writes a thin note rather than blocking the PR.
4. **§4 — Strengthen `test_deprecation_warning_logs_only_once`.** Spec's negative-only assertion shape passed vacuously in red phase (no warning fires at all → assertion trivially true). Fix: split into positive-then-negative — first call MUST log, second call MUST NOT.
5. **§5 — Reject unknown role names in `models` dict.** `extra="forbid"` only sealed top-level fields; typos like `consolitation` silently added a 4th key while §1's merge supplied the default for the *intended* `consolidation` key. Fix: `_KNOWN_EMBEDDING_ROLES` closed-set check at the top of `_validate_models`. Locked by `test_unknown_role_name_is_rejected`.

## Test plan

- [x] `pytest tests/ -v` — full suite green (378 passed, 15 skipped; count updated in CLAUDE.md sanity-check)
- [x] Live embedder smoke test against Ollama: `dim=2560`
- [x] Config round-trip with all three roles registered (verification §2)
- [x] Legacy YAML round-trip preserves migrated `hot` AND `consolidation` default (verification §3, proves §1's merge through migration path)
- [x] Recall diff captured at `docs/superpowers/notes/qwen3-recall-diff.md` (sparse-note variant — DB empty on this branch; substantive diff deferred until DB accumulates findings, per §3's early-out)
- [x] End-to-end watcher run on scratch dir produces a review file (Task 8 Step 2)

## Out of scope

- `consolidation` role unwired (Phase B, parked)
- `rerank` role unwired (Phase C, parked)
- `research_agent`'s embedder construction (legacy `embed_cfg.get("model", ...)` shape) unchanged — separate ticket migrates research_agent's dict-config path