### PR TITLE
Implementation-vs-plan audit of all 6 plans + close 2 reviewer-grounding flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,17 +158,22 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 
 ### Resume here next time
 
-All open backlog items from the last two sessions are closed. Remaining
-deferred work is low-priority and not blocking anything:
+All open backlog items are closed. The 2026-05-15 implementation audit
+(`docs/superpowers/plans/2026-05-15-implementation-audit.md`) verified all
+6 plans against landed code: 4 SHIPPED, context-builder + triage SHIPPED,
+v0.2 incident schema cleanly NOT STARTED (parked).
 
-1. **Sanity check first.** `pytest tests/ -q` should report 378 / 15 skip.
-2. **Remaining open items** (from `docs/superpowers/followups.md`):
-   - CB-1 — dedupe impact-report formatters (harmless until `build_research_context` is reachable for impact data)
+1. **Sanity check first.** `pytest tests/ -q` should report ~494 collected
+   / 479 passed / 15 skip.
+2. **CB-1 is DONE** (commit `1313681`) — was previously mis-tracked OPEN
+   here and in followups.md; corrected by the 2026-05-15 audit. No open
+   follow-ups remain.
+
 ### Pickable next moves (ordered by leverage)
 
 | # | Item | Effort | Risk | Notes |
 |---|---|---|---|---|
-| 1 | CB-1 — dedupe impact-report formatter between `recipes.py:_format_impact_report` and `synthesis.py:format_impact_report` | ~30-45 min | low | Harmless today (mutually exclusive paths); only triggers if `build_research_context` ever gets impact data. |
+| 1 | v0.2 incident schema — Finding/Incident split | ~3-4 days | med | Plan `docs/superpowers/plans/2026-05-02-v02-incident-schema.md`. Its prerequisite (reviewer-grounding) is now SHIPPED, so this is unblocked. Fully parked — zero code footprint today. |
 
 Skip TR-3 — deliberate spec deviation, documented in followups.md.
 

--- a/docs/superpowers/followups.md
+++ b/docs/superpowers/followups.md
@@ -14,22 +14,22 @@ Not blockers — each entry has enough context to pick up in a fresh session.
 Plan: `docs/superpowers/plans/2026-04-16-context-builder.md`.
 Spec: `docs/superpowers/specs/2026-04-16-context-builder-design.md`.
 
-### CB-1. Dedupe impact-report formatters
+### CB-1. Dedupe impact-report formatters — DONE (commit 1313681)
 
-**Files:** `ollama_sentinel/context/recipes.py:_format_impact_report`,
+**Files:** `ollama_sentinel/context/recipes.py:format_impact_report`,
 `research_agent/tools/synthesis.py:format_impact_report`.
 
-**Issue:** two formatters diverge — the `SynthesisTool` version emits a
-`SUGGESTED FIRST COMMIT` block for HIGH-severity items; the recipe version
-does not. Currently mutually exclusive (synthesis short-circuits impact
-before reaching the recipe), so harmless today.
+Canonical `format_impact_report` now lives at
+`ollama_sentinel/context/recipes.py:115` (exported via
+`ollama_sentinel/context/__init__.py`). `synthesis.py:18` imports it as
+`_shared_format_impact_report`; `synthesis.py:115-122` is a thin wrapper that
+delegates to it and only prepends an `"IMPACT ANALYSIS: "` header. The
+divergence the ticket described (synthesis emitted a `SUGGESTED FIRST COMMIT`
+block the recipe lacked) no longer exists.
 
-**Fix:** move the canonical formatter to a neutral location
-(`ollama_sentinel/context/recipes.py` or a shared
-`research_agent/core/impact.py`) and have both callers import it.
-
-**Trigger:** any PR that makes `build_research_context` a reachable path
-for impact data.
+Closed by `1313681`, which landed after CB-7 (`826648f`) — i.e. after this
+section was last meaningfully updated, which is why it was previously listed
+OPEN here. Surfaced by the 2026-05-15 implementation audit.
 
 ### CB-2. SemanticRetriever integration test — DONE (commit 566eb67)
 

--- a/docs/superpowers/plans/2026-04-16-context-builder.md
+++ b/docs/superpowers/plans/2026-04-16-context-builder.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**Status:** SHIPPED 2026-04-16 — all phases landed. Follow-ups CB-1..CB-7 all closed (CB-1 by commit 1313681; followups.md previously mis-tracked it OPEN). Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
+
 **Goal:** Introduce a shared, token-budgeted, embedding-ranked context assembler (`ollama_sentinel/context/`) that replaces ad-hoc prompt assembly in the sentinel and the research agent, and upgrade `ViolationDB` to semantic recall via Ollama embeddings.
 
 **Architecture:** Six new files under `ollama_sentinel/context/` (pure assembler + tokenizer wrapper + Ollama embedder + retrievers + two named recipes). `ViolationDB` gains an `embed_text` column and a similarity-ranked query; `EnhancedMemoryStore` gets an optional async upgrade. Failures in the embedding path degrade to the existing exact-match / token-overlap behavior — review output is never blocked by infrastructure.

--- a/docs/superpowers/plans/2026-04-16-triage.md
+++ b/docs/superpowers/plans/2026-04-16-triage.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**Status:** SHIPPED 2026-04-16 — all 6 phases landed; one documented deviation (TR-3, empty-input exit 1/ERROR vs spec's exit 0/INFO). Follow-ups TR-1/TR-2 closed. Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
+
 **Goal:** Ship `ollama-sentinel triage` — a new CLI subcommand that reads tool output from stdin or a file, auto-extracts referenced source paths, and returns a diagnose-and-fix suggestion from the local Ollama model.
 
 **Architecture:** Three new files in `ollama_sentinel/triage/` (extractor, runner, `__init__`), one appended recipe (`build_triage_context`) in `ollama_sentinel/context/recipes.py`, one new method on `OllamaClient` (`generate_with_model`) with the existing `generate_review` retained as a thin wrapper, one new Typer command in `cli.py`, and a new `triage` model role emitted by `create_default_config`. No new runtime dependencies.

--- a/docs/superpowers/plans/2026-05-01-cb3-wire-find-similar-webpages.md
+++ b/docs/superpowers/plans/2026-05-01-cb3-wire-find-similar-webpages.md
@@ -1,6 +1,6 @@
 # CB-3: Wire `find_similar_webpages_sync` into the analyze node
 
-**Status:** ready to ship
+**Status:** SHIPPED — commit 821b6b0 (2026-05-01). Test mechanism deviated from spec (formatter unit tests + source-level wiring guard instead of monkeypatch integration tests) per the closure-testing convention; equivalent guarantees, documented in commit body. Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
 **Effort:** ~30 min implementation + ~30 min tests, plus optional polish
 **Owner:** unassigned
 **Plan source:** Phase D of `~/.claude/plans/yes-putting-both-moonlit-galaxy.md`

--- a/docs/superpowers/plans/2026-05-01-phase-a-qwen3-hot-path-swap.md
+++ b/docs/superpowers/plans/2026-05-01-phase-a-qwen3-hot-path-swap.md
@@ -1,6 +1,6 @@
 # Phase A: Qwen3 hot-path swap + pre-registered role schema
 
-**Status:** ready to ship
+**Status:** SHIPPED 2026-05-01 (PR #4 area). Two documented deviations (§1 merge-in-validator, §5 closed role set) hardened the spec; both test-locked. Recall-diff receipt captured but sparse (thin violation DB). Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
 **Effort:** ~3-4 hours implementation + ~1 hour smoke testing
 **Owner:** unassigned (different agent team than the one implementing CB-3)
 **Plan source:** Phase A of `~/.claude/plans/yes-putting-both-moonlit-galaxy.md`,

--- a/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
+++ b/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
@@ -1,6 +1,6 @@
 # v0.2: Incident Schema — Finding/Incident Split
 
-**Status:** ready for review, then implementation
+**Status:** NOT STARTED — cleanly parked, verified untouched at master @ 47f1929 (no incidents table / hooks.py / pytest plugin / CLI verbs / tests; CLAUDE.md "parked" claim accurate). Prerequisite (reviewer-grounding) now SHIPPED, so this is the next real implementation candidate. Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
 **Effort:** ~3-4 days across schema + hooks + pytest plugin + CLI verbs
 **Owner:** unassigned
 **Prerequisites:** Phase A merged (PR #4). CB-3 shipped.

--- a/docs/superpowers/plans/2026-05-09-reviewer-grounding.md
+++ b/docs/superpowers/plans/2026-05-09-reviewer-grounding.md
@@ -1,6 +1,6 @@
 # Reviewer grounding — schema-constrained output + verbatim validator
 
-**Status:** SHIPPED — master @ 47f1929 (Pre-1 2a83477; Step 1 810fc02+720972a; Step 2 d3262d6; Step 3 2f1e18e; --no-grounding 47f1929). Regex fallback retained behind --no-grounding per the plan's flag option. NOTE: the body below is stale pre-implementation prose ("After Pre-1 lands…", ground-truth @ 5c1e4a6) — describes pre-state, not current. Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
+**Status:** SHIPPED — master @ 47f1929 (Pre-1 2a83477; Step 1 810fc02+720972a; Step 2 d3262d6; Step 3 2f1e18e; --no-grounding 47f1929). Regex fallback retained behind --no-grounding per the plan's flag option. NOTE: the body is the original pre-build plan ("After Pre-1 lands…", ground-truth @ 5c1e4a6); each Step/Validation heading carries a `> **SHIPPED**` marker recording what landed. Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
 **Effort:** ~1.5 days (Step 1) + ~2h (Step 2) on top of Pre-1
 **Owner:** unassigned
 **Prerequisites:** Pre-1 (widen `OllamaClient.response_format` to `Optional[Union[str, dict]]`)
@@ -133,6 +133,8 @@ Notes:
 
 ### Step 1: schema-constrained `generate_review` + validator (~1 day)
 
+> **SHIPPED** (810fc02 + 720972a). Prose below is the original pre-build plan. See audit: `docs/superpowers/plans/2026-05-15-implementation-audit.md`.
+
 **Files:** `ollama_sentinel/processor.py`, `ollama_sentinel/extractor.py`,
 `tests/test_processor.py`, `tests/test_extractor.py`
 
@@ -181,6 +183,8 @@ the wiring is:
 
 ### Step 2: quote-first prompt ordering (~2h)
 
+> **SHIPPED** (d3262d6; made grounding-conditional in 47f1929). Prose below is the original pre-build plan. See audit: `docs/superpowers/plans/2026-05-15-implementation-audit.md`.
+
 **Files:** `ollama_sentinel/context/recipes.py`, `tests/test_recipes.py`
 
 `build_review_context` (`recipes.py:48-91`) currently orders sections
@@ -210,6 +214,8 @@ tokens reach the schema's `verbatim_excerpt` slot naturally.
   measurably increases the WARNING-log rate on the same input set.
 
 ### Step 3: regression test against the May-3 slop set (~1h)
+
+> **SHIPPED** (2f1e18e — `tests/test_grounding_regression.py`, R1-R4 slop + P1-P4 real-source positive cases). The May-3 retro never snapshotted raw model responses, so fixtures are synthetic-slop / verbatim-real-source rather than replayed captures — see the P1-P4 header comment and the audit doc. See audit: `docs/superpowers/plans/2026-05-15-implementation-audit.md`.
 
 **Files:** `tests/test_grounding_regression.py` (new)
 
@@ -248,6 +254,12 @@ that is verifiable). This is the empirical seal on the fix.
 ---
 
 ## Validation — the empirical test
+
+> **SHIPPED & CLOSED.** Item 1 (slop inputs → zero findings): R1-R4. Item 2
+> (correct findings round-trip un-rejected): `test_correct_finding_on_real_source_is_not_rejected`
+> (P1-P4) using verbatim real source from `processor.py` @ 47f1929 — closes
+> the synthetic-positive gap the 2026-05-15 audit flagged. Item 3 (full
+> suite green post-removal): 483 passed / 15 skipped.
 
 Before this spec ships to merge:
 

--- a/docs/superpowers/plans/2026-05-09-reviewer-grounding.md
+++ b/docs/superpowers/plans/2026-05-09-reviewer-grounding.md
@@ -1,6 +1,6 @@
 # Reviewer grounding — schema-constrained output + verbatim validator
 
-**Status:** ready for review, then implementation
+**Status:** SHIPPED — master @ 47f1929 (Pre-1 2a83477; Step 1 810fc02+720972a; Step 2 d3262d6; Step 3 2f1e18e; --no-grounding 47f1929). Regex fallback retained behind --no-grounding per the plan's flag option. NOTE: the body below is stale pre-implementation prose ("After Pre-1 lands…", ground-truth @ 5c1e4a6) — describes pre-state, not current. Audit: docs/superpowers/plans/2026-05-15-implementation-audit.md
 **Effort:** ~1.5 days (Step 1) + ~2h (Step 2) on top of Pre-1
 **Owner:** unassigned
 **Prerequisites:** Pre-1 (widen `OllamaClient.response_format` to `Optional[Union[str, dict]]`)

--- a/docs/superpowers/plans/2026-05-15-implementation-audit.md
+++ b/docs/superpowers/plans/2026-05-15-implementation-audit.md
@@ -148,12 +148,28 @@ harmless `RuntimeWarning` (un-awaited AsyncMock) in the test run.
 3. Status headers corrected on the 4 plans that have them; status line added
    to the 2 that don't (context-builder, triage).
 
+## Resolved same day (2026-05-15)
+
+Both reviewer-grounding flags were closed for good rather than deferred:
+
+- **Plan-body staleness.** Not a wholesale rewrite (that would turn a
+  planning doc into a duplicate of this audit). Added per-section
+  `> **SHIPPED**` markers under Step 1 / Step 2 / Step 3 / Validation so a
+  mid-doc reader can't be misled; the "Ground truth at the time this spec
+  was written" section stays frozen by design. Header was already annotated.
+- **Validation item 2 (synthetic positives).** Closed with
+  `test_correct_finding_on_real_source_is_not_rejected` (P1-P4) in
+  `tests/test_grounding_regression.py`. Fixtures are VERBATIM real source
+  frozen from `processor.py` @ 47f1929 (the exact `@retry` construct the
+  plan's schema example cites), each with a uniqueness guard so it cannot
+  pass for the wrong reason. Covers the strictness modes item 2 names that
+  R3 did not: multi-line spans, line-range start/end boundaries, deep
+  indentation, regex-metachar excerpts. Path A (replay pre-grounding
+  `.ollama_reviews/` captures) is structurally impossible — those predate
+  the `verbatim_excerpt` field, so they lack the key the validator checks.
+  Suite: 483 passed / 15 skipped.
+
 ## Not done (flagged, no action)
 
-- reviewer-grounding plan **body** is stale pre-implementation prose. Header
-  fixed; full-body rewrite deferred — low value, the plan is shipped and the
-  header now says so.
-- reviewer-grounding validation-checklist item 2 uses synthetic rather than
-  captured real-history positive fixtures. Minor empirical gap, not a defect.
 - phase-a recall-diff receipt is sparse — re-capture when violation DB has
   real data.

--- a/docs/superpowers/plans/2026-05-15-implementation-audit.md
+++ b/docs/superpowers/plans/2026-05-15-implementation-audit.md
@@ -1,0 +1,159 @@
+# Implementation-vs-plan audit — 2026-05-15
+
+Read-only audit of all 6 plans in `docs/superpowers/plans/` against the code
+that actually landed. master @ `47f1929`, working tree clean, 494 tests
+collected (479 passed / 15 skipped).
+
+Method: 6 parallel read-only agents, one per plan. Plans CLAUDE.md marks
+shipped got a claims-verification pass against `followups.md`; the two live
+plans (reviewer-grounding, v0.2 incident schema) got full audits.
+
+---
+
+## Verdict table
+
+| Plan | Header said | Reality | Action taken |
+|---|---|---|---|
+| 2026-05-09-reviewer-grounding | ready for review, then implementation | **SHIPPED** | header corrected |
+| 2026-05-02-v02-incident-schema | ready for review, then implementation | **NOT STARTED (parked, clean)** | header clarified |
+| 2026-05-01-phase-a-qwen3-hot-path-swap | ready to ship | **SHIPPED** (2 hardening deviations) | header corrected |
+| 2026-05-01-cb3-wire-find-similar-webpages | ready to ship | **SHIPPED** | header corrected |
+| 2026-04-16-context-builder | (no header) | **SHIPPED** | header added |
+| 2026-04-16-triage | (no header) | **SHIPPED** (TR-3 deviation) | header added |
+
+**No plan is partially implemented or silently abandoned.** Everything
+marked shipped is real; the one plan marked parked is genuinely untouched.
+
+---
+
+## Headline finding — CB-1 is mis-tracked as OPEN everywhere
+
+`followups.md` lists **CB-1 (dedupe impact-report formatters) as OPEN**, and
+CLAUDE.md repeats it as **"Pickable next moves" item #1** plus in the "Open
+follow-ups" / "Resume here next time" breadcrumbs.
+
+**CB-1 was closed by commit `1313681`** ("refactor(context): dedupe
+format_impact_report into shared canonical function (CB-1)"). Verified
+directly:
+
+- Canonical formatter: `ollama_sentinel/context/recipes.py:115` `format_impact_report`.
+- `research_agent/tools/synthesis.py:18` imports it as `_shared_format_impact_report`.
+- `synthesis.py:115-122` is now a thin wrapper delegating to the shared
+  formatter (only prepends an `"IMPACT ANALYSIS: "` header). The divergence
+  the ticket described (synthesis emits a SUGGESTED FIRST COMMIT block, recipe
+  does not) no longer exists.
+
+Commit `1313681` lands after CB-7 (`826648f`) and before the grounding work,
+i.e. after the `followups.md` CB section was last meaningfully touched —
+which is why it was missed. **Net effect: the top-of-CLAUDE.md "next move"
+is already done.** This is the single highest-value correction in this audit.
+
+---
+
+## Per-plan detail
+
+### 2026-05-09-reviewer-grounding — SHIPPED (high confidence)
+
+Every Pre-1 / Step 1.1–1.7 / Step 2 / Step 3 item and all listed test
+guarantees are present and green.
+
+- Pre-1 `2a83477`; `_REVIEW_SCHEMA` + schema-constrained `generate_review`
+  `810fc02`; `_validate_verbatim` + `verbatim_excerpt` on Finding + rename
+  `extract_findings`→`validate_findings` `720972a`; quote-first INSTRUCTIONS
+  section `d3262d6`; slop-regression suite (R1–R4) `2f1e18e`; `--no-grounding`
+  `47f1929`.
+- Deviations (all net-positive, documented, test-locked):
+  - Regex fallback **kept behind `--no-grounding`** (`extract_findings_legacy`)
+    rather than deleted — the plan explicitly permitted the flag option.
+  - `--no-grounding` is a richer escape hatch than sketched: a real
+    `ProcessingConfig.grounding` knob plumbed CLI→YAML→`_review_format()`→
+    INSTRUCTIONS section. 8 new tests.
+  - `validate_findings` is `async` (plan implied sync). Harmless; awaited at
+    `watcher.py:238`.
+- Minor empirical gap (not a defect): validation-checklist item 2 ("three
+  known-correct real reviews round-trip un-rejected") is covered by synthetic
+  positive cases, not replayed real-history fixtures.
+- **Doc debt:** the plan *body* still reads as pre-implementation ("After
+  Pre-1 lands…", "Ground truth … master @ `5c1e4a6`, Pre-1 not yet
+  shipped"). Header is fixed; a reader of the body should know it describes
+  pre-state.
+
+### 2026-05-02-v02-incident-schema — NOT STARTED, cleanly parked (high confidence)
+
+Zero footprint in code. No `Incident` dataclass, no `incidents` table, no
+`hooks.py`/`pytest_plugin.py`, no `install-hooks`/`record-commit`/`confirm`/
+`incidents` CLI verbs, no `pytest11` entry point, no tests. `grep -rni
+incident ollama_sentinel/ research_agent/ tests/` → no matches. The only
+"v0.2" commit (`a936c92`) is docs-only.
+
+The plan's own "Ground truth at the time this spec was written" section still
+matches reality exactly. The `Finding` dataclass gained `verbatim_excerpt`
+via the *grounding* work (`720972a`) — unrelated to this plan, not partial
+implementation of it. CLAUDE.md's "parked" claim is accurate. **Its
+prerequisite (reviewer-grounding) is now satisfied**, so this is the next
+real implementation candidate when picked up.
+
+### 2026-05-01-phase-a-qwen3-hot-path-swap — SHIPPED (high confidence)
+
+All 11 acceptance criteria satisfied. `EmbeddingConfig` named-role dict with
+`extra="forbid"`, legacy `model:` auto-migration with one-shot v0.3
+deprecation warning, hot default `qwen3-embedding:4b`. 33 tests pass for
+embed/qwen/migrate.
+
+- Two documented deviations that **harden** the spec (both test-locked,
+  documented inline in `models.py:18-33,251-256`): §1 merge-in-validator
+  pre-registers `consolidation`/`rerank` for partial dicts; §5
+  `_KNOWN_EMBEDDING_ROLES` rejects unknown role keys (plan's `extra="forbid"`
+  only covered top-level).
+- `timeout_seconds` field on `EmbeddingConfig` is unrelated later work
+  (`d17fd8c`, `c72d2ee`), not Phase A scope creep.
+- Recall-diff receipt captured but sparse (thin violation DB) — plan's soft
+  criterion #10 met formally; re-capture once the DB has real data.
+
+### 2026-05-01-cb3-wire-find-similar-webpages — SHIPPED (high confidence)
+
+Cleanest of the audited plans. Commit `821b6b0`. `research_agent/core/prompts.py`
+leaf module with `_format_similar_pages_block`; `workflow.py:144` analyze node
+calls `find_similar_webpages_sync` alongside `find_similar_queries_sync`;
+renders the "Relevant pages from prior research:" block. 93 tests pass with
+no `[research]` extras needed.
+
+- Test mechanism deviated (transparently, in commit body): 5 pure formatter
+  unit tests + 1 source-level wiring guard instead of the plan's 3 monkeypatch
+  integration tests. The plan pre-authorized this; matches the documented
+  closure-testing convention. Equivalent guarantees.
+
+### 2026-04-16-context-builder — SHIPPED (high confidence)
+
+CB-2..CB-7 all verified against their cited commits and current code
+(`566eb67`, `aa28795`, `3b58e66`, `de45da4`, `826648f`; CB-3 `821b6b0`).
+**CB-1 closed by `1313681` but tracked as OPEN — see Headline finding.** All
+plan File-Structure-table deliverables present.
+
+### 2026-04-16-triage — SHIPPED (high confidence)
+
+TR-1 (`9ecee0a`, leaf `prompts.py`, no intra-package imports), TR-2
+(`350929e`, renamed test + caplog assertion), TR-3 (real & still documented:
+empty input → exit 1/ERROR, not spec's exit 0/INFO — deliberate, in
+`followups.md`). All File-Structure deliverables present. 42 tests pass. One
+harmless `RuntimeWarning` (un-awaited AsyncMock) in the test run.
+
+---
+
+## Actions applied (this audit)
+
+1. `followups.md` CB-1 → marked DONE (commit `1313681`).
+2. CLAUDE.md → CB-1 removed from "Pickable next moves" / "Open follow-ups" /
+   "Resume here"; test baseline noted as 494 collected.
+3. Status headers corrected on the 4 plans that have them; status line added
+   to the 2 that don't (context-builder, triage).
+
+## Not done (flagged, no action)
+
+- reviewer-grounding plan **body** is stale pre-implementation prose. Header
+  fixed; full-body rewrite deferred — low value, the plan is shipped and the
+  header now says so.
+- reviewer-grounding validation-checklist item 2 uses synthetic rather than
+  captured real-history positive fixtures. Minor empirical gap, not a defect.
+- phase-a recall-diff receipt is sparse — re-capture when violation DB has
+  real data.

--- a/tests/test_grounding_regression.py
+++ b/tests/test_grounding_regression.py
@@ -166,3 +166,185 @@ def test_mixed_batch_preserves_valid_finding(caplog):
     assert any("MAGIC = 42" in m for m in warnings), (
         "WARNING must include the rejected excerpt"
     )
+
+
+# ---------------------------------------------------------------------------
+# P1-P4 — real-code positive cases (plan Validation item 2).
+#
+# Validation item 2 of docs/superpowers/plans/2026-05-09-reviewer-grounding.md:
+# "Run the pipeline against reviews known to be correct ... The findings must
+#  round-trip without being rejected by the validator. If they're rejected,
+#  the validator is too strict (whitespace normalization wrong, line-range
+#  off-by-one, etc.)."
+#
+# The May-3 retro never snapshotted raw model responses, and the pre-grounding
+# .ollama_reviews/ captures predate the verbatim_excerpt field, so there is no
+# replayable real-history corpus. Instead these fixtures use VERBATIM real
+# source frozen from ollama_sentinel/processor.py @ 47f1929 — the exact
+# @retry construct the plan's own schema example cites — and assert correct
+# findings on it survive the full validate_findings path. Each case targets
+# a strictness failure mode item 2 names that R3 (zero-indent, 2-line) does
+# not cover: multi-line spans, line-range boundaries, deep indentation, and
+# regex-metachar excerpts (a guard against any future substring->regex swap).
+#
+# To regenerate after a real refactor: re-copy the cited line ranges from
+# processor.py and update line_start/line_end. The uniqueness guard below
+# fails loudly if an excerpt stops being unique to its cited range, so a
+# stale fixture cannot pass for the wrong reason.
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+
+def _norm(text: str) -> str:
+    """Mirror extractor._validate_verbatim's private whitespace normaliser."""
+    return _re.sub(r"\s+", " ", text).strip()
+
+
+# processor.py:112-117 — the @retry decorator block (multi-line, 4-space
+# indent, parens). The plan's schema example cites this exact construct.
+_RETRY_BLOCK = (
+    "    @retry(\n"
+    "        retry=retry_if_exception(_is_retryable_ollama_error),\n"
+    "        wait=wait_exponential(multiplier=1, min=2, max=60),\n"
+    "        stop=stop_after_attempt(5),\n"
+    "        reraise=True,\n"
+    "    )\n"
+)
+
+# processor.py:64-66 — contiguous real block used for both line-range
+# boundary cases (first line and last line).
+_STATUS_GUARD = (
+    "    if isinstance(exc, httpx.HTTPStatusError):\n"
+    "        status = exc.response.status_code\n"
+    "        return status == 408 or status == 429 or status >= 500\n"
+)
+
+# processor.py:104-106 — deeply-indented httpx client init; line 2 is rich
+# in regex metacharacters ( ( ) [ ] " . ).
+_CLIENT_INIT = (
+    "        self.client = httpx.AsyncClient(\n"
+    "            timeout=httpx.Timeout(connect=5.0, read=float(config[\"request_timeout\"]), write=5.0, pool=5.0)\n"
+    "        )\n"
+)
+
+
+@pytest.mark.parametrize(
+    "case_id, file_content, finding",
+    [
+        # P1 — multi-line (>2) excerpt, real 4-space indentation, parens.
+        (
+            "P1_multiline_decorator",
+            _RETRY_BLOCK,
+            {
+                "line_start": 1,
+                "line_end": 6,
+                "category": "reliability",
+                "severity": "medium",
+                "verbatim_excerpt": (
+                    "@retry( retry=retry_if_exception(_is_retryable_ollama_error), "
+                    "wait=wait_exponential(multiplier=1, min=2, max=60), "
+                    "stop=stop_after_attempt(5), reraise=True, )"
+                ),
+                "description": "retry predicate spans the whole decorator block.",
+            },
+        ),
+        # P2 — line-range END boundary: excerpt only on the final line.
+        # An end-exclusive off-by-one would slice it away and reject.
+        (
+            "P2_end_boundary",
+            _STATUS_GUARD,
+            {
+                "line_start": 3,
+                "line_end": 3,
+                "category": "maintainability",
+                "severity": "low",
+                "verbatim_excerpt": "return status == 408 or status == 429 or status >= 500",
+                "description": "Status predicate is the last line of the block.",
+            },
+        ),
+        # P3 — line-range START boundary: excerpt only on line 1.
+        # A start-off-by-one (lines[start:end] with start=line_start) empties
+        # the slice and rejects.
+        (
+            "P3_start_boundary",
+            _STATUS_GUARD,
+            {
+                "line_start": 1,
+                "line_end": 1,
+                "category": "design",
+                "severity": "low",
+                "verbatim_excerpt": "if isinstance(exc, httpx.HTTPStatusError):",
+                "description": "Guard clause is the first line of the block.",
+            },
+        ),
+        # P4 — deep (12-space) indentation + regex metacharacters in the
+        # excerpt. Whitespace must normalise; ( ) [ ] " must NOT be treated
+        # as a pattern (guards a future substring->regex regression).
+        (
+            "P4_deep_indent_metachars",
+            _CLIENT_INIT,
+            {
+                "line_start": 2,
+                "line_end": 2,
+                "category": "reliability",
+                "severity": "medium",
+                "verbatim_excerpt": (
+                    'timeout=httpx.Timeout(connect=5.0, '
+                    'read=float(config["request_timeout"]), write=5.0, pool=5.0)'
+                ),
+                "description": "Timeout construction line, deeply indented.",
+            },
+        ),
+    ],
+    ids=[
+        "P1_multiline_decorator",
+        "P2_end_boundary",
+        "P3_start_boundary",
+        "P4_deep_indent_metachars",
+    ],
+)
+def test_correct_finding_on_real_source_is_not_rejected(
+    case_id, file_content, finding, caplog
+):
+    """A correct finding on verbatim real source round-trips un-rejected.
+
+    Empirical seal on plan Validation item 2: the validator must not be too
+    strict against real, correct findings (whitespace, multi-line, line-range
+    boundaries, metachars).
+    """
+    # Uniqueness guard: the normalised excerpt occurs exactly once in the
+    # normalised file, so a True result can ONLY mean the cited range matched
+    # — not an accidental substring elsewhere (green-for-wrong-reason).
+    occurrences = _norm(file_content).count(_norm(finding["verbatim_excerpt"]))
+    assert occurrences == 1, (
+        f"{case_id}: excerpt must be unique to its cited range "
+        f"(found {occurrences}); fixture is ambiguous and proves nothing"
+    )
+
+    # Step 1: the validator helper accepts it.
+    assert _validate_verbatim(finding, file_content) is True, (
+        f"{case_id}: validator rejected a correct excerpt — it is too strict"
+    )
+
+    # Step 2: the full path returns the finding intact, no WARNING.
+    with caplog.at_level("WARNING"):
+        result = asyncio.run(
+            validate_findings([finding], f"{case_id}.py", file_content)
+        )
+
+    assert len(result) == 1, f"{case_id}: correct finding must survive validation"
+    survived = result[0]
+    assert survived.verbatim_excerpt == finding["verbatim_excerpt"]
+    assert survived.category == finding["category"]
+    assert survived.description == finding["description"]
+
+    rejection_warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelname == "WARNING" and "not found in cited range" in r.getMessage()
+    ]
+    assert not rejection_warnings, (
+        f"{case_id}: a correct finding must not emit a rejection WARNING; "
+        f"got {rejection_warnings}"
+    )


### PR DESCRIPTION
## What

Read-only implementation-vs-plan audit of all 6 plans in `docs/superpowers/plans/`, then closed the two gaps it surfaced. Docs + tests only — **no production code changed**.

### Audit result (commit `e0b4281`)

All 6 plans are in clean states — nothing half-built or silently abandoned:

| Plan | Header said | Reality |
|---|---|---|
| reviewer-grounding | "ready for review" | **SHIPPED** |
| v0.2-incident-schema | "ready for review" | **NOT STARTED** — cleanly parked (accurate) |
| phase-a-qwen3 | "ready to ship" | **SHIPPED** (2 hardening deviations) |
| cb3-find-similar-webpages | "ready to ship" | **SHIPPED** |
| context-builder | (no header) | **SHIPPED** |
| triage | (no header) | **SHIPPED** (TR-3 deviation, documented) |

**Headline finding:** CB-1 (dedupe impact-report formatters) was mis-tracked as **OPEN** in `followups.md` *and* in CLAUDE.md's "Pickable next moves" #1 — but it was actually closed by commit `1313681` (`synthesis.py:115` is now a thin wrapper over the canonical `recipes.py:115`). Verified directly. Corrected in both places; CLAUDE.md's next move is now the (unblocked) v0.2 incident schema, and the stale test baseline `378` → `~494` was fixed.

New consolidated report: `docs/superpowers/plans/2026-05-15-implementation-audit.md`. Method: 6 parallel read-only agents, uniform return schema.

### Two flags closed for good (commit `e3011cd`)

**Validation item 2 — was synthetic-only.** The plan's "replay existing correct reviews" was never executable: the May-3 retro never snapshotted raw model responses, and pre-grounding `.ollama_reviews/` captures predate the `verbatim_excerpt` field (structurally unreplayable). Added `test_correct_finding_on_real_source_is_not_rejected` (P1–P4) using **verbatim real source frozen from `processor.py` @ 47f1929** — the `@retry` construct the plan's own schema example cites. Covers the strictness modes item 2 names that R3 didn't: multi-line spans, line-range start/end boundaries, deep indentation, regex-metachar excerpts. Each case has a uniqueness guard so it can't pass for the wrong reason.

**Plan-body staleness.** Not a wholesale rewrite (would duplicate the audit doc and blur plan-vs-retro). Added per-section `> **SHIPPED**` markers under Step 1/2/3 + Validation; the "Ground truth at the time this spec was written" section stays frozen by design.

## Test

`pytest tests/ -q` → **483 passed, 15 skipped** (was 479; +4 new positive-path cases). No regression.

## Risk

Docs + one test file. No production code touched.