### PR TITLE
ci: add two-runner matrix ([dev], [dev,research])

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extras: ["dev", "dev,research"]
+    name: pytest (${{ matrix.extras }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -e ".[${{ matrix.extras }}]"
+      - run: pytest tests/ -q


### PR DESCRIPTION
Closes #5.

## Summary

Adds `.github/workflows/test.yml` with a two-runner matrix per the issue spec:
- `[dev]` only — the current local-equivalent setup (sentinel + dev tooling)
- `[dev,research]` — pulls in `[research]` extras (langchain, playwright, langchain_openai, etc.) and exercises the 15 currently-skipped tests in `tests/test_research_agent.py`

## What this closes

The 15 skipped tests (gated by `try/except ImportError` for research-agent-only deps) have never actually run in their target environment — they're skipped on every local pytest invocation because the `[dev]` extras don't pull those deps. With this PR, the `[dev,research]` runner exercises them on every push and PR.

This also closes the CI gap explicitly named in the v0.2.0 release notes: the agent doing review work was functionally acting as CI (Phase A's mid-execution §4 and §5 catches were the only formal review the schema received before merge). With CI in place, that load shifts off the agent.

## Workflow shape

```yaml
strategy:
  fail-fast: false  # one runner failing must not cancel the other
  matrix:
    extras: ["dev", "dev,research"]
```

`fail-fast: false` is deliberate — for a two-runner matrix, the value of seeing both results is higher than the cost of one extra runner-minute. `cache: pip` is included for speed on subsequent runs.

## What to watch for on first green run

- The 15 previously-skipped tests now show as "passed" on `[dev,research]` (currently they show as "skipped")
- Runtime per runner stays under ~60s (issue acceptance criterion). If `[dev,research]` blows past that, candidates for follow-up:
  - Pre-cache the playwright Chromium download (likely the biggest install-time hit)
  - Add `pip cache` retention across runs (already have `cache: pip` so largely covered)
  - Split the runners by Python version too if the dep install time amortizes badly

## Test plan

- [ ] PR merges; both runners go green on a follow-up PR
- [ ] The 15 previously-skipped tests show as "passed" on `[dev,research]`
- [ ] Once green, mark both runners as required-status checks via repo branch protection