### PR TITLE
v0.2 Piece 2 — post-commit hook + install-hooks/record-commit (stacked on #8)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
+++ b/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
@@ -1,6 +1,6 @@
 # v0.2: Incident Schema — Finding/Incident Split
 
-**Status:** IN PROGRESS — **Piece 1 SHIPPED** (schema + migration + CRUD + 9 tests, TDD). Pieces 2–5 (post-commit hook, confirm verb, pytest plugin, incidents CLI) not started. Prerequisite (reviewer-grounding) SHIPPED.
+**Status:** IN PROGRESS — **Pieces 1 & 2 SHIPPED.** P1: schema + migration + CRUD (9 tests). P2: post-commit hook + `install-hooks`/`record-commit` CLI verbs (9 tests). Both TDD. Pieces 3–5 (confirm verb, pytest plugin, incidents CLI) not started. Prerequisite (reviewer-grounding) SHIPPED.
 **Effort:** ~3-4 days across schema + hooks + pytest plugin + CLI verbs
 **Owner:** unassigned
 **Prerequisites:** Phase A merged (PR #4). CB-3 shipped.
@@ -253,6 +253,17 @@ db.close()`). New test class `TestIncidents`:
   and findings have the new nullable columns.
 
 ### Piece 2: Post-commit hook + `install-hooks` CLI verb (~half day)
+
+> **SHIPPED.** New `ollama_sentinel/hooks.py`: `install_hooks(repo_path)`
+> (writes an executable `.git/hooks/post-commit`, never clobbers an
+> existing one, raises on non-repo) and `record_commit(repo_path, db, *,
+> commit_sha=None)` (resolves HEAD/SHA via GitPython, links touched files
+> via `link_commit_to_findings`). CLI verbs `install-hooks` /
+> `record-commit` added to `cli.py` (shared `_load_config_or_exit`
+> helper). 9 tests in `tests/test_hooks.py` — the plan's 5 plus
+> non-repo-reject, explicit-SHA, and 2 CLI-wrapper tests (untested
+> wrappers would violate TDD; same "complete the surface" rule as P1's
+> 9th test). Real git repos via GitPython, no mocks. Suite 497 / 15.
 
 **Files:** `ollama_sentinel/hooks.py` (new), `ollama_sentinel/cli.py`,
 `tests/test_hooks.py` (new)

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -309,6 +309,81 @@ def report(
         console.print(table)
 
 
+def _load_config_or_exit(config_path: str):
+    """Shared: resolve + load the YAML config or exit(1)."""
+    from .config import load_config
+
+    config_file = pathlib.Path(config_path)
+    if not config_file.exists():
+        log.error(f"Configuration file not found: {config_file}")
+        raise typer.Exit(code=1)
+    config = load_config(config_file)
+    if not config:
+        log.error("Failed to load configuration")
+        raise typer.Exit(code=1)
+    return config
+
+
+@app.command(name="install-hooks")
+def install_hooks_cmd(
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Install the git post-commit hook into the watched repository."""
+    from .hooks import install_hooks
+
+    config = _load_config_or_exit(config_path)
+    repo_path = pathlib.Path(config.watch.directory).resolve()
+    try:
+        installed = install_hooks(repo_path)
+    except FileNotFoundError as e:
+        log.error(str(e))
+        raise typer.Exit(code=1)
+
+    if installed:
+        console.print(
+            f"[green]Installed git hook(s): {', '.join(installed)}[/green]"
+        )
+    else:
+        console.print(
+            "[yellow]post-commit hook already exists — left untouched.[/yellow]"
+        )
+
+
+@app.command(name="record-commit")
+def record_commit_cmd(
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    commit_sha: Optional[str] = typer.Option(
+        None, "--commit", help="Commit SHA to link (default: HEAD)",
+    ),
+):
+    """Link a commit to open Findings in the files it touched.
+
+    Called by the post-commit git hook; also usable manually.
+    """
+    from .hooks import record_commit
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    repo_path = pathlib.Path(config.watch.directory).resolve()
+    db_path = repo_path / config.memory.db_path
+    if not db_path.exists():
+        log.info("No violation database yet — nothing to link.")
+        raise typer.Exit()
+
+    db = ViolationDB(str(db_path))
+    try:
+        linked = record_commit(repo_path, db, commit_sha=commit_sha)
+    finally:
+        db.close()
+    log.info("Linked %d finding(s) to the commit.", linked)
+
+
 @app.command()
 def triage(
     input_path: Optional[str] = typer.Argument(

--- a/ollama_sentinel/hooks.py
+++ b/ollama_sentinel/hooks.py
@@ -1,0 +1,68 @@
+"""Git hook scripts and installers for ollama-sentinel (v0.2 Piece 2).
+
+The post-commit hook links each commit to open Findings in the files it
+touched, recording the commit SHA on those Findings for later Incident
+attribution. Findings still come only from the model; this just stamps
+``triggering_commit_sha`` so a future test failure (Piece 4) can build
+the causal chain.
+"""
+
+import pathlib
+import stat
+from typing import List, Optional
+
+import git
+
+from .violation_db import ViolationDB
+
+_POST_COMMIT_HOOK = """\
+#!/bin/sh
+# Installed by ollama-sentinel install-hooks.
+# Links the commit to open Findings in the files it touched.
+ollama-sentinel record-commit
+"""
+
+
+def install_hooks(repo_path) -> List[str]:
+    """Install git hooks into ``repo_path/.git/hooks/``.
+
+    Returns the list of hook names installed. An existing ``post-commit``
+    hook is left untouched (and not counted) — we never clobber a user's
+    own hook. Raises ``FileNotFoundError`` if ``repo_path`` is not a git
+    repository.
+    """
+    hooks_dir = pathlib.Path(repo_path) / ".git" / "hooks"
+    if not hooks_dir.is_dir():
+        raise FileNotFoundError(f"Not a git repository: {hooks_dir} missing")
+
+    post_commit = hooks_dir / "post-commit"
+    if post_commit.exists():
+        return []
+
+    post_commit.write_text(_POST_COMMIT_HOOK)
+    post_commit.chmod(
+        post_commit.stat().st_mode
+        | stat.S_IXUSR
+        | stat.S_IXGRP
+        | stat.S_IXOTH
+    )
+    return ["post-commit"]
+
+
+def record_commit(
+    repo_path,
+    db: ViolationDB,
+    *,
+    commit_sha: Optional[str] = None,
+) -> int:
+    """Link a commit to open Findings in the files it touched.
+
+    Resolves ``commit_sha`` (or ``HEAD`` if None) via GitPython, extracts
+    the touched file paths, and calls
+    ``db.link_commit_to_findings``. Returns the number of Findings linked
+    (0 if the commit touches no files with open Findings — a clean no-op).
+    """
+    repo = git.Repo(repo_path)
+    commit = repo.commit(commit_sha) if commit_sha else repo.head.commit
+    touched = list(commit.stats.files.keys())
+    return db.link_commit_to_findings(commit.hexsha, touched)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,253 @@
+"""Tests for ollama_sentinel.hooks — v0.2 Piece 2.
+
+Post-commit hook installer + record_commit (links a commit to open
+Findings in the files it touched). Mirrors test_violation_db.py
+conventions: tmp_path, try/finally db.close(), real code (real git
+repos via GitPython, no mocks).
+"""
+
+import os
+import stat
+
+import git
+import pytest
+from typer.testing import CliRunner
+
+from ollama_sentinel.violation_db import Finding, ViolationDB
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git_repo(path):
+    """Init a real git repo at *path* with commit identity configured."""
+    repo = git.Repo.init(path)
+    cw = repo.config_writer()
+    cw.set_value("user", "name", "Test")
+    cw.set_value("user", "email", "test@example.com")
+    cw.release()
+    return repo
+
+
+def _commit_file(repo, repo_path, rel_path, content="x = 1\n"):
+    """Write rel_path under the repo, stage it, commit; return the SHA."""
+    fp = os.path.join(repo_path, rel_path)
+    os.makedirs(os.path.dirname(fp), exist_ok=True) if os.path.dirname(fp) else None
+    with open(fp, "w") as fh:
+        fh.write(content)
+    repo.index.add([rel_path])
+    return repo.index.commit(f"add {rel_path}").hexsha
+
+
+def _make_finding(**overrides) -> Finding:
+    defaults = dict(
+        file_path="src/app.py",
+        line_start=10,
+        line_end=12,
+        category="bug",
+        severity="high",
+        description="Possible null dereference",
+    )
+    defaults.update(overrides)
+    return Finding(**defaults)
+
+
+def _seed_finding_id(db, **overrides) -> int:
+    f = _make_finding(**overrides)
+    db.persist_findings(f.file_path, [f])
+    row = db._conn.execute(
+        "SELECT id FROM findings WHERE file_path=? AND line_start=? "
+        "AND line_end=? AND category=? ORDER BY id DESC LIMIT 1",
+        (f.file_path, f.line_start, f.line_end, f.category),
+    ).fetchone()
+    return row[0]
+
+
+# ---------------------------------------------------------------------------
+# install_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestInstallHooks:
+    def test_install_hooks_creates_post_commit(self, tmp_path):
+        from ollama_sentinel.hooks import install_hooks
+
+        _git_repo(tmp_path)
+        installed = install_hooks(tmp_path)
+
+        assert installed == ["post-commit"]
+        hook = tmp_path / ".git" / "hooks" / "post-commit"
+        assert hook.exists()
+        assert "ollama-sentinel record-commit" in hook.read_text()
+        # Executable bit set for the owner.
+        assert hook.stat().st_mode & stat.S_IXUSR
+
+    def test_install_hooks_does_not_overwrite_existing(self, tmp_path):
+        from ollama_sentinel.hooks import install_hooks
+
+        _git_repo(tmp_path)
+        hook = tmp_path / ".git" / "hooks" / "post-commit"
+        hook.write_text("#!/bin/sh\necho pre-existing\n")
+
+        installed = install_hooks(tmp_path)
+
+        assert installed == []  # nothing installed
+        assert hook.read_text() == "#!/bin/sh\necho pre-existing\n"
+
+    def test_install_hooks_rejects_non_repo(self, tmp_path):
+        from ollama_sentinel.hooks import install_hooks
+
+        with pytest.raises(FileNotFoundError):
+            install_hooks(tmp_path)  # no .git/hooks here
+
+
+# ---------------------------------------------------------------------------
+# record_commit
+# ---------------------------------------------------------------------------
+
+
+class TestRecordCommit:
+    def test_record_commit_links_findings_in_touched_files(self, tmp_path):
+        from ollama_sentinel.hooks import record_commit
+
+        repo = _git_repo(tmp_path)
+        db = ViolationDB(str(tmp_path / "memory.db"))
+        try:
+            fid = _seed_finding_id(db, file_path="src/c.py")
+            sha = _commit_file(repo, str(tmp_path), "src/c.py")
+
+            n = record_commit(tmp_path, db)
+
+            assert n == 1
+            row = db._conn.execute(
+                "SELECT triggering_commit_sha FROM findings WHERE id=?", (fid,)
+            ).fetchone()
+            assert row[0] == sha
+        finally:
+            db.close()
+
+    def test_record_commit_skips_resolved_findings(self, tmp_path):
+        from ollama_sentinel.hooks import record_commit
+
+        repo = _git_repo(tmp_path)
+        db = ViolationDB(str(tmp_path / "memory.db"))
+        try:
+            open_fid = _seed_finding_id(
+                db, file_path="src/c.py", line_start=1, line_end=2
+            )
+            resolved_fid = _seed_finding_id(
+                db, file_path="src/c.py", line_start=9, line_end=9
+            )
+            db.mark_resolved(resolved_fid)
+            _commit_file(repo, str(tmp_path), "src/c.py")
+
+            n = record_commit(tmp_path, db)
+
+            assert n == 1
+            assert (
+                db._conn.execute(
+                    "SELECT triggering_commit_sha FROM findings WHERE id=?",
+                    (open_fid,),
+                ).fetchone()[0]
+                is not None
+            )
+            assert (
+                db._conn.execute(
+                    "SELECT triggering_commit_sha FROM findings WHERE id=?",
+                    (resolved_fid,),
+                ).fetchone()[0]
+                is None
+            )
+        finally:
+            db.close()
+
+    def test_record_commit_no_findings_is_noop(self, tmp_path):
+        from ollama_sentinel.hooks import record_commit
+
+        repo = _git_repo(tmp_path)
+        db = ViolationDB(str(tmp_path / "memory.db"))
+        try:
+            _commit_file(repo, str(tmp_path), "untracked_by_findings.py")
+            assert record_commit(tmp_path, db) == 0
+        finally:
+            db.close()
+
+    def test_record_commit_explicit_sha(self, tmp_path):
+        from ollama_sentinel.hooks import record_commit
+
+        repo = _git_repo(tmp_path)
+        db = ViolationDB(str(tmp_path / "memory.db"))
+        try:
+            _seed_finding_id(db, file_path="src/c.py")
+            sha1 = _commit_file(repo, str(tmp_path), "src/c.py")
+            _commit_file(repo, str(tmp_path), "other.py")  # HEAD moves past sha1
+
+            n = record_commit(tmp_path, db, commit_sha=sha1)
+
+            assert n == 1  # links by the explicit (older) commit, not HEAD
+        finally:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI verbs (thin wrappers — kept TDD-pure)
+# ---------------------------------------------------------------------------
+
+
+class TestHookCLIVerbs:
+    def _write_config(self, tmp_path):
+        cfg = tmp_path / "ollama-sentinel.yaml"
+        cfg.write_text(
+            "ollama:\n"
+            "  host: http://localhost:11434\n"
+            "  models:\n"
+            "    default:\n"
+            "      name: qwen2.5-coder:7b\n"
+            "      system_prompt: review this\n"
+            f"watch:\n"
+            f"  directory: {tmp_path}\n"
+            "memory:\n"
+            "  enabled: true\n"
+            "  db_path: memory.db\n"
+        )
+        return cfg
+
+    def test_install_hooks_cli_installs(self, tmp_path):
+        from ollama_sentinel.cli import app
+
+        _git_repo(tmp_path)
+        cfg = self._write_config(tmp_path)
+        result = CliRunner().invoke(
+            app, ["install-hooks", "--config", str(cfg)]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".git" / "hooks" / "post-commit").exists()
+
+    def test_record_commit_cli_links(self, tmp_path):
+        from ollama_sentinel.cli import app
+
+        repo = _git_repo(tmp_path)
+        cfg = self._write_config(tmp_path)
+        db = ViolationDB(str(tmp_path / "memory.db"))
+        try:
+            _seed_finding_id(db, file_path="src/c.py")
+        finally:
+            db.close()
+        _commit_file(repo, str(tmp_path), "src/c.py")
+
+        result = CliRunner().invoke(
+            app, ["record-commit", "--config", str(cfg)]
+        )
+        assert result.exit_code == 0, result.output
+
+        db2 = ViolationDB(str(tmp_path / "memory.db"))
+        try:
+            linked = db2._conn.execute(
+                "SELECT triggering_commit_sha FROM findings "
+                "WHERE file_path='src/c.py'"
+            ).fetchone()[0]
+            assert linked is not None
+        finally:
+            db2.close()


### PR DESCRIPTION
## What

Piece 2 of 5 of the v0.2 incident-schema plan. **Stacked on #8** (base = `feat/v02-piece-1`) since it uses Piece 1's `link_commit_to_findings`. Review/merge #8 first; this PR's diff shows only Piece 2.

When a commit touches files with open Findings, the post-commit hook stamps `triggering_commit_sha` on them — the input Piece 4's pytest plugin needs to build the Finding→Incident causal chain.

## Changes

- **`ollama_sentinel/hooks.py`** (new):
  - `install_hooks(repo_path)` — writes an executable `.git/hooks/post-commit` calling `ollama-sentinel record-commit`. **Never clobbers** an existing post-commit hook (returns `[]`); raises `FileNotFoundError` on a non-repo path.
  - `record_commit(repo_path, db, *, commit_sha=None)` — resolves HEAD (or explicit SHA) via GitPython, extracts touched files, delegates to `db.link_commit_to_findings`. Returns count; 0 is a clean no-op.
- **`cli.py`**: `install-hooks` + `record-commit` verbs, plus a shared `_load_config_or_exit` helper (mirrors `report`'s config→db pattern).

## Tests (TDD)

9 in `tests/test_hooks.py` — the plan's 5 guarantees + non-repo-reject + explicit-SHA + 2 CLI-wrapper tests (untested wrappers would violate the iron law; same "complete the surface" discipline as Piece 1's 9th test). **Real git repos via GitPython, no mocks.** Watched all fail first; post-impl failures were only a bad fixture YAML, fixed test-side.

`pytest tests/ -q` → **497 passed, 15 skipped** (was 488 on the Piece-1 base; +9). No regression.

## Scope

Surgical: hooks + 2 thin CLI verbs only. No pre-commit surfacing, no pytest plugin, no Pattern detection — those are later pieces / explicitly out of scope per the plan.