### PR TITLE
v0.2 Piece 1 — Incident schema + migration + CRUD

### DIFF
--- a/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
+++ b/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
@@ -1,6 +1,6 @@
 # v0.2: Incident Schema — Finding/Incident Split
 
-**Status:** ready for review, then implementation
+**Status:** IN PROGRESS — **Piece 1 SHIPPED** (schema + migration + CRUD + 9 tests, TDD). Pieces 2–5 (post-commit hook, confirm verb, pytest plugin, incidents CLI) not started. Prerequisite (reviewer-grounding) SHIPPED.
 **Effort:** ~3-4 days across schema + hooks + pytest plugin + CLI verbs
 **Owner:** unassigned
 **Prerequisites:** Phase A merged (PR #4). CB-3 shipped.
@@ -179,6 +179,19 @@ resolves the Finding AND creates an Incident. Flag this in the PR.
 ## Implementation — five pieces
 
 ### Piece 1: Schema + migration + CRUD (~half day)
+
+> **SHIPPED.** `Incident` dataclass + `incidents` table + `_migrate`
+> extension (`triggering_commit_sha`, `fix_commit_sha`) + `PRAGMA
+> foreign_keys=ON` + `persist_incident` / `get_incidents_for_finding` /
+> `get_recent_incidents` / `get_findings_with_incidents` /
+> `link_commit_to_findings` + behavioral `mark_resolved(*, fix_commit=)`.
+> 9 tests in `TestIncidents` (the 8 specified + one for
+> `get_recent_incidents` so every CRUD method has a guarantee). TDD,
+> red→green→refactor; full suite 488 passed / 15 skipped (off master; 492 once PR #7 grounding tests also land). Reconciliation:
+> the "Ground truth" section below is frozen-as-written and now stale in
+> two ways that did NOT affect Piece 1 — test count is 488 here off master (not 378), and
+> `ImportResolver` was promoted to `ollama_sentinel.context` (commit
+> 0176b2f); the latter matters for Piece 4 (pytest plugin), not here.
 
 **Files:** `ollama_sentinel/violation_db.py`, `tests/test_violation_db.py`
 
@@ -490,6 +503,19 @@ feels forced or missing, the schema is wrong and needs revision before
 implementation starts.
 
 This exercise is not optional. It's the spec's acceptance test.
+
+> **EXECUTED 2026-05-16 (Piece 1).** No somaCURA / Song Expanse access,
+> so — same in-repo-substitution principle as the reviewer-grounding
+> fixtures — the exercise was run against a real *ollama-sentinel* bug:
+> the `run_dashboard` per-tick DB-connection churn caught in adversarial
+> review and fixed in `1b3c127`. A `Finding` + `Incident` pair was filled
+> out and round-tripped through the shipped schema: every field
+> (`triggering_commit`, `suspect_commits`, `confirming_signal`/`artifact`,
+> `symptom_file`/`line`, `blast_radius`, `fix_commit`, `fix_shape`)
+> populated cleanly with nothing forced or missing, and it naturally
+> demonstrated A3-style multi-corroboration (`manual_confirm` +
+> `fix_commit` Incidents on one Finding). Schema accepted — no revision
+> needed before Pieces 2–5.
 
 ---
 

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -1,11 +1,12 @@
 """
 SQLite persistence layer for tracking code review findings.
 """
+import json
 import sqlite3
 import threading
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import List
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
 
 
 @dataclass
@@ -18,6 +19,27 @@ class Finding:
     severity: str    # "critical", "high", "medium", "low"
     description: str
     verbatim_excerpt: str = ""
+
+
+@dataclass
+class Incident:
+    """A corroborated event linking a Finding to objective evidence.
+
+    Findings are model opinions. Incidents are things that actually happened.
+    Each Incident references exactly one Finding and carries the artifact
+    that proves the corroboration. Multiple Incidents may reference the same
+    Finding; Incidents are never upserted — each row is a distinct event.
+    """
+    finding_id: int
+    confirming_signal: str    # "test_failure" | "manual_confirm" | "fix_commit"
+    confirming_artifact: str  # pytest node id, commit SHA, or CLI context
+    triggering_commit: Optional[str] = None
+    suspect_commits: Optional[List[str]] = None  # ranked candidates (ambiguous attribution)
+    symptom_file: Optional[str] = None
+    symptom_line: Optional[int] = None
+    blast_radius: Optional[List[str]] = None     # all files where failure surfaced
+    fix_commit: Optional[str] = None
+    fix_shape: Optional[str] = None
 
 
 class ViolationDB:
@@ -40,13 +62,32 @@ class ViolationDB:
         )
     """
 
+    _CREATE_INCIDENTS_TABLE = """
+        CREATE TABLE IF NOT EXISTS incidents (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            finding_id          INTEGER NOT NULL REFERENCES findings(id),
+            confirming_signal   TEXT    NOT NULL,
+            confirming_artifact TEXT    NOT NULL,
+            triggering_commit   TEXT,
+            suspect_commits     TEXT,
+            symptom_file        TEXT,
+            symptom_line        INTEGER,
+            blast_radius        TEXT,
+            fix_commit          TEXT,
+            fix_shape           TEXT,
+            created_at          TEXT    NOT NULL
+        )
+    """
+
     def __init__(self, db_path: str) -> None:
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         with self._lock:
             self._conn.execute("PRAGMA journal_mode=WAL")
             self._conn.execute("PRAGMA busy_timeout=5000")
+            self._conn.execute("PRAGMA foreign_keys=ON")
             self._conn.execute(self._CREATE_TABLE)
+            self._conn.execute(self._CREATE_INCIDENTS_TABLE)
             self._conn.commit()
         self._migrate()
 
@@ -68,6 +109,15 @@ class ViolationDB:
                         """
                     )
                     self._conn.commit()
+                if "triggering_commit_sha" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN triggering_commit_sha TEXT"
+                    )
+                if "fix_commit_sha" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN fix_commit_sha TEXT"
+                    )
+                self._conn.commit()
         except sqlite3.DatabaseError as e:
             import logging
             logging.getLogger("ollama-sentinel").error("ViolationDB migration failed: %s", e)
@@ -141,18 +191,158 @@ class ViolationDB:
                 self._conn.rollback()
                 raise
 
-    def mark_resolved(self, finding_id: int) -> None:
-        """Set *resolved=1* for the given finding."""
+    def mark_resolved(
+        self, finding_id: int, *, fix_commit: Optional[str] = None
+    ) -> None:
+        """Set ``resolved=1`` for the given finding.
+
+        Behavioral change (v0.2): when ``fix_commit`` is provided, also
+        records ``fix_commit_sha`` on the finding and inserts an Incident
+        with ``confirming_signal='fix_commit'``. The old single-argument
+        call shape is unchanged and creates no Incident.
+        """
         with self._lock:
+            if fix_commit is None:
+                self._conn.execute(
+                    "UPDATE findings SET resolved = 1 WHERE id = ?",
+                    (finding_id,),
+                )
+                self._conn.commit()
+                return
             self._conn.execute(
-                "UPDATE findings SET resolved = 1 WHERE id = ?",
-                (finding_id,),
+                "UPDATE findings SET resolved = 1, fix_commit_sha = ? WHERE id = ?",
+                (fix_commit, finding_id),
             )
             self._conn.commit()
+        self.persist_incident(
+            Incident(
+                finding_id=finding_id,
+                confirming_signal="fix_commit",
+                confirming_artifact=fix_commit,
+                fix_commit=fix_commit,
+            )
+        )
+
+    def persist_incident(self, incident: Incident) -> int:
+        """Insert an Incident row and return its new id. Never upserts."""
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            cur = self._conn.cursor()
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO incidents
+                        (finding_id, confirming_signal, confirming_artifact,
+                         triggering_commit, suspect_commits, symptom_file,
+                         symptom_line, blast_radius, fix_commit, fix_shape,
+                         created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        incident.finding_id,
+                        incident.confirming_signal,
+                        incident.confirming_artifact,
+                        incident.triggering_commit,
+                        json.dumps(incident.suspect_commits)
+                        if incident.suspect_commits is not None
+                        else None,
+                        incident.symptom_file,
+                        incident.symptom_line,
+                        json.dumps(incident.blast_radius)
+                        if incident.blast_radius is not None
+                        else None,
+                        incident.fix_commit,
+                        incident.fix_shape,
+                        now,
+                    ),
+                )
+                self._conn.commit()
+                # lastrowid is always set after a successful single INSERT.
+                return int(cur.lastrowid) if cur.lastrowid is not None else -1
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def link_commit_to_findings(
+        self, commit_sha: str, touched_files: List[str]
+    ) -> int:
+        """Set ``triggering_commit_sha`` on open findings in ``touched_files``.
+
+        Returns the number of findings linked. Resolved findings are skipped.
+        """
+        if not touched_files:
+            return 0
+        placeholders = ", ".join("?" * len(touched_files))
+        with self._lock:
+            cur = self._conn.execute(
+                f"""
+                UPDATE findings
+                SET triggering_commit_sha = ?
+                WHERE file_path IN ({placeholders}) AND resolved = 0
+                """,
+                (commit_sha, *touched_files),
+            )
+            self._conn.commit()
+            return cur.rowcount
 
     # ------------------------------------------------------------------
     # Read operations
     # ------------------------------------------------------------------
+
+    def _incident_rows(self, cur: sqlite3.Cursor) -> List[dict]:
+        """Rows → dicts with JSON-array columns decoded back to lists."""
+        rows = self._rows_to_dicts(cur)
+        for r in rows:
+            for key in ("suspect_commits", "blast_radius"):
+                if r.get(key) is not None:
+                    r[key] = json.loads(r[key])
+        return rows
+
+    def get_incidents_for_finding(self, finding_id: int) -> List[dict]:
+        """Return all Incidents referencing this Finding, oldest first."""
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM incidents WHERE finding_id = ? ORDER BY id ASC",
+                (finding_id,),
+            )
+            return self._incident_rows(cur)
+
+    def get_recent_incidents(
+        self, *, days: int = 30, limit: int = 50
+    ) -> List[dict]:
+        """Return recent Incidents across all Findings, newest first."""
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=days)
+        ).isoformat()
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                SELECT * FROM incidents
+                WHERE created_at >= ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                (cutoff, limit),
+            )
+            return self._incident_rows(cur)
+
+    def get_findings_with_incidents(
+        self, file_paths: List[str]
+    ) -> List[dict]:
+        """Return Findings in ``file_paths`` that have ≥1 Incident."""
+        if not file_paths:
+            return []
+        placeholders = ", ".join("?" * len(file_paths))
+        with self._lock:
+            cur = self._conn.execute(
+                f"""
+                SELECT DISTINCT findings.* FROM findings
+                JOIN incidents ON incidents.finding_id = findings.id
+                WHERE findings.file_path IN ({placeholders})
+                """,
+                file_paths,
+            )
+            return self._rows_to_dicts(cur)
 
     def get_unresolved(self, file_path: str) -> List[dict]:
         """Return all unresolved findings for *file_path*."""

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -412,3 +412,206 @@ class TestThreadSafety:
         db = ViolationDB(str(tmp_path / "close.db"))
         db.close()
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# v0.2 Piece 1 — Incident schema + migration + CRUD
+# ---------------------------------------------------------------------------
+
+
+def _seed_finding_id(db, **overrides) -> int:
+    """Persist one finding and return its row id.
+
+    Selects by the finding's full upsert key (not ``[0]``) so it stays
+    correct when several findings share a file.
+    """
+    f = _make_finding(**overrides)
+    db.persist_findings(f.file_path, [f])
+    row = db._conn.execute(
+        """
+        SELECT id FROM findings
+        WHERE file_path = ? AND line_start = ? AND line_end = ? AND category = ?
+        ORDER BY id DESC LIMIT 1
+        """,
+        (f.file_path, f.line_start, f.line_end, f.category),
+    ).fetchone()
+    return row[0]
+
+
+def _make_incident(finding_id: int, **overrides):
+    """Build an Incident with sensible defaults, allowing overrides."""
+    from ollama_sentinel.violation_db import Incident
+
+    defaults = dict(
+        finding_id=finding_id,
+        confirming_signal="test_failure",
+        confirming_artifact="tests/test_x.py::test_y",
+        triggering_commit="abc123",
+        suspect_commits=["abc123", "def456"],
+        symptom_file="src/other.py",
+        symptom_line=55,
+        blast_radius=["src/other.py", "src/more.py"],
+        fix_commit=None,
+        fix_shape=None,
+    )
+    defaults.update(overrides)
+    return Incident(**defaults)
+
+
+class TestIncidents:
+    def test_persist_incident_creates_row(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            fid = _seed_finding_id(db)
+            new_id = db.persist_incident(_make_incident(fid))
+            assert isinstance(new_id, int) and new_id > 0
+
+            rows = db.get_incidents_for_finding(fid)
+            assert len(rows) == 1
+            row = rows[0]
+            assert row["finding_id"] == fid
+            assert row["confirming_signal"] == "test_failure"
+            assert row["confirming_artifact"] == "tests/test_x.py::test_y"
+            assert row["symptom_line"] == 55
+            # JSON-array columns round-trip as Python lists.
+            assert row["suspect_commits"] == ["abc123", "def456"]
+            assert row["blast_radius"] == ["src/other.py", "src/more.py"]
+            assert row["created_at"]
+        finally:
+            db.close()
+
+    def test_multiple_incidents_same_finding(self, tmp_path):
+        """A1: two incidents on one finding are two distinct rows."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            fid = _seed_finding_id(db)
+            db.persist_incident(_make_incident(fid, confirming_artifact="run-1"))
+            db.persist_incident(_make_incident(fid, confirming_artifact="run-2"))
+
+            rows = db.get_incidents_for_finding(fid)
+            assert len(rows) == 2
+            assert {r["confirming_artifact"] for r in rows} == {"run-1", "run-2"}
+        finally:
+            db.close()
+
+    def test_incident_requires_valid_finding_id(self, tmp_path):
+        """Incidents require a real Finding FK — orphan inserts must fail."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                db.persist_incident(_make_incident(99999))
+        finally:
+            db.close()
+
+    def test_get_findings_with_incidents_filters_correctly(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            fid_with = _seed_finding_id(db, file_path="src/a.py")
+            _seed_finding_id(db, file_path="src/b.py")  # no incident
+            db.persist_incident(_make_incident(fid_with))
+
+            rows = db.get_findings_with_incidents(["src/a.py", "src/b.py"])
+            assert len(rows) == 1
+            assert rows[0]["id"] == fid_with
+            assert rows[0]["file_path"] == "src/a.py"
+        finally:
+            db.close()
+
+    def test_link_commit_to_findings_updates_open_only(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            open_fid = _seed_finding_id(db, file_path="src/c.py", line_start=1, line_end=2)
+            resolved_fid = _seed_finding_id(
+                db, file_path="src/c.py", line_start=9, line_end=9
+            )
+            db.mark_resolved(resolved_fid)
+
+            n = db.link_commit_to_findings("sha789", ["src/c.py"])
+            assert n == 1
+
+            open_row = next(
+                r for r in db.get_unresolved("src/c.py") if r["id"] == open_fid
+            )
+            assert open_row["triggering_commit_sha"] == "sha789"
+
+            resolved_row = db._conn.execute(
+                "SELECT triggering_commit_sha FROM findings WHERE id = ?",
+                (resolved_fid,),
+            ).fetchone()
+            assert resolved_row[0] is None
+        finally:
+            db.close()
+
+    def test_mark_resolved_with_fix_commit_creates_incident(self, tmp_path):
+        """Behavioral change: fix_commit resolves AND records an Incident."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            fid = _seed_finding_id(db)
+            db.mark_resolved(fid, fix_commit="fixsha1")
+
+            assert db.get_unresolved("src/app.py") == []
+            row = db._conn.execute(
+                "SELECT fix_commit_sha FROM findings WHERE id = ?", (fid,)
+            ).fetchone()
+            assert row[0] == "fixsha1"
+
+            incidents = db.get_incidents_for_finding(fid)
+            assert len(incidents) == 1
+            assert incidents[0]["confirming_signal"] == "fix_commit"
+            assert incidents[0]["fix_commit"] == "fixsha1"
+        finally:
+            db.close()
+
+    def test_mark_resolved_without_fix_commit_backward_compat(self, tmp_path):
+        """Old call shape still works and creates no Incident."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            fid = _seed_finding_id(db)
+            db.mark_resolved(fid)
+
+            assert db.get_unresolved("src/app.py") == []
+            assert db.get_incidents_for_finding(fid) == []
+        finally:
+            db.close()
+
+    def test_get_recent_incidents_orders_by_created_at_desc(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            fid = _seed_finding_id(db)
+            db.persist_incident(_make_incident(fid, confirming_artifact="older"))
+            db.persist_incident(_make_incident(fid, confirming_artifact="newer"))
+
+            rows = db.get_recent_incidents(days=30, limit=50)
+            assert len(rows) == 2
+            # Most recent first (created_at desc, id desc tiebreak).
+            assert rows[0]["confirming_artifact"] == "newer"
+        finally:
+            db.close()
+
+    def test_migration_on_populated_db(self, tmp_path):
+        """A7: reopening a populated pre-v0.2 DB migrates without data loss."""
+        db_path = str(tmp_path / "v.db")
+        db1 = ViolationDB(db_path)
+        for i in range(5):
+            db1.persist_findings(
+                f"src/f{i}.py", [_make_finding(file_path=f"src/f{i}.py")]
+            )
+        assert len(db1.get_all_unresolved()) == 5
+        db1.close()
+
+        # Reopen — triggers _migrate on an existing populated DB.
+        db2 = ViolationDB(db_path)
+        try:
+            assert len(db2.get_all_unresolved()) == 5  # no data loss
+
+            cur = db2._conn.execute("PRAGMA table_info(findings)")
+            cols = {row[1] for row in cur.fetchall()}
+            assert "triggering_commit_sha" in cols
+            assert "fix_commit_sha" in cols
+
+            tbl = db2._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='incidents'"
+            ).fetchone()
+            assert tbl is not None
+        finally:
+            db2.close()


### PR DESCRIPTION
## What

First of the 5 pieces of the v0.2 incident-schema plan (`docs/superpowers/plans/2026-05-02-v02-incident-schema.md`). Splits the sentinel's memory schema into **Findings** (model opinions) and **Incidents** (corroborated events with causal structure). Surgical, dependency-root, independently shippable; Pieces 2–5 (post-commit hook, `confirm` verb, pytest plugin, `incidents` CLI) are NOT in this PR.

## Changes

- `Incident` dataclass next to `Finding`
- `incidents` table (FK → `findings.id`) + `PRAGMA foreign_keys=ON`
- `_migrate` extended: adds `triggering_commit_sha` + `fix_commit_sha` to `findings`, idempotent, follows the existing `embed_text` pattern (adversarial case A7)
- CRUD: `persist_incident`, `get_incidents_for_finding`, `get_recent_incidents`, `get_findings_with_incidents`, `link_commit_to_findings`
- `mark_resolved(finding_id, *, fix_commit=None)` — **behavioral change**: when `fix_commit` is given it also records `fix_commit_sha` and inserts a `fix_commit` Incident. Old positional call shape is unchanged; verified **zero non-test callers exist anywhere** (incl. `_archive`), so no breakage surface.

## Tests (TDD)

9 tests in `TestIncidents` — the plan's 8 named guarantees plus one for `get_recent_incidents` so every CRUD method has a guarantee (transparent deviation: the plan listed the method without a guarantee). Red→green→refactor; watched all fail first. Covers FK orphan rejection, backward-compat, A1 multi-incident, A7 migration on a populated DB.

`pytest tests/ -q` off master → **488 passed, 15 skipped** (was 479; +9). Becomes 492 once PR #7's grounding tests also land.

## Acceptance test

The plan's mandatory schema-validation exercise was executed (recorded in the plan): a real ollama-sentinel bug (the `1b3c127` dashboard connection-churn fix) was filled into a `Finding`+`Incident` pair and round-tripped through the shipped schema — every field populated cleanly, nothing forced, and it naturally demonstrated A3 multi-corroboration. Schema accepted; no revision before Pieces 2–5.

## Relationship to PR #7

Independent. PR #7 is the docs/audit PR (no production code). This branch is off `master`; the only shared file is the v0.2 plan doc, where a 1-line status-header merge may need a trivial resolution depending on merge order (Piece 1's "IN PROGRESS" is the later truth).