### PR TITLE
v0.2 Piece 3 — confirm verb (stacked on #9)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
+++ b/docs/superpowers/plans/2026-05-02-v02-incident-schema.md
@@ -1,6 +1,6 @@
 # v0.2: Incident Schema — Finding/Incident Split
 
-**Status:** IN PROGRESS — **Pieces 1 & 2 SHIPPED.** P1: schema + migration + CRUD (9 tests). P2: post-commit hook + `install-hooks`/`record-commit` CLI verbs (9 tests). Both TDD. Pieces 3–5 (confirm verb, pytest plugin, incidents CLI) not started. Prerequisite (reviewer-grounding) SHIPPED.
+**Status:** IN PROGRESS — **Pieces 1, 2 & 3 SHIPPED.** P1: schema + migration + CRUD (9 tests). P2: post-commit hook + `install-hooks`/`record-commit` verbs (9 tests). P3: `confirm` verb (3 tests). All TDD. Pieces 4–5 (pytest plugin, incidents CLI) not started. Prerequisite (reviewer-grounding) SHIPPED.
 **Effort:** ~3-4 days across schema + hooks + pytest plugin + CLI verbs
 **Owner:** unassigned
 **Prerequisites:** Phase A merged (PR #4). CB-3 shipped.
@@ -344,6 +344,16 @@ def record_commit_cmd(...):
   findings returns 0, no error.
 
 ### Piece 3: `ollama-sentinel confirm` CLI verb (~2 hours)
+
+> **SHIPPED.** `confirm <finding_id> [--note]` verb in `cli.py`: inserts
+> a `manual_confirm` Incident via `persist_incident`; the Finding stays
+> open (corroboration ≠ resolution). Nonexistent finding ids are caught
+> via Piece 1's FK constraint (`sqlite3.IntegrityError` → user error,
+> exit 1) — no extra existence query needed. `confirming_artifact` is the
+> `--note` text, or a default CLI-context string. Reuses Piece 2's
+> `_load_config_or_exit`. 3 tests in `tests/test_cli.py::TestConfirmCommand`
+> (the plan's 3 guarantees) using the existing `_make_report_config` /
+> CliRunner convention. Suite 500 / 15.
 
 **Files:** `ollama_sentinel/cli.py`, `tests/test_cli.py`
 

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -385,6 +385,62 @@ def record_commit_cmd(
 
 
 @app.command()
+def confirm(
+    finding_id: int = typer.Argument(
+        ..., help="ID of the Finding to confirm"
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    note: str = typer.Option(
+        "", "--note", "-n",
+        help="Optional context for the confirmation",
+    ),
+):
+    """Manually confirm a Finding, promoting it to an Incident.
+
+    Creates an Incident with confirming_signal='manual_confirm'. The
+    Finding stays open — confirmation is corroboration, not resolution.
+    """
+    import sqlite3
+
+    from .violation_db import Incident, ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    repo_path = pathlib.Path(config.watch.directory).resolve()
+    db_path = repo_path / config.memory.db_path
+    if not db_path.exists():
+        console.print("[red]No violation database found.[/red]")
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        artifact = note or "manual confirm via `ollama-sentinel confirm`"
+        try:
+            db.persist_incident(
+                Incident(
+                    finding_id=finding_id,
+                    confirming_signal="manual_confirm",
+                    confirming_artifact=artifact,
+                )
+            )
+        except sqlite3.IntegrityError:
+            console.print(
+                f"[red]No finding with id {finding_id}; "
+                f"nothing to confirm.[/red]"
+            )
+            raise typer.Exit(code=1)
+    finally:
+        db.close()
+
+    console.print(
+        f"[green]Confirmed finding {finding_id} — Incident recorded "
+        f"(finding stays open).[/green]"
+    )
+
+
+@app.command()
 def triage(
     input_path: Optional[str] = typer.Argument(
         None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,3 +334,82 @@ class TestDefaultCommand:
         assert result.exit_code == 0
         output = (result.stdout or "") + (result.output or "")
         assert "ollama-sentinel" in output
+
+
+# ---------------------------------------------------------------------------
+# v0.2 Piece 3 — `ollama-sentinel confirm`
+# ---------------------------------------------------------------------------
+
+
+def _seed_one_finding_id(db_path):
+    """Seed a single finding and return (db_path, finding_id)."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = ViolationDB(str(db_path))
+    try:
+        db.persist_findings(
+            "src/app.py",
+            [Finding("src/app.py", 10, 12, "bug", "high", "Null deref")],
+        )
+        fid = db._conn.execute(
+            "SELECT id FROM findings ORDER BY id DESC LIMIT 1"
+        ).fetchone()[0]
+    finally:
+        db.close()
+    return fid
+
+
+class TestConfirmCommand:
+    """Tests for 'ollama-sentinel confirm' (manual corroboration)."""
+
+    def test_confirm_creates_incident(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+
+        result = runner.invoke(
+            app, ["confirm", str(fid), "--config", str(cfg)]
+        )
+        assert result.exit_code == 0, result.output
+
+        db = ViolationDB(str(db_path))
+        try:
+            incidents = db.get_incidents_for_finding(fid)
+            assert len(incidents) == 1
+            assert incidents[0]["confirming_signal"] == "manual_confirm"
+            # Confirmation is corroboration, NOT resolution — finding stays open.
+            assert len(db.get_unresolved("src/app.py")) == 1
+        finally:
+            db.close()
+
+    def test_confirm_nonexistent_finding_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()  # empty DB, no finding 9999
+
+        result = runner.invoke(
+            app, ["confirm", "9999", "--config", str(cfg)]
+        )
+        assert result.exit_code == 1
+        assert "9999" in result.output or "no finding" in result.output.lower()
+
+    def test_confirm_with_note(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+
+        result = runner.invoke(
+            app,
+            ["confirm", str(fid), "--config", str(cfg), "--note", "hit in prod"],
+        )
+        assert result.exit_code == 0, result.output
+
+        db = ViolationDB(str(db_path))
+        try:
+            artifact = db.get_incidents_for_finding(fid)[0]["confirming_artifact"]
+            assert "hit in prod" in artifact
+        finally:
+            db.close()


### PR DESCRIPTION
## What

Piece 3 of 5 of the v0.2 incident-schema plan. **Stacked on #9** (base = `feat/v02-piece-2`). Adds `ollama-sentinel confirm <finding_id> [--note]` — manual corroboration: inserts a `manual_confirm` Incident while leaving the Finding open (corroboration ≠ resolution).

Stacked linearly rather than branched off Piece 1 (the plan calls 2/3/4 "parallel") because `confirm` reuses Piece 2's `_load_config_or_exit` helper — linear stacking avoids a duplicate-introduction merge conflict.

## Changes

- `cli.py`: `confirm` verb. Nonexistent finding ids are caught via **Piece 1's FK constraint** (`sqlite3.IntegrityError` → exit 1, user-facing message) — no extra existence query. `confirming_artifact` = `--note` text or a default CLI-context string.

## Tests (TDD)

3 in `tests/test_cli.py::TestConfirmCommand` — the plan's 3 guarantees (creates-incident + finding-stays-open, nonexistent→exit 1, note→artifact). Uses the existing `_make_report_config`/CliRunner convention. Watched all fail first.

`pytest tests/ -q` → **500 passed, 15 skipped** (was 497 on the Piece-2 base; +3). No regression.

## Merge order

#8 → #9 → #10. GitHub auto-retargets each base as its parent merges. Pieces 4–5 (pytest plugin, `incidents` CLI) remain unstarted.