### PR TITLE
feat(dashboard): triage-console visual overhaul

### DIFF
--- a/docs/superpowers/plans/2026-05-17-dashboard-triage-revamp.md
+++ b/docs/superpowers/plans/2026-05-17-dashboard-triage-revamp.md
@@ -1,0 +1,918 @@
+# Dashboard Triage-Console Visual Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn `ollama-sentinel dashboard`'s v2 Rich TUI into a triage console — vitals strip, bold severity banner, dominant blended-ranked Patterns list, thin Reviews rail — with zero data-layer or input-model changes.
+
+**Architecture:** Additive-first. Tasks 1-6 add pure helpers (no deletions, full suite stays green). Tasks 7-8 rewire the two v2 entry points (`render_layout` v2 branch + the `_build_layout` closure in `run_dashboard`). Task 9 deletes the now-dead superseded helpers and migrates their tests in one consistent step. Legacy two-panel path (`config_path == ""`) is never touched and is regression-locked.
+
+**Tech Stack:** Python 3.10+, Rich (`Panel`/`Table`/`Layout`), pytest (`asyncio_mode=auto`).
+
+**Spec:** `docs/superpowers/specs/2026-05-17-dashboard-triage-revamp-design.md`
+**Branch:** `feat/dashboard-triage-revamp` (already created off `master`).
+
+---
+
+## Ordering invariant (why this sequence)
+
+`_reviews_panel` is used by the **legacy** `render_layout` branch (line
+419) — it must **never** be deleted. `_header_panel_v2`, `_overview_panel`,
+and `_reviews_panel_interactive` are v2-only and become dead **only after
+both** Tasks 7 and 8 rewire their callers — so they are deleted exactly
+once, in Task 9, together with their test/import migration. Consequence:
+every task ends with the **entire** suite green (`pytest tests/ -q`), not
+a scoped subset. No task leaves a dangling reference to a deleted symbol.
+
+## Test mechanism (confirmed, used by every task)
+
+`tests/test_dashboard.py` asserts on Rich object attributes —
+`panel.title`, `panel.border_style`, and `layout["region"]` indexing.
+For content assertions add this helper **once**, in Task 1 Step 1,
+directly below the existing `_touch` function (line 32):
+
+```python
+def _render(renderable, width: int = 120) -> str:
+    """Render a Rich renderable to plain text for content assertions."""
+    from rich.console import Console
+    c = Console(width=width, record=True, file=open(os.devnull, "w"))
+    c.print(renderable)
+    return c.export_text()
+```
+
+(`os` is already imported in the test file, line 3.)
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `ollama_sentinel/dashboard.py` | v2 render path + pure helpers | add `_SEVERITY_WEIGHT`/`blended_rank`/`_vitals_strip`/`_severity_banner`/`_reviews_rail`; revise `_SEVERITY_STYLE` + `_patterns_panel*` single-line; rewire `render_layout` v2 + `_build_layout` v2; **T9** deletes dead `_header_panel_v2`/`_overview_panel`/`_reviews_panel_interactive`. `_reviews_panel`/`_violations_panel`/legacy path untouched. |
+| `tests/test_dashboard.py` | unit + structural + regression | add `_render`; new tests per task; **T9** migrates the import block + superseded-panel tests |
+
+---
+
+## Task 1: `_SEVERITY_WEIGHT` + `blended_rank` (pure)
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py` (add after `_STATUS_STYLE`, line 47)
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Add the `_render` helper**
+
+In `tests/test_dashboard.py`, immediately after the `_touch` function
+(ends line 32, before `class TestRecentReviews`), insert the `_render`
+helper exactly as shown in "Test mechanism" above.
+
+- [ ] **Step 2: Write failing tests**
+
+Append to `tests/test_dashboard.py`:
+
+```python
+class TestBlendedRank:
+    def _vr(self, sev, count, fp="f.py", line=1):
+        return ViolationRow(count=count, severity=sev, category="bug",
+                             file_path=fp, line_start=line, line_end=line,
+                             description="d")
+
+    def test_severity_weight_ordering_invariant(self):
+        from ollama_sentinel.dashboard import _SEVERITY_WEIGHT
+        w = _SEVERITY_WEIGHT
+        assert w["critical"] > w["high"] > w["medium"] > w["low"]
+        assert w["critical"] > 7 * w["low"]   # one CRIT outranks 7 LOW
+
+    def test_blended_orders_by_weight_times_count(self):
+        from ollama_sentinel.dashboard import blended_rank
+        rows = [
+            self._vr("medium", 15),   # 2*15 = 30
+            self._vr("high", 11),     # 4*11 = 44
+            self._vr("critical", 4),  # 8*4  = 32
+            self._vr("low", 50),      # 1*50 = 50
+        ]
+        ranked = blended_rank(rows)
+        assert [(r.severity, r.count) for r in ranked] == [
+            ("low", 50), ("high", 11), ("critical", 4), ("medium", 15)]
+
+    def test_tiebreak_count_then_filepath(self):
+        from ollama_sentinel.dashboard import blended_rank
+        a = self._vr("high", 5, fp="z.py")   # 20
+        b = self._vr("high", 5, fp="a.py")   # 20 -> file asc
+        c = self._vr("high", 9, fp="m.py")   # 36
+        ranked = blended_rank([a, b, c])
+        assert [r.file_path for r in ranked] == ["m.py", "a.py", "z.py"]
+
+    def test_unknown_severity_weight_zero_sorts_last(self):
+        from ollama_sentinel.dashboard import blended_rank
+        good = self._vr("low", 1)
+        bad = self._vr("bogus", 999)
+        assert blended_rank([bad, good]) == [good, bad]
+
+    def test_empty_returns_empty(self):
+        from ollama_sentinel.dashboard import blended_rank
+        assert blended_rank([]) == []
+```
+
+- [ ] **Step 3: Run, verify FAIL**
+
+Run: `python -m pytest tests/test_dashboard.py::TestBlendedRank -v`
+Expected: FAIL — `cannot import name '_SEVERITY_WEIGHT'` / `blended_rank`.
+
+- [ ] **Step 4: Implement**
+
+In `ollama_sentinel/dashboard.py`, after the `_STATUS_STYLE` dict (line
+47) and before the `# ---` separator (line 49), add:
+
+```python
+_SEVERITY_WEIGHT = {
+    "critical": 8,
+    "high": 4,
+    "medium": 2,
+    "low": 1,
+}
+
+
+def blended_rank(rows: "List[ViolationRow]") -> "List[ViolationRow]":
+    """Order recurring findings by triage urgency.
+
+    Sort key: ``severity_weight * count`` descending; unknown severities
+    weigh 0 (sort last). Ties: count desc, then file_path asc. Pure and
+    stable; never raises on bad input.
+    """
+    def key(r: "ViolationRow"):
+        weight = _SEVERITY_WEIGHT.get(r.severity.lower(), 0)
+        return (-(weight * r.count), -r.count, r.file_path)
+
+    return sorted(rows, key=key)
+```
+
+- [ ] **Step 5: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS (pure addition; `TestBlendedRank` green, nothing else
+affected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): add blended severity*recurrence ranking"
+```
+
+---
+
+## Task 2: Revise `_SEVERITY_STYLE` palette
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py:35-40`
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_dashboard.py`:
+
+```python
+class TestSeverityPalette:
+    def test_palette_is_bold_saturated_and_distinct(self):
+        from ollama_sentinel.dashboard import _SEVERITY_STYLE
+        s = _SEVERITY_STYLE
+        assert s["critical"] == "bold red"
+        assert s["high"] == "bold yellow"
+        assert s["medium"] == "cyan"
+        assert s["low"] == "dim"
+        assert len(set(s.values())) == 4
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `python -m pytest tests/test_dashboard.py::TestSeverityPalette -v`
+Expected: FAIL — `s["high"]` is `"red"`, `s["medium"]` is `"yellow"`.
+
+- [ ] **Step 3: Implement**
+
+In `ollama_sentinel/dashboard.py`, replace the `_SEVERITY_STYLE` dict
+(lines 35-40):
+
+```python
+_SEVERITY_STYLE = {
+    "critical": "bold red",
+    "high": "red",
+    "medium": "yellow",
+    "low": "dim",
+}
+```
+
+with:
+
+```python
+_SEVERITY_STYLE = {
+    "critical": "bold red",
+    "high": "bold yellow",
+    "medium": "cyan",
+    "low": "dim",
+}
+```
+
+- [ ] **Step 4: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS — no other test pins exact palette values (verified:
+only `ViolationRow(severity=...)` construction references severities,
+never `_SEVERITY_STYLE` values).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): bold saturated severity palette"
+```
+
+---
+
+## Task 3: Add `_vitals_strip` (pure addition)
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py` (add immediately after `_header_panel_v2`, ~line 272 — do NOT remove `_header_panel_v2`; it is still wired until Task 9)
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to class `TestControlCenterPanels` in `tests/test_dashboard.py`:
+
+```python
+    def test_vitals_strip_renders(self):
+        from ollama_sentinel.dashboard import _vitals_strip
+        stats = OverviewStats(
+            total_reviews=5, newest_review_age_s=30.0, total_unresolved=8,
+            config_path="test.yaml", model_name="gemma3",
+            watch_dir="/code", db_exists=True,
+        )
+        panel = _vitals_strip(stats, time.time())
+        text = _render(panel)
+        assert "gemma3" in text
+        assert "Active" in text                 # age 30s -> Active
+        assert panel.border_style == "bold cyan"
+
+    def test_vitals_strip_handles_empty(self):
+        from ollama_sentinel.dashboard import _vitals_strip
+        stats = OverviewStats(total_reviews=0, newest_review_age_s=None,
+                              total_unresolved=0)
+        panel = _vitals_strip(stats, time.time())   # must not raise
+        assert "unknown" in _render(panel)
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `python -m pytest "tests/test_dashboard.py::TestControlCenterPanels" -k vitals -v`
+Expected: FAIL — `cannot import name '_vitals_strip'`.
+
+- [ ] **Step 3: Implement (add only)**
+
+In `ollama_sentinel/dashboard.py`, directly after the `_header_panel_v2`
+function (after line 271, before `watcher_status_from_age`), add:
+
+```python
+def _vitals_strip(stats: OverviewStats, now: float) -> Panel:
+    """One-line vitals: status dot, model, open count, update clock.
+
+    Triage replacement for the old three-line v2 header. Status dot
+    color tracks watcher staleness. Never raises on empty stats.
+    """
+    ts = _dt.datetime.fromtimestamp(now).strftime("%H:%M:%S")
+    status_label, status_key = watcher_status_from_age(stats.newest_review_age_s)
+    status_style = _STATUS_STYLE.get(status_key, "dim")
+    model = stats.model_name or "unknown"
+    if stats.db_exists:
+        db_info = f"[white]{stats.total_unresolved}[/] open"
+    else:
+        db_info = "[dim]no DB[/]"
+    body = (
+        f"[{status_style}]●[/] [{status_style}]{status_label}[/]"
+        f"  [dim]│[/]  [white]{model}[/]"
+        f"  [dim]│[/]  {db_info}"
+        f"  [dim]│[/]  [dim]rev[/] [white]{ts}[/]"
+    )
+    return Panel(Text.from_markup(body), border_style="bold cyan",
+                 padding=(0, 1))
+```
+
+`watcher_status_from_age` is defined at line 274 (module scope) — fine
+to call from a function defined above it.
+
+- [ ] **Step 4: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS — pure addition; old `test_header_v2_renders` still
+green (`_header_panel_v2` untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): add one-line vitals strip helper"
+```
+
+---
+
+## Task 4: Add `_severity_banner` (pure addition)
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py` (add after `_vitals_strip`)
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to class `TestControlCenterPanels`:
+
+```python
+    def test_severity_banner_shows_counts_and_action(self):
+        from ollama_sentinel.dashboard import _severity_banner
+        stats = OverviewStats(
+            total_reviews=59, newest_review_age_s=30.0, total_unresolved=1230,
+            severity_counts={"critical": 74, "high": 104,
+                             "medium": 576, "low": 476},
+            hottest_file="ErasZoneView.swift", hottest_count=239,
+            db_exists=True,
+        )
+        text = _render(_severity_banner(stats))
+        assert "74" in text and "104" in text and "576" in text and "476" in text
+        assert "ErasZoneView.swift" in text and "239" in text
+        assert "critical" in text.lower()       # from suggested_action
+
+    def test_severity_banner_empty_placeholder(self):
+        from ollama_sentinel.dashboard import _severity_banner
+        stats = OverviewStats(total_reviews=0, newest_review_age_s=None,
+                              total_unresolved=0, db_exists=False)
+        assert "no findings" in _render(_severity_banner(stats)).lower()
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `python -m pytest "tests/test_dashboard.py::TestControlCenterPanels" -k severity_banner -v`
+Expected: FAIL — `cannot import name '_severity_banner'`.
+
+- [ ] **Step 3: Implement**
+
+In `ollama_sentinel/dashboard.py`, immediately after `_vitals_strip`, add:
+
+```python
+def _severity_banner(stats: OverviewStats) -> Panel:
+    """Bold severity scoreboard + hottest-file / next-action callout.
+
+    Line 1: per-severity counts (descending severity), each styled by
+    _SEVERITY_STYLE. Line 2: hottest file + suggested action. Empty /
+    no-DB state shows a muted placeholder; never raises.
+    """
+    if not stats.db_exists or stats.total_unresolved == 0:
+        msg = ("[dim]no findings yet — save a watched file[/]"
+               if stats.total_reviews == 0
+               else "[bold green]All clear — no open findings[/]")
+        return Panel(Text.from_markup(msg), border_style="green",
+                     padding=(0, 1))
+
+    cells = []
+    for sev in ("critical", "high", "medium", "low"):
+        count = stats.severity_counts.get(sev, 0)
+        style = _SEVERITY_STYLE[sev]
+        cells.append(f"[{style}]{sev[:4].upper()} {count}[/]")
+    line1 = "   ".join(cells)
+
+    if stats.hottest_file:
+        hot = (f"[red]🔥[/] [white]{stats.hottest_file}[/]"
+               f" [dim]({stats.hottest_count})[/]")
+    else:
+        hot = "[dim]🔥 —[/]"
+    line2 = f"{hot}   [dim]▸[/] [italic]{suggested_action(stats)}[/]"
+
+    border = "red" if stats.severity_counts.get("critical", 0) else "yellow"
+    return Panel(Text.from_markup(f"{line1}\n{line2}"),
+                 border_style=border, padding=(0, 1))
+```
+
+- [ ] **Step 4: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS (pure addition).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): add severity banner with hottest/action"
+```
+
+---
+
+## Task 5: Add `_reviews_rail` (pure addition)
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py` (add after `_severity_banner`; remove nothing — `_reviews_panel` stays for legacy, `_reviews_panel_interactive` removed in Task 9)
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to class `TestControlCenterPanels`:
+
+```python
+    def test_reviews_rail_compact_and_selection(self):
+        from ollama_sentinel.dashboard import _reviews_rail
+        now = time.time()
+        rows = [ReviewRow(rel_path="Sources/Vinyl/VinylAudioSourceSelector.md",
+                          mtime=now - 2760),
+                ReviewRow(rel_path="a/b/Left.md", mtime=now - 3000)]
+        panel = _reviews_rail(rows, now, selection=0, scroll=0)
+        text = _render(panel, width=40)
+        assert "46m" in text                         # 2760s -> 46m ago
+        assert "VinylAudioSourceSelector" in text    # basename kept
+        assert panel.border_style == "blue"
+        assert all(len(ln) <= 40 for ln in text.splitlines())
+
+    def test_reviews_rail_empty(self):
+        from ollama_sentinel.dashboard import _reviews_rail
+        panel = _reviews_rail([], time.time(), selection=-1, scroll=0)
+        assert "no reviews" in _render(panel).lower()
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `python -m pytest "tests/test_dashboard.py::TestControlCenterPanels" -k reviews_rail -v`
+Expected: FAIL — `cannot import name '_reviews_rail'`.
+
+- [ ] **Step 3: Implement (add only)**
+
+In `ollama_sentinel/dashboard.py`, immediately after `_severity_banner`,
+add:
+
+```python
+def _reviews_rail(
+    rows: List[ReviewRow], now: float, selection: int, scroll: int,
+) -> Panel:
+    """Narrow Recent-Reviews rail: '{ago}  {basename}', one line each.
+
+    Selection highlight preserved (REVIEWS panel stays focusable). Path
+    is basename-biased so the rail stays readable when narrow.
+    """
+    if not rows:
+        return Panel(Text("no reviews yet", style="dim"),
+                     title="Recent", border_style="blue")
+    visible = rows[scroll:scroll + 15]
+    table = Table.grid(padding=(0, 1), expand=True)
+    table.add_column(justify="right", no_wrap=True)
+    table.add_column(no_wrap=True, overflow="ellipsis")
+    for i, r in enumerate(visible):
+        sel = (scroll + i) == selection
+        name = r.rel_path.rsplit("/", 1)[-1]
+        table.add_row(
+            Text(_format_ago(r.mtime, now), style="reverse" if sel else "dim"),
+            Text(name, style="reverse" if sel else ""),
+        )
+    count = len(rows)
+    title = f"Recent ({count})"
+    if scroll > 0 or scroll + 15 < count:
+        title += f" [{scroll + 1}-{min(scroll + 15, count)}]"
+    return Panel(table, title=title, border_style="blue")
+```
+
+- [ ] **Step 4: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS (pure addition).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): add compact reviews rail helper"
+```
+
+---
+
+## Task 6: Single-line Patterns rows
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py` — `_patterns_panel` (line 345), `_patterns_panel_interactive` (line 810)
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_dashboard.py`:
+
+```python
+class TestPatternsSingleLine:
+    LONG = ("Fragile auto-collapse on timeout: the timeout collapses "
+            "detailExpanded unconditionally and will incorrectly collapse "
+            "a different era's detail opened during the override window.")
+
+    def _row(self):
+        return ViolationRow(count=11, severity="high", category="bug",
+                            file_path="ErasZoneView.swift", line_start=183,
+                            line_end=190, description=self.LONG)
+
+    def test_interactive_row_stays_one_line(self):
+        from ollama_sentinel.dashboard import _patterns_panel_interactive
+        panel = _patterns_panel_interactive([self._row()], selection=-1, scroll=0)
+        out = _render(panel, width=80)
+        body = [l for l in out.splitlines() if "ErasZoneView.swift" in l]
+        assert len(body) == 1                 # description did NOT wrap
+        assert "…" in out                     # it was ellipsised
+
+    def test_static_patterns_row_stays_one_line(self):
+        from ollama_sentinel.dashboard import _patterns_panel
+        panel = _patterns_panel([self._row()])
+        body = [l for l in _render(panel, width=80).splitlines()
+                if "ErasZoneView.swift" in l]
+        assert len(body) == 1
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `python -m pytest tests/test_dashboard.py::TestPatternsSingleLine -v`
+Expected: FAIL — description column has no `no_wrap=True`, so the long
+description wraps and `ErasZoneView.swift` appears with the description
+spilling to extra physical lines (the body-line / `…` assertions fail).
+
+- [ ] **Step 3: Implement**
+
+In `_patterns_panel`, change line 345:
+
+```python
+    table.add_column(overflow="ellipsis")
+```
+to:
+```python
+    table.add_column(no_wrap=True, overflow="ellipsis")
+```
+
+In `_patterns_panel_interactive`, change line 810:
+
+```python
+    table.add_column(overflow="ellipsis")
+```
+to:
+```python
+    table.add_column(no_wrap=True, overflow="ellipsis")
+```
+
+- [ ] **Step 4: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS — single-line rows; full text still reachable via
+Enter→DETAIL (`_detail_panel` unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "fix(dashboard): patterns rows stay single-line (ellipsis)"
+```
+
+---
+
+## Task 7: Rewire `render_layout` v2 branch
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py:425-458` (Control Center branch only — legacy branch lines 409-423 untouched)
+- Modify: `tests/test_dashboard.py` — `test_new_signature_produces_control_center` (lines 385-396)
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Replace the structure test**
+
+In `tests/test_dashboard.py`, replace `test_new_signature_produces_control_center`
+(lines 385-396) with:
+
+```python
+    def test_new_signature_produces_triage_layout(self, tmp_path):
+        now = time.time()
+        layout = render_layout(
+            str(tmp_path), tmp_path, tmp_path / "memory.db",
+            [], [], now,
+            config_path="test.yaml", model_name="gemma3",
+            severity_counts={"high": 2},
+        )
+        assert layout["header"] is not None
+        assert layout["banner"] is not None
+        assert layout["body"]["left"] is not None
+        assert layout["body"]["right"] is not None
+        assert layout["footer"] is not None
+```
+
+(`test_old_signature_produces_legacy_layout` is left exactly as-is — it
+is the legacy regression lock.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `python -m pytest tests/test_dashboard.py::TestRenderLayoutBackwardsCompat -v`
+Expected: `test_new_signature_produces_triage_layout` FAILS (`KeyError:
+'banner'` — old v2 tree has no banner region). Legacy test still PASSES.
+
+- [ ] **Step 3: Implement — rebuild only the v2 branch**
+
+In `ollama_sentinel/dashboard.py`, replace the Control Center branch of
+`render_layout` (lines 425-458: from the `# Control Center layout`
+comment through its `return layout`) with:
+
+```python
+    # Control Center triage layout
+    stats = compute_overview(
+        reviews=reviews,
+        severity_counts=severity_counts or {},
+        hottest=hottest,
+        new_this_week=new_this_week,
+        config_path=config_path,
+        model_name=model_name,
+        watch_dir=watch_dir,
+        db_exists=db_path.exists(),
+        now=now,
+        research_latest=research_latest,
+    )
+    ranked = blended_rank(violations)
+
+    layout = Layout()
+    layout.split_column(
+        Layout(name="header", size=3),
+        Layout(name="banner", size=4),
+        Layout(name="body", ratio=1),
+        Layout(name="footer", size=3),
+    )
+    layout["header"].update(_vitals_strip(stats, now))
+    layout["banner"].update(_severity_banner(stats))
+    layout["body"].split_row(
+        Layout(name="left", ratio=3),
+        Layout(name="right", ratio=1),
+    )
+    layout["body"]["left"].update(_patterns_panel(ranked))
+    layout["body"]["right"].update(_reviews_rail(reviews, now, -1, 0))
+    layout["footer"].update(_footer_panel_v2())
+    return layout
+```
+
+Do **not** delete `_overview_panel`/`_header_panel_v2` here — they are
+still referenced by `_build_layout` until Task 8; removed in Task 9.
+
+- [ ] **Step 4: Run full suite, verify GREEN (incl. legacy lock)**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS — `test_new_signature_produces_triage_layout` green
+AND `test_old_signature_produces_legacy_layout` green (legacy branch
+and `_reviews_panel` untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): render_layout v2 -> triage region tree"
+```
+
+---
+
+## Task 8: Rewire the `_build_layout` closure (live path)
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py:616-684` (Control Center section of `_build_layout` inside `run_dashboard`)
+- Test: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Write failing wiring-guard test**
+
+The closure can't be imported; guard its source (project closure-testing
+pattern — its pure panels are already unit-tested in Tasks 1-6). Append:
+
+```python
+class TestBuildLayoutWiring:
+    def _src(self):
+        import inspect
+        from ollama_sentinel.dashboard import run_dashboard
+        return inspect.getsource(run_dashboard)
+
+    def test_live_path_uses_triage_tree_and_blended_rank(self):
+        src = self._src()
+        assert "blended_rank(" in src
+        assert 'Layout(name="banner"' in src
+        assert "_vitals_strip(" in src
+        assert "_severity_banner(" in src
+        assert "_reviews_rail(" in src
+        assert "_overview_panel(" not in src
+        assert "_header_panel_v2(" not in src
+        assert "_reviews_panel_interactive(" not in src
+
+    def test_detail_mode_path_preserved(self):
+        src = self._src()
+        assert "Mode.DETAIL" in src and "_detail_panel(" in src
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `python -m pytest tests/test_dashboard.py::TestBuildLayoutWiring -v`
+Expected: FAIL — current `_build_layout` still calls `_header_panel_v2`/
+`_overview_panel`/`_reviews_panel_interactive`, no `blended_rank`/banner.
+
+- [ ] **Step 3: Implement — rebuild the closure's v2 section**
+
+In `ollama_sentinel/dashboard.py`, replace the Control Center section of
+`_build_layout` (lines 616-684: from the `# Interactive Control Center
+layout` comment through its final `return layout`) with:
+
+```python
+        # Interactive Control Center triage layout
+        stats = compute_overview(
+            reviews=reviews,
+            severity_counts=data["severity_counts"],
+            hottest=data["hottest"],
+            new_this_week=data["new_this_week"],
+            config_path=config_path,
+            model_name=model_name,
+            watch_dir=str(watch_dir),
+            db_exists=db_path.exists(),
+            now=now,
+            research_latest=data["research_latest"],
+        )
+        ranked = blended_rank(violations)
+
+        layout = Layout()
+        layout.split_column(
+            Layout(name="header", size=3),
+            Layout(name="banner", size=4),
+            Layout(name="body", ratio=1),
+            Layout(name="footer", size=3),
+        )
+        layout["header"].update(_vitals_strip(stats, now))
+
+        # Detail mode: keep banner, replace body full-width
+        if state.mode == Mode.DETAIL:
+            layout["banner"].update(_severity_banner(stats))
+            layout["body"].update(_detail_panel(state, reviews, ranked, now))
+            layout["footer"].update(_footer_interactive(state))
+            return layout
+
+        # OVERVIEW focus highlights the banner region border.
+        banner_p = _severity_banner(stats)
+        if state.focused_panel == PanelId.OVERVIEW:
+            banner_p.border_style = "bold cyan"
+        layout["banner"].update(banner_p)
+
+        reviews_border = "bold cyan" if state.focused_panel == PanelId.REVIEWS else "blue"
+        patterns_border = "bold cyan" if state.focused_panel == PanelId.PATTERNS else "magenta"
+
+        sel_idx_p = state.selection.get(PanelId.PATTERNS, 0) if state.focused_panel == PanelId.PATTERNS else -1
+        scroll_p = state.scroll_offset.get(PanelId.PATTERNS, 0)
+        title_suffix = f" [filter: {state.filter_text}]" if state.filter_active else ""
+        patterns_p = _patterns_panel_interactive(ranked, sel_idx_p, scroll_p, title_suffix)
+        patterns_p.border_style = patterns_border
+
+        sel_idx_r = state.selection.get(PanelId.REVIEWS, 0) if state.focused_panel == PanelId.REVIEWS else -1
+        scroll_r = state.scroll_offset.get(PanelId.REVIEWS, 0)
+        reviews_p = _reviews_rail(reviews, now, sel_idx_r, scroll_r)
+        reviews_p.border_style = reviews_border
+
+        layout["body"].split_row(
+            Layout(name="left", ratio=3),
+            Layout(name="right", ratio=1),
+        )
+        layout["body"]["left"].update(patterns_p)
+        layout["body"]["right"].update(reviews_p)
+
+        if interactive:
+            layout["footer"].update(_footer_interactive(state))
+        else:
+            layout["footer"].update(_footer_panel_v2())
+
+        return layout
+```
+
+`_detail_panel`'s signature is `(state, reviews, violations, now)`
+(verified dashboard.py:833). Passing `ranked` as the violations arg
+keeps DETAIL selection indices consistent with the ranked Patterns list
+the user navigated. `_patterns_panel_interactive(rows, selection,
+scroll, title_suffix)` and `_reviews_rail(rows, now, selection, scroll)`
+match their Task 5/6 signatures.
+
+- [ ] **Step 4: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS — wiring guard green; `TestRunDashboard` loop tests
+green (loop / `_fetch_data` / error-isolation untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): live _build_layout -> triage tree + blended rank"
+```
+
+---
+
+## Task 9: Delete superseded helpers + migrate their tests
+
+After Tasks 7-8, `_header_panel_v2`, `_overview_panel`, and
+`_reviews_panel_interactive` have **zero callers**. Remove them and
+their now-orphaned tests in one consistent step.
+
+**Files:**
+- Modify: `ollama_sentinel/dashboard.py` — delete `_header_panel_v2`, `_overview_panel`, `_reviews_panel_interactive`
+- Modify: `tests/test_dashboard.py` — import block (lines 21-24), `test_overview_panel_renders`, `test_header_v2_renders`
+
+- [ ] **Step 1: Prove they are dead**
+
+Run: `grep -n "_header_panel_v2\|_overview_panel\|_reviews_panel_interactive" ollama_sentinel/dashboard.py`
+Expected: only the `def` lines themselves (no call sites). If any call
+site remains, STOP — Task 7 or 8 is incomplete.
+
+- [ ] **Step 2: Delete the three functions**
+
+In `ollama_sentinel/dashboard.py` delete, in full:
+- `_header_panel_v2` (the `def _header_panel_v2(...)` block)
+- `_overview_panel` (the `def _overview_panel(...)` block)
+- `_reviews_panel_interactive` (the `def _reviews_panel_interactive(...)` block)
+
+Leave `_reviews_panel`, `_violations_panel`, `_header_panel`,
+`_footer_panel`, `_footer_panel_v2`, `_footer_interactive`,
+`_patterns_panel`, `_patterns_panel_interactive`, `_detail_panel`
+untouched.
+
+- [ ] **Step 3: Migrate the test file**
+
+In `tests/test_dashboard.py` import block (lines 21-24), remove the
+`_overview_panel,` and `_header_panel_v2,` lines (keep `_patterns_panel,`
+and `_footer_panel_v2,`). Delete `test_overview_panel_renders` and
+`test_header_v2_renders` from `TestControlCenterPanels` (their content
+moved to `_vitals_strip`/`_severity_banner`, already covered by
+`test_vitals_strip_renders` + `test_severity_banner_*`).
+
+- [ ] **Step 4: Run full suite, verify GREEN**
+
+Run: `python -m pytest tests/test_dashboard.py -q`
+Expected: all PASS — no import error, no orphaned test, no dead code.
+
+- [ ] **Step 5: Static surface check**
+
+Run: `python -c "import ollama_sentinel.dashboard as d; assert hasattr(d,'blended_rank') and hasattr(d,'_vitals_strip') and hasattr(d,'_severity_banner') and hasattr(d,'_reviews_rail') and hasattr(d,'_reviews_panel') and not hasattr(d,'_header_panel_v2') and not hasattr(d,'_overview_panel') and not hasattr(d,'_reviews_panel_interactive')"`
+Expected: exit 0 — new surface present, legacy `_reviews_panel` kept,
+superseded v2 helpers gone.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ollama_sentinel/dashboard.py tests/test_dashboard.py
+git commit -m "refactor(dashboard): drop superseded v2 panels + migrate tests"
+```
+
+---
+
+## Task 10: Full suite, manual smoke, PR
+
+- [ ] **Step 1: Whole project suite**
+
+Run: `python -m pytest tests/ -q`
+Expected: all green. Net test delta vs. master: `+~17` added (Tasks
+1-8) `-2` removed (`test_overview_panel_renders`, `test_header_v2_renders`,
+Task 9) `~1` replaced (`test_new_signature…` renamed). Investigate any
+unexpected failure before proceeding — do not edit assertions to force
+green.
+
+- [ ] **Step 2: Manual smoke (user-run — a Rich TUI cannot be asserted headless)**
+
+Ask the user to run, in a real terminal against a project with a
+populated `.ollama_reviews/memory.db`:
+`ollama-sentinel dashboard <config.yaml>`
+and confirm: one-line vitals strip on top; bold severity banner with
+the CRITICAL count prominent + 🔥 hottest line; Patterns list dominant
+and single-line; Reviews a thin right rail; `Tab`/`j`/`k`/`Enter`/`/`
+behave exactly as before; `Enter` on a Pattern shows full description in
+detail. This is a checklist item, not an automated gate.
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(dashboard): triage-console visual overhaul" \
+  --body "Rebuilds the \`ollama-sentinel dashboard\` v2 Rich TUI as a triage console: one-line vitals strip, bold severity banner (CRITICAL prominent + 🔥 hottest/next-action), a dominant Patterns list ranked by blended severity×recurrence (CRIT8/HIGH4/MED2/LOW1, count then file tiebreak), and a thin Recent-Reviews rail. Kills the wasted whitespace and the wrapping wall-of-text — rows are single-line, full text on Enter→detail.
+
+Zero data-layer changes, zero \`dashboard_input.py\` changes (same q·Tab·j/k·Enter·/ model; Tab still cycles OVERVIEW→REVIEWS→PATTERNS, OVERVIEW focus now highlights the banner). Legacy two-panel path (\`config_path == \"\"\`) untouched and regression-locked. Superseded v2 helpers (\`_header_panel_v2\`, \`_overview_panel\`, \`_reviews_panel_interactive\`) removed; their tests migrated to the new surface — a transparent, expected consequence of a visual overhaul.
+
+Spec: \`docs/superpowers/specs/2026-05-17-dashboard-triage-revamp-design.md\`
+Plan: \`docs/superpowers/plans/2026-05-17-dashboard-triage-revamp.md\`"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** vitals strip → T3; severity banner → T4; blended
+  rank 8/4/2/1 + tiebreaks → T1; one-line Patterns + Enter-detail → T6;
+  bold palette → T2; thin reviews rail → T5; new region tree both v2
+  entry points → T7 (pure) + T8 (closure); legacy regression-lock → T7
+  S4 (and untouched by construction); superseded-helper cleanup → T9;
+  manual TUI verification → T10 S2. Every spec section maps to a task. ✓
+- **Ordering correctness:** `_reviews_panel` (legacy dependency) is never
+  deleted. The three v2-only helpers are deleted only in T9, after both
+  callers (T7, T8) are rewired — every task ends with the whole suite
+  green, no dangling deleted-symbol references. The earlier draft's
+  interleaved deletions (which would have broken the legacy lock at T5)
+  are removed. ✓
+- **Placeholder scan:** every code/test step has literal content; the
+  sole manual step (T10 S2) is explicitly marked non-automatable, not a
+  vague code instruction. ✓
+- **Name/type consistency:** `blended_rank`, `_SEVERITY_WEIGHT`,
+  `_vitals_strip`, `_severity_banner(stats)`, `_reviews_rail(rows, now,
+  selection, scroll)`, `_patterns_panel_interactive(rows, selection,
+  scroll, title_suffix)`, region names `header/banner/body{left,right}/
+  footer`, ratio `3:1`, and reused `_detail_panel(state, reviews,
+  violations, now)` are spelled identically across T1-T9 and tests. ✓

--- a/docs/superpowers/specs/2026-05-17-dashboard-triage-revamp-design.md
+++ b/docs/superpowers/specs/2026-05-17-dashboard-triage-revamp-design.md
@@ -1,0 +1,154 @@
+# Dashboard triage-console visual overhaul — design
+
+**Status:** approved, ready for implementation plan
+**Scope:** in-place visual overhaul of the Rich TUI v2 (Control Center)
+render path. **No data-layer changes, no input-model changes.**
+**Branch:** `feat/dashboard-triage-revamp` (off `master`, independent of
+the open grounding PR #12).
+
+---
+
+## The problem in one paragraph
+
+`ollama-sentinel dashboard` renders a Rich TUI that wastes most of the
+screen: the Overview box is a cramped 8-line panel with a large void
+beneath it, Recent Reviews is mostly low-signal `7d ago … .md` rows, and
+the Patterns panel is a wrapping wall of text where the one number that
+matters for action (74 CRITICAL findings) does not visually stand out.
+The underlying data is rich — 1230 open findings, per-severity counts,
+hottest file, recurrence — so this is purely a presentation failure. The
+revamp turns the dashboard into a **triage console**: glance at it and
+immediately know what to fix next.
+
+## Locked decisions (from brainstorming)
+
+1. **Surface & ambition:** in-place visual overhaul of the existing Rich
+   TUI. Same data sources, same keyboard model (`q · Tab · j/k · Enter ·
+   /`). Legacy two-panel render path (`config_path == ""`) untouched.
+2. **Primary job:** triage console — severity-led; "what do I fix next"
+   dominates. Liveness/status compressed to a thin strip.
+3. **Layout skeleton:** vitals strip → bold severity banner + hottest
+   callout → body = dominant Patterns triage list (left, wide) + narrow
+   Recent-Reviews rail (right) → footer keys.
+4. **Patterns ranking:** blended score `severity_weight × count`,
+   weights **CRIT=8 HIGH=4 MED=2 LOW=1**, descending. One ranked list
+   (not severity bands). Ties: count desc, then file path asc.
+5. **Wall-of-text fix:** one line per Patterns row, ellipsis-truncated;
+   full text via the existing Enter → DETAIL mode (unchanged).
+6. **Palette:** bold/saturated severity-driven colors (CRITICAL bright
+   red, HIGH orange/yellow, MED cyan, LOW dim), centralized so banner,
+   rows, and detail agree.
+7. **Recent Reviews:** demoted to a thin right rail, not dropped.
+
+## Out of scope
+
+- Any change to `_fetch_data`, `ViolationDB`, or new SQL queries.
+- Any change to `dashboard_input.py` (keys, `UIState`, `Mode`,
+  `PanelId`, `apply_key`, `key_reader_loop`).
+- The legacy two-panel layout (`render_layout` when `config_path == ""`)
+  — must remain byte-for-byte behaviorally identical (regression-locked).
+- Detail-mode content/structure beyond palette consistency.
+- A web surface, new dependencies, or restructuring the 863-line
+  `dashboard.py` into modules (targeted helper extraction only).
+- Config hot-reload / OP-1 (unrelated, tracked in followups.md).
+
+---
+
+## Architecture & components
+
+All changes live in the **v2 render path of `ollama_sentinel/dashboard.py`**
+(`render_layout` / `_build_layout` when `config_path` is set). The
+`run_dashboard` loop, data fetching, error isolation, and DB-connection
+reuse are unchanged.
+
+| Function | Status | Role |
+|---|---|---|
+| `_SEVERITY_WEIGHT` | **new** module const | `{"critical":8,"high":4,"medium":2,"low":1}` (case-insensitive lookup, unknown → 0). |
+| `_SEVERITY_STYLE` | **revised** module const | Bold/saturated Rich styles per severity; single source for banner + rows + detail. |
+| `blended_rank(rows)` | **new** pure fn | `List[ViolationRow] -> List[ViolationRow]` sorted by `weight(sev)×count` desc, tie → count desc → `file_path` asc. Stable; tolerates unknown severity (weight 0, sorts last). |
+| `_vitals_strip(stats, now)` | **new** (replaces `_header_panel_v2` in v2 tree) | One line: status dot (color by staleness) · model · `rev HH:MM:SS` · age. |
+| `_severity_banner(stats)` | **new** | Line 1: `CRIT 74  HIGH 104  MED 576  LOW 476`, each cell styled by `_SEVERITY_STYLE`, CRITICAL most prominent. Line 2: `🔥 {hottest_file} ({n}) ▸ {suggested_action}`. Empty/no-DB → muted "no findings yet". |
+| `_patterns_panel_interactive` | **revised** | Consumes pre-ranked rows; renders **one line per row**: `{count}x · {SEV} · {cat} · {file}:{line} — {desc}` with `overflow="ellipsis"`, `no_wrap=True`. Selection/scroll behavior unchanged (operates on the passed list). |
+| `_reviews_rail(rows, now)` | **new** (replaces `_reviews_panel_interactive` call in v2 tree) | Compact narrow rail: `{ago}  {elided rel_path}`, basename-biased elision. Selection highlight preserved (REVIEWS panel still focusable). |
+| `render_layout` / `_build_layout` v2 branch | **revised** | New region tree (below). Legacy branch unchanged. |
+
+`compute_overview`/`OverviewStats` is reused as-is (already exposes
+severity counts, hottest, model, status age, last-review age). If a
+needed value is already on `stats`, no recomputation is added.
+
+## Layout (region tree, v2 path only)
+
+```
+Layout (split_column):
+  header  size 3   → _vitals_strip(stats, now)
+  banner  size 4   → _severity_banner(stats)
+  body    ratio 1  → split_row:
+                       left  ratio 3 → _patterns_panel_interactive(ranked, sel, scroll, filt)
+                       right ratio 1 → _reviews_rail(reviews, now, sel, scroll)
+  footer  size 3   → _footer_interactive(state)        # non-interactive → _footer_panel_v2
+```
+
+(Footer stays `size 3`: `_footer_interactive` returns a bordered Rich
+`Panel`, which needs 3 rows — top border, single content line, bottom
+border. "Thin" is achieved by single-line content + `padding=(0,1)`, as
+the existing footer already does, not by shrinking the region.)
+
+- DETAIL mode still replaces `body` full-width (unchanged code path),
+  using `_SEVERITY_STYLE` for consistency.
+- Focus styling: `Tab` still cycles `OVERVIEW → REVIEWS → PATTERNS`
+  (`_PANEL_CYCLE` unchanged). `OVERVIEW` focus highlights the **banner**
+  region border (selection is a no-op there, exactly as the Overview
+  panel is today). `REVIEWS` → rail border; `PATTERNS` → patterns border.
+
+## Data flow
+
+`_fetch_data` is unchanged. In `_build_layout` v2 branch, the existing
+filter is applied to `violations` first (unchanged), then
+`blended_rank()` reorders the filtered list, then the ranked list is
+passed to `_patterns_panel_interactive`. Because selection/scroll indices
+already index into the passed list and `_reclamp_selection` runs after
+each data refresh, reordering stays consistent with no input-model
+change. Filter (`/`) still substring-matches severity/category over the
+(now ranked) list.
+
+## Error handling
+
+No change. Per-panel try/except degrade, single `ViolationDB` connection
+reuse with reset-on-failure, and `asyncio.to_thread` offloading already
+in `run_dashboard` are untouched. New pure helpers must not raise on
+empty/missing inputs (return empty/placeholder panels) so the existing
+degrade contract holds.
+
+## Testing approach
+
+TDD, matches the project's "tests before merge" convention. The Rich
+panel/table introspection mechanism already used in
+`tests/test_dashboard.py` (450 lines) is the confirmed mechanism reused
+here.
+
+- **Pure unit tests (new):**
+  - `blended_rank`: severity dominates within reachable counts; count
+    tiebreak; file-path tiebreak; unknown/missing severity → weight 0
+    sorts last; empty input → `[]`; stability.
+  - `_SEVERITY_WEIGHT` ordering invariant: `CRIT > HIGH > MED > LOW` and
+    `1×CRIT > 7×LOW` (geometric-gap regression lock).
+  - `_severity_banner`: contains each count and the hottest/action line;
+    no-DB/empty → muted placeholder, no crash.
+  - `_vitals_strip`: status dot reflects staleness; renders with empty
+    model/age without raising.
+- **Structural tests (new):** v2 `render_layout` yields regions
+  `header / banner / body{left,right} / footer`; left:right ratio 3:1;
+  Patterns rows are single-line (no wrap) given a long description.
+- **Regression lock:** legacy path (`config_path == ""`) layout
+  unchanged — assert existing two-panel structure still holds.
+- **Existing tests:** assertions tied to the old v2 titles/structure
+  (`_header_panel_v2`, `_overview_panel`, old Patterns wrapping) are
+  updated to the new structure. This is a transparent, expected
+  consequence of a visual overhaul and will be called out in the plan
+  and PR. Legacy-path tests stay green untouched.
+
+## Open judgment calls (resolved)
+
+- Blended weights `8/4/2/1` (geometric so one CRIT outranks 7×LOW) —
+  **accepted** by user.
+- Keep Recent Reviews as a thin rail rather than cut — **accepted**.

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -718,7 +718,7 @@ async def run_dashboard(
                 str(watch_dir), reviews_dir, db_path, reviews, violations, now,
             )
 
-        # Interactive Control Center layout
+        # Interactive Control Center triage layout
         stats = compute_overview(
             reviews=reviews,
             severity_counts=data["severity_counts"],
@@ -731,55 +731,50 @@ async def run_dashboard(
             now=now,
             research_latest=data["research_latest"],
         )
+        ranked = blended_rank(violations)
 
         layout = Layout()
         layout.split_column(
-            Layout(name="header", size=5),
+            Layout(name="header", size=3),
+            Layout(name="banner", size=4),
             Layout(name="body", ratio=1),
             Layout(name="footer", size=3),
         )
-        layout["header"].update(_header_panel_v2(stats, now))
+        layout["header"].update(_vitals_strip(stats, now))
 
-        # Detail mode: replace body with full-width detail panel
+        # Detail mode: keep banner, replace body full-width
         if state.mode == Mode.DETAIL:
-            detail_panel = _detail_panel(state, reviews, violations, now)
-            layout["body"].update(detail_panel)
+            layout["banner"].update(_severity_banner(stats))
+            layout["body"].update(_detail_panel(state, reviews, ranked, now))
             layout["footer"].update(_footer_interactive(state))
             return layout
 
-        # Panel focus styling
-        overview_border = "bold cyan" if state.focused_panel == PanelId.OVERVIEW else "green"
+        # OVERVIEW focus highlights the banner region border.
+        banner_p = _severity_banner(stats)
+        if state.focused_panel == PanelId.OVERVIEW:
+            banner_p.border_style = "bold cyan"
+        layout["banner"].update(banner_p)
+
         reviews_border = "bold cyan" if state.focused_panel == PanelId.REVIEWS else "blue"
         patterns_border = "bold cyan" if state.focused_panel == PanelId.PATTERNS else "magenta"
 
-        # Build panels with selection awareness
-        overview_p = _overview_panel(stats)
-        overview_p.border_style = overview_border
-
-        # Reviews panel with selection
-        sel_idx = state.selection.get(PanelId.REVIEWS, 0) if state.focused_panel == PanelId.REVIEWS else -1
-        scroll = state.scroll_offset.get(PanelId.REVIEWS, 0)
-        reviews_p = _reviews_panel_interactive(reviews, now, sel_idx, scroll)
-        reviews_p.border_style = reviews_border
-
-        # Patterns panel with selection and filter
         sel_idx_p = state.selection.get(PanelId.PATTERNS, 0) if state.focused_panel == PanelId.PATTERNS else -1
         scroll_p = state.scroll_offset.get(PanelId.PATTERNS, 0)
         title_suffix = f" [filter: {state.filter_text}]" if state.filter_active else ""
-        patterns_p = _patterns_panel_interactive(violations, sel_idx_p, scroll_p, title_suffix)
+        patterns_p = _patterns_panel_interactive(ranked, sel_idx_p, scroll_p, title_suffix)
         patterns_p.border_style = patterns_border
 
+        sel_idx_r = state.selection.get(PanelId.REVIEWS, 0) if state.focused_panel == PanelId.REVIEWS else -1
+        scroll_r = state.scroll_offset.get(PanelId.REVIEWS, 0)
+        reviews_p = _reviews_rail(reviews, now, sel_idx_r, scroll_r)
+        reviews_p.border_style = reviews_border
+
         layout["body"].split_row(
-            Layout(name="left", ratio=2),
-            Layout(name="right", ratio=3),
+            Layout(name="left", ratio=3),
+            Layout(name="right", ratio=1),
         )
-        layout["body"]["left"].split_column(
-            Layout(name="overview", size=8),
-            Layout(name="reviews", ratio=1),
-        )
-        layout["body"]["left"]["overview"].update(overview_p)
-        layout["body"]["left"]["reviews"].update(reviews_p)
-        layout["body"]["right"].update(patterns_p)
+        layout["body"]["left"].update(patterns_p)
+        layout["body"]["right"].update(reviews_p)
 
         if interactive:
             layout["footer"].update(_footer_interactive(state))

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -449,7 +449,7 @@ def _patterns_panel(rows: List[ViolationRow]) -> Panel:
     table.add_column(justify="right", style="bold", no_wrap=True)
     table.add_column(no_wrap=True)
     table.add_column(no_wrap=True)
-    table.add_column(overflow="ellipsis")
+    table.add_column(no_wrap=True, overflow="ellipsis")
     for r in rows:
         sev_style = _SEVERITY_STYLE.get(r.severity.lower(), "white")
         table.add_row(
@@ -914,7 +914,7 @@ def _patterns_panel_interactive(
     table.add_column(justify="right", style="bold", no_wrap=True)
     table.add_column(no_wrap=True)
     table.add_column(no_wrap=True)
-    table.add_column(overflow="ellipsis")
+    table.add_column(no_wrap=True, overflow="ellipsis")
     for i, r in enumerate(visible):
         abs_idx = scroll + i
         if abs_idx == selection:

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -292,6 +292,30 @@ def _header_panel_v2(stats: OverviewStats, now: float) -> Panel:
     return Panel(Text.from_markup(body), border_style="bold cyan", padding=(0, 1))
 
 
+def _vitals_strip(stats: OverviewStats, now: float) -> Panel:
+    """One-line vitals: status dot, model, open count, update clock.
+
+    Triage replacement for the old three-line v2 header. Status dot
+    color tracks watcher staleness. Never raises on empty stats.
+    """
+    ts = _dt.datetime.fromtimestamp(now).strftime("%H:%M:%S")
+    status_label, status_key = watcher_status_from_age(stats.newest_review_age_s)
+    status_style = _STATUS_STYLE.get(status_key, "dim")
+    model = stats.model_name or "unknown"
+    if stats.db_exists:
+        db_info = f"[white]{stats.total_unresolved}[/] open"
+    else:
+        db_info = "[dim]no DB[/]"
+    body = (
+        f"[{status_style}]●[/] [{status_style}]{status_label}[/]"
+        f"  [dim]│[/]  [white]{model}[/]"
+        f"  [dim]│[/]  {db_info}"
+        f"  [dim]│[/]  [dim]rev[/] [white]{ts}[/]"
+    )
+    return Panel(Text.from_markup(body), border_style="bold cyan",
+                 padding=(0, 1))
+
+
 def watcher_status_from_age(age_s: Optional[float]) -> tuple:
     """Derive watcher status from the newest review's age in seconds."""
     if age_s is None:

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -529,7 +529,7 @@ def render_layout(
         layout["footer"].update(_footer_panel())
         return layout
 
-    # Control Center layout
+    # Control Center triage layout
     stats = compute_overview(
         reviews=reviews,
         severity_counts=severity_counts or {},
@@ -542,25 +542,23 @@ def render_layout(
         now=now,
         research_latest=research_latest,
     )
+    ranked = blended_rank(violations)
 
     layout = Layout()
     layout.split_column(
-        Layout(name="header", size=5),
+        Layout(name="header", size=3),
+        Layout(name="banner", size=4),
         Layout(name="body", ratio=1),
         Layout(name="footer", size=3),
     )
-    layout["header"].update(_header_panel_v2(stats, now))
+    layout["header"].update(_vitals_strip(stats, now))
+    layout["banner"].update(_severity_banner(stats))
     layout["body"].split_row(
-        Layout(name="left", ratio=2),
-        Layout(name="right", ratio=3),
+        Layout(name="left", ratio=3),
+        Layout(name="right", ratio=1),
     )
-    layout["body"]["left"].split_column(
-        Layout(name="overview", size=8),
-        Layout(name="reviews", ratio=1),
-    )
-    layout["body"]["left"]["overview"].update(_overview_panel(stats))
-    layout["body"]["left"]["reviews"].update(_reviews_panel(reviews, now))
-    layout["body"]["right"].update(_patterns_panel(violations))
+    layout["body"]["left"].update(_patterns_panel(ranked))
+    layout["body"]["right"].update(_reviews_rail(reviews, now, -1, 0))
     layout["footer"].update(_footer_panel_v2())
     return layout
 

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -349,6 +349,35 @@ def _severity_banner(stats: OverviewStats) -> Panel:
                  border_style=border, padding=(0, 1))
 
 
+def _reviews_rail(
+    rows: List[ReviewRow], now: float, selection: int, scroll: int,
+) -> Panel:
+    """Narrow Recent-Reviews rail: '{ago}  {basename}', one line each.
+
+    Selection highlight preserved (REVIEWS panel stays focusable). Path
+    is basename-biased so the rail stays readable when narrow.
+    """
+    if not rows:
+        return Panel(Text("no reviews yet", style="dim"),
+                     title="Recent", border_style="blue")
+    visible = rows[scroll:scroll + 15]
+    table = Table.grid(padding=(0, 1), expand=True)
+    table.add_column(justify="right", no_wrap=True)
+    table.add_column(no_wrap=True, overflow="ellipsis")
+    for i, r in enumerate(visible):
+        sel = (scroll + i) == selection
+        name = r.rel_path.rsplit("/", 1)[-1]
+        table.add_row(
+            Text(_format_ago(r.mtime, now), style="reverse" if sel else "dim"),
+            Text(name, style="reverse" if sel else ""),
+        )
+    count = len(rows)
+    title = f"Recent ({count})"
+    if scroll > 0 or scroll + 15 < count:
+        title += f" [{scroll + 1}-{min(scroll + 15, count)}]"
+    return Panel(table, title=title, border_style="blue")
+
+
 def watcher_status_from_age(age_s: Optional[float]) -> tuple:
     """Derive watcher status from the newest review's age in seconds."""
     if age_s is None:

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -304,11 +304,12 @@ def _severity_banner(stats: OverviewStats) -> Panel:
         return Panel(Text.from_markup(msg), border_style="green",
                      padding=(0, 1))
 
+    _ABBR = {"critical": "CRIT", "high": "HIGH", "medium": "MED", "low": "LOW"}
     cells = []
     for sev in ("critical", "high", "medium", "low"):
         count = stats.severity_counts.get(sev, 0)
         style = _SEVERITY_STYLE[sev]
-        cells.append(f"[{style}]{sev[:4].upper()} {count}[/]")
+        cells.append(f"[{style}]{_ABBR[sev]} {count}[/]")
     line1 = "   ".join(cells)
 
     if stats.hottest_file:

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -46,6 +46,27 @@ _STATUS_STYLE = {
     "no_data": "dim",
 }
 
+_SEVERITY_WEIGHT = {
+    "critical": 8,
+    "high": 4,
+    "medium": 2,
+    "low": 1,
+}
+
+
+def blended_rank(rows: "List[ViolationRow]") -> "List[ViolationRow]":
+    """Order recurring findings by triage urgency.
+
+    Sort key: ``severity_weight * count`` descending; unknown severities
+    weigh 0 (sort last). Ties: count desc, then file_path asc. Pure and
+    stable; never raises on bad input.
+    """
+    def key(r: "ViolationRow"):
+        weight = _SEVERITY_WEIGHT.get(r.severity.lower(), 0)
+        return (-(weight * r.count), -r.count, r.file_path)
+
+    return sorted(rows, key=key)
+
 
 # ---------------------------------------------------------------------------
 # Pure data helpers (unit-tested)

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -34,8 +34,8 @@ log = logging.getLogger(__name__)
 
 _SEVERITY_STYLE = {
     "critical": "bold red",
-    "high": "red",
-    "medium": "yellow",
+    "high": "bold yellow",
+    "medium": "cyan",
     "low": "dim",
 }
 

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -266,32 +266,6 @@ def _violations_panel(rows: List[ViolationRow]) -> Panel:
 # Control Center v2 panels
 # ---------------------------------------------------------------------------
 
-def _header_panel_v2(stats: OverviewStats, now: float) -> Panel:
-    """Rich header with title, config/model line, and status badges."""
-    ts = _dt.datetime.fromtimestamp(now).strftime("%H:%M:%S")
-    status_label, status_key = watcher_status_from_age(stats.newest_review_age_s)
-    status_style = _STATUS_STYLE.get(status_key, "dim")
-
-    line1 = "[bold white]OLLAMA SENTINEL[/] [dim]·[/] [bold cyan]CONTROL CENTER[/]"
-    line2 = (
-        f"[dim]Watching:[/] [white]{stats.watch_dir}[/]"
-        f"   [dim]Model:[/] [white]{stats.model_name or 'unknown'}[/]"
-    )
-    db_info = ""
-    if stats.db_exists:
-        db_info = f"[green]●[/] {stats.total_unresolved} open"
-    else:
-        db_info = "[dim]● no DB yet[/]"
-    line3 = (
-        f"[dim]Status:[/] [{status_style}]● {status_label}[/]"
-        f"   [dim]DB:[/] {db_info}"
-        f"   [dim]Updated:[/] [white]{ts}[/]"
-    )
-
-    body = f"{line1}\n{line2}\n{line3}"
-    return Panel(Text.from_markup(body), border_style="bold cyan", padding=(0, 1))
-
-
 def _vitals_strip(stats: OverviewStats, now: float) -> Panel:
     """One-line vitals: status dot, model, open count, update clock.
 
@@ -387,55 +361,6 @@ def watcher_status_from_age(age_s: Optional[float]) -> tuple:
     if age_s < 300:
         return ("Idle", "idle")
     return ("Stale", "stale")
-
-
-def _overview_panel(stats: OverviewStats) -> Panel:
-    """Overview card with severity breakdown, hottest file, and next action."""
-    table = Table.grid(padding=(0, 2), expand=True)
-    table.add_column(no_wrap=True)
-    table.add_column(no_wrap=True)
-
-    # Row 1: counts
-    new_badge = f"  [green]+{stats.new_this_week}/7d[/]" if stats.new_this_week else ""
-    table.add_row(
-        f"[dim]Open:[/] [bold white]{stats.total_unresolved}[/]{new_badge}",
-        f"[dim]Reviews:[/] [bold white]{stats.total_reviews}[/]",
-    )
-
-    # Row 2: severity breakdown
-    sev_parts = []
-    for sev in ("critical", "high", "medium", "low"):
-        count = stats.severity_counts.get(sev, 0)
-        if count > 0:
-            style = _SEVERITY_STYLE[sev]
-            label = sev[:4].upper()
-            sev_parts.append(f"[{style}]{label} {count}[/]")
-    sev_line = "  ".join(sev_parts) if sev_parts else "[dim]—[/]"
-    table.add_row(sev_line, "")
-
-    # Row 3: hottest file
-    if stats.hottest_file:
-        table.add_row(
-            f"[dim]Hottest:[/] [white]{stats.hottest_file}[/] ({stats.hottest_count})",
-            "",
-        )
-    else:
-        table.add_row("[dim]Hottest:[/] [dim]—[/]", "")
-
-    # Row 4: suggested action
-    action = suggested_action(stats)
-    table.add_row(f"[dim]Action:[/] [italic]{action}[/]", "")
-
-    # Row 5: latest research (conditional, null-safe)
-    if stats.research_latest:
-        r = stats.research_latest
-        q = (r.get("query") or "")[:35]
-        conf = r.get("confidence") or 0
-        ts = r.get("timestamp")
-        ago = _format_ago(ts, time.time()) if ts else ""
-        table.add_row(f"[dim]Research:[/] [white]{q}[/] ({conf:.0%}) [dim]{ago}[/]", "")
-
-    return Panel(table, title="Overview", border_style="green", padding=(0, 1))
 
 
 def _patterns_panel(rows: List[ViolationRow]) -> Panel:
@@ -868,31 +793,6 @@ async def run_dashboard(
 # ---------------------------------------------------------------------------
 # Interactive panel variants
 # ---------------------------------------------------------------------------
-
-def _reviews_panel_interactive(
-    rows: List[ReviewRow], now: float, selection: int, scroll: int,
-) -> Panel:
-    """Reviews panel with selection highlighting."""
-    if not rows:
-        return Panel(Text("no reviews yet — save a watched file", style="dim"),
-                     title="Recent Reviews", border_style="blue")
-    visible = rows[scroll:scroll + 15]
-    table = Table.grid(padding=(0, 1), expand=True)
-    table.add_column(justify="right", style="dim", no_wrap=True)
-    table.add_column(no_wrap=True, overflow="ellipsis")
-    for i, r in enumerate(visible):
-        abs_idx = scroll + i
-        style = "reverse" if abs_idx == selection else ""
-        table.add_row(
-            Text(_format_ago(r.mtime, now), style=style or "dim"),
-            Text(r.rel_path, style=style),
-        )
-    count = len(rows)
-    title = f"Recent Reviews ({count})"
-    if scroll > 0 or scroll + 15 < count:
-        title += f" [{scroll + 1}-{min(scroll + 15, count)}]"
-    return Panel(table, title=title, border_style="blue")
-
 
 def _patterns_panel_interactive(
     rows: List[ViolationRow], selection: int, scroll: int, title_suffix: str = "",

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -364,6 +364,30 @@ def watcher_status_from_age(age_s: Optional[float]) -> tuple:
     return ("Stale", "stale")
 
 
+def _format_pattern_row(r: ViolationRow, *, selected: bool = False) -> Text:
+    """Build a single Patterns row as a fixed-width Text, ellipsised by Rich.
+
+    Bypasses Rich's column auto-sizer (which silently drops min_width columns
+    when total constraints don't fit) by manually padding count/severity/
+    category to fixed widths inside one Text. The description is appended and
+    Rich's no_wrap=True/overflow="ellipsis" trims it cleanly. The visible
+    layout is predictable at every terminal width.
+    """
+    sev_style = "reverse" if selected else _SEVERITY_STYLE.get(r.severity.lower(), "white")
+    base_style = "reverse" if selected else ""
+    bold_style = "reverse" if selected else "bold"
+    t = Text(no_wrap=True, overflow="ellipsis")
+    t.append(f"{r.count}x".rjust(5), style=bold_style)          # 5 chars (fits "9999x")
+    t.append(" ")
+    t.append(f"{r.severity:<8}", style=sev_style)               # 8 chars (fits "critical")
+    t.append(" ")
+    t.append(f"{r.category:<11}", style=base_style)             # 11 chars (fits "performance")
+    t.append(" ")
+    t.append(f"{r.file_path}:{r.line_start} — {r.description}",
+             style=base_style)
+    return t
+
+
 def _patterns_panel(rows: List[ViolationRow]) -> Panel:
     """Patterns panel — renamed from 'Top Recurring' for clearer mental model."""
     if not rows:
@@ -371,19 +395,10 @@ def _patterns_panel(rows: List[ViolationRow]) -> Panel:
             Text("no patterns detected yet — run some reviews first", style="dim"),
             title="Patterns", border_style="magenta",
         )
-    table = Table.grid(padding=(0, 1), expand=True)
-    table.add_column(justify="right", style="bold", no_wrap=True)
-    table.add_column(no_wrap=True)
-    table.add_column(no_wrap=True)
+    table = Table.grid(padding=(0, 0), expand=True)
     table.add_column(no_wrap=True, overflow="ellipsis")
     for r in rows:
-        sev_style = _SEVERITY_STYLE.get(r.severity.lower(), "white")
-        table.add_row(
-            f"{r.count}x",
-            Text(r.severity, style=sev_style),
-            r.category,
-            f"{r.file_path}:{r.line_start} — {r.description}",
-        )
+        table.add_row(_format_pattern_row(r))
     return Panel(table, title=f"Patterns ({len(rows)})", border_style="magenta")
 
 
@@ -804,28 +819,11 @@ def _patterns_panel_interactive(
         return Panel(Text(msg, style="dim"),
                      title=f"Patterns{title_suffix}", border_style="magenta")
     visible = rows[scroll:scroll + 15]
-    table = Table.grid(padding=(0, 1), expand=True)
-    table.add_column(justify="right", style="bold", no_wrap=True)
-    table.add_column(no_wrap=True)
-    table.add_column(no_wrap=True)
+    table = Table.grid(padding=(0, 0), expand=True)
     table.add_column(no_wrap=True, overflow="ellipsis")
     for i, r in enumerate(visible):
         abs_idx = scroll + i
-        if abs_idx == selection:
-            table.add_row(
-                Text(f"{r.count}x", style="reverse"),
-                Text(r.severity, style="reverse"),
-                Text(r.category, style="reverse"),
-                Text(f"{r.file_path}:{r.line_start} — {r.description}", style="reverse"),
-            )
-        else:
-            sev_style = _SEVERITY_STYLE.get(r.severity.lower(), "white")
-            table.add_row(
-                f"{r.count}x",
-                Text(r.severity, style=sev_style),
-                r.category,
-                f"{r.file_path}:{r.line_start} — {r.description}",
-            )
+        table.add_row(_format_pattern_row(r, selected=(abs_idx == selection)))
     count = len(rows)
     title = f"Patterns ({count}){title_suffix}"
     return Panel(table, title=title, border_style="magenta")

--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -316,6 +316,39 @@ def _vitals_strip(stats: OverviewStats, now: float) -> Panel:
                  padding=(0, 1))
 
 
+def _severity_banner(stats: OverviewStats) -> Panel:
+    """Bold severity scoreboard + hottest-file / next-action callout.
+
+    Line 1: per-severity counts (descending severity), each styled by
+    _SEVERITY_STYLE. Line 2: hottest file + suggested action. Empty /
+    no-DB state shows a muted placeholder; never raises.
+    """
+    if not stats.db_exists or stats.total_unresolved == 0:
+        msg = ("[dim]no findings yet — save a watched file[/]"
+               if stats.total_reviews == 0
+               else "[bold green]All clear — no open findings[/]")
+        return Panel(Text.from_markup(msg), border_style="green",
+                     padding=(0, 1))
+
+    cells = []
+    for sev in ("critical", "high", "medium", "low"):
+        count = stats.severity_counts.get(sev, 0)
+        style = _SEVERITY_STYLE[sev]
+        cells.append(f"[{style}]{sev[:4].upper()} {count}[/]")
+    line1 = "   ".join(cells)
+
+    if stats.hottest_file:
+        hot = (f"[red]🔥[/] [white]{stats.hottest_file}[/]"
+               f" [dim]({stats.hottest_count})[/]")
+    else:
+        hot = "[dim]🔥 —[/]"
+    line2 = f"{hot}   [dim]▸[/] [italic]{suggested_action(stats)}[/]"
+
+    border = "red" if stats.severity_counts.get("critical", 0) else "yellow"
+    return Panel(Text.from_markup(f"{line1}\n{line2}"),
+                 border_style=border, padding=(0, 1))
+
+
 def watcher_status_from_age(age_s: Optional[float]) -> tuple:
     """Derive watcher status from the newest review's age in seconds."""
     if age_s is None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -587,3 +587,28 @@ class TestBlendedRank:
     def test_empty_returns_empty(self):
         from ollama_sentinel.dashboard import blended_rank
         assert blended_rank([]) == []
+
+
+class TestPatternsSingleLine:
+    LONG = ("Fragile auto-collapse on timeout: the timeout collapses "
+            "detailExpanded unconditionally and will incorrectly collapse "
+            "a different era's detail opened during the override window.")
+
+    def _row(self):
+        return ViolationRow(count=11, severity="high", category="bug",
+                            file_path="ErasZoneView.swift", line_start=183,
+                            line_end=190, description=self.LONG)
+
+    def test_interactive_row_stays_one_line(self):
+        from ollama_sentinel.dashboard import _patterns_panel_interactive
+        panel = _patterns_panel_interactive([self._row()], selection=-1, scroll=0)
+        out = _render(panel, width=80)
+        body = [l for l in out.splitlines() if "ErasZoneView.swift" in l]
+        assert len(body) == 1                 # description did NOT wrap
+        assert "…" in out                     # it was ellipsised
+
+    def test_static_patterns_row_stays_one_line(self):
+        panel = _patterns_panel([self._row()])
+        body = [l for l in _render(panel, width=80).splitlines()
+                if "ErasZoneView.swift" in l]
+        assert len(body) == 1

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -18,9 +18,7 @@ from ollama_sentinel.dashboard import (
     top_violations,
     watcher_status,
     watcher_status_from_age,
-    _overview_panel,
     _patterns_panel,
-    _header_panel_v2,
     _footer_panel_v2,
 )
 from ollama_sentinel.violation_db import Finding, ViolationDB
@@ -343,16 +341,6 @@ class TestSuggestedAction:
 
 
 class TestControlCenterPanels:
-    def test_overview_panel_renders(self):
-        stats = OverviewStats(
-            total_reviews=10, newest_review_age_s=30.0, total_unresolved=5,
-            severity_counts={"high": 3, "medium": 2},
-            hottest_file="src/app.py", hottest_count=3,
-            new_this_week=2,
-        )
-        panel = _overview_panel(stats)
-        assert panel.title == "Overview"
-
     def test_patterns_panel_empty(self):
         panel = _patterns_panel([])
         assert panel.title == "Patterns"
@@ -365,15 +353,6 @@ class TestControlCenterPanels:
         ]
         panel = _patterns_panel(rows)
         assert "Patterns (1)" in panel.title
-
-    def test_header_v2_renders(self):
-        stats = OverviewStats(
-            total_reviews=5, newest_review_age_s=30.0, total_unresolved=8,
-            config_path="test.yaml", model_name="gemma3",
-            watch_dir="/code", db_exists=True,
-        )
-        panel = _header_panel_v2(stats, time.time())
-        assert panel.border_style == "bold cyan"
 
     def test_footer_v2_renders(self):
         panel = _footer_panel_v2()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -632,6 +632,19 @@ class TestPatternsSingleLine:
         assert len(body) == 1
         assert "…" in out
 
+    def test_count_and_category_columns_survive_long_description(self):
+        """Production-width regression: with a long description, the count and
+        category columns must NOT be starved to zero width by Rich's auto-sizer,
+        and severity must render its full word (not truncated to 'hi…')."""
+        from ollama_sentinel.dashboard import _patterns_panel_interactive
+        panel = _patterns_panel_interactive([self._row()], selection=-1, scroll=0)
+        out = _render(panel, width=215)        # the user's live terminal width
+        row_line = next(l for l in out.splitlines() if "ErasZoneView.swift" in l)
+        assert "11x" in row_line               # count column visible
+        assert "high" in row_line              # severity full word, not "hi…"
+        assert "hi…" not in row_line           # not truncated
+        assert "bug" in row_line               # category column visible
+
 
 class TestBuildLayoutWiring:
     def _src(self):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -608,7 +608,9 @@ class TestPatternsSingleLine:
         assert "…" in out                     # it was ellipsised
 
     def test_static_patterns_row_stays_one_line(self):
+        from ollama_sentinel.dashboard import _patterns_panel
         panel = _patterns_panel([self._row()])
-        body = [l for l in _render(panel, width=80).splitlines()
-                if "ErasZoneView.swift" in l]
+        out = _render(panel, width=80)
+        body = [l for l in out.splitlines() if "ErasZoneView.swift" in l]
         assert len(body) == 1
+        assert "…" in out

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -420,6 +420,23 @@ class TestControlCenterPanels:
                               total_unresolved=0, db_exists=False)
         assert "no findings" in _render(_severity_banner(stats)).lower()
 
+    def test_severity_banner_all_clear_when_no_unresolved(self):
+        from ollama_sentinel.dashboard import _severity_banner
+        stats = OverviewStats(total_reviews=10, newest_review_age_s=30.0,
+                              total_unresolved=0, db_exists=True)
+        assert "all clear" in _render(_severity_banner(stats)).lower()
+
+    def test_severity_banner_no_hottest_file_fallback(self):
+        from ollama_sentinel.dashboard import _severity_banner
+        stats = OverviewStats(
+            total_reviews=5, newest_review_age_s=30.0, total_unresolved=10,
+            severity_counts={"high": 5, "medium": 5},
+            hottest_file=None, hottest_count=0, db_exists=True,
+        )
+        text = _render(_severity_banner(stats))
+        assert "—" in text          # 🔥 — fallback rendered
+        assert "ErasZoneView" not in text
+
 
 class TestRenderLayoutBackwardsCompat:
     def test_old_signature_produces_legacy_layout(self, tmp_path):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -400,6 +400,26 @@ class TestControlCenterPanels:
         assert "unknown" in _render(panel)
         assert "no DB" in _render(panel)
 
+    def test_severity_banner_shows_counts_and_action(self):
+        from ollama_sentinel.dashboard import _severity_banner
+        stats = OverviewStats(
+            total_reviews=59, newest_review_age_s=30.0, total_unresolved=1230,
+            severity_counts={"critical": 74, "high": 104,
+                             "medium": 576, "low": 476},
+            hottest_file="ErasZoneView.swift", hottest_count=239,
+            db_exists=True,
+        )
+        text = _render(_severity_banner(stats))
+        assert "74" in text and "104" in text and "576" in text and "476" in text
+        assert "ErasZoneView.swift" in text and "239" in text
+        assert "critical" in text.lower()       # from suggested_action
+
+    def test_severity_banner_empty_placeholder(self):
+        from ollama_sentinel.dashboard import _severity_banner
+        stats = OverviewStats(total_reviews=0, newest_review_age_s=None,
+                              total_unresolved=0, db_exists=False)
+        assert "no findings" in _render(_severity_banner(stats)).lower()
+
 
 class TestRenderLayoutBackwardsCompat:
     def test_old_signature_produces_legacy_layout(self, tmp_path):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -392,6 +392,9 @@ class TestControlCenterPanels:
         assert "74" in text and "104" in text and "576" in text and "476" in text
         assert "ErasZoneView.swift" in text and "239" in text
         assert "critical" in text.lower()       # from suggested_action
+        assert "MED 576" in text
+        assert "MEDI" not in text
+        assert "CRIT 74" in text and "HIGH 104" in text and "LOW 476" in text
 
     def test_severity_banner_empty_placeholder(self):
         from ollama_sentinel.dashboard import _severity_banner

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -32,6 +32,14 @@ def _touch(path: pathlib.Path, mtime: float) -> None:
     os.utime(path, (mtime, mtime))
 
 
+def _render(renderable, width: int = 120) -> str:
+    """Render a Rich renderable to plain text for content assertions."""
+    from rich.console import Console
+    c = Console(width=width, record=True, file=open(os.devnull, "w"))
+    c.print(renderable)
+    return c.export_text()
+
+
 class TestRecentReviews:
     def test_empty_dir_returns_empty(self, tmp_path):
         assert recent_reviews(tmp_path, limit=10) == []
@@ -448,3 +456,46 @@ class TestViolationDBNewHelpers:
             assert db.hottest_file() == []
         finally:
             db.close()
+
+
+class TestBlendedRank:
+    def _vr(self, sev, count, fp="f.py", line=1):
+        return ViolationRow(count=count, severity=sev, category="bug",
+                             file_path=fp, line_start=line, line_end=line,
+                             description="d")
+
+    def test_severity_weight_ordering_invariant(self):
+        from ollama_sentinel.dashboard import _SEVERITY_WEIGHT
+        w = _SEVERITY_WEIGHT
+        assert w["critical"] > w["high"] > w["medium"] > w["low"]
+        assert w["critical"] > 7 * w["low"]   # one CRIT outranks 7 LOW
+
+    def test_blended_orders_by_weight_times_count(self):
+        from ollama_sentinel.dashboard import blended_rank
+        rows = [
+            self._vr("medium", 15),   # 2*15 = 30
+            self._vr("high", 11),     # 4*11 = 44
+            self._vr("critical", 4),  # 8*4  = 32
+            self._vr("low", 50),      # 1*50 = 50
+        ]
+        ranked = blended_rank(rows)
+        assert [(r.severity, r.count) for r in ranked] == [
+            ("low", 50), ("high", 11), ("critical", 4), ("medium", 15)]
+
+    def test_tiebreak_count_then_filepath(self):
+        from ollama_sentinel.dashboard import blended_rank
+        a = self._vr("high", 5, fp="z.py")   # 20
+        b = self._vr("high", 5, fp="a.py")   # 20 -> file asc
+        c = self._vr("high", 9, fp="m.py")   # 36
+        ranked = blended_rank([a, b, c])
+        assert [r.file_path for r in ranked] == ["m.py", "a.py", "z.py"]
+
+    def test_unknown_severity_weight_zero_sorts_last(self):
+        from ollama_sentinel.dashboard import blended_rank
+        good = self._vr("low", 1)
+        bad = self._vr("bogus", 999)
+        assert blended_rank([bad, good]) == [good, bad]
+
+    def test_empty_returns_empty(self):
+        from ollama_sentinel.dashboard import blended_rank
+        assert blended_rank([]) == []

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -398,6 +398,7 @@ class TestControlCenterPanels:
                               total_unresolved=0)
         panel = _vitals_strip(stats, time.time())   # must not raise
         assert "unknown" in _render(panel)
+        assert "no DB" in _render(panel)
 
 
 class TestRenderLayoutBackwardsCompat:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -34,8 +34,9 @@ def _touch(path: pathlib.Path, mtime: float) -> None:
 
 def _render(renderable, width: int = 120) -> str:
     """Render a Rich renderable to plain text for content assertions."""
+    import io
     from rich.console import Console
-    c = Console(width=width, record=True, file=open(os.devnull, "w"))
+    c = Console(width=width, record=True, file=io.StringIO())
     c.print(renderable)
     return c.export_text()
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -461,6 +461,40 @@ class TestRenderLayoutBackwardsCompat:
         assert layout["footer"] is not None
 
 
+class TestTriageRenderIntegration:
+    """End-to-end lock: render_layout's v2 patterns panel shows findings in
+    blended (severity*recurrence) order, not input/recurrence-only order."""
+
+    def test_render_layout_patterns_are_blended_ranked(self, tmp_path):
+        now = time.time()
+        # low x50 -> weight 50 ; critical x1 -> weight 8 ; high x11 -> weight 44
+        # blended order must be: low(50), high(44), critical(8)
+        violations = [
+            ViolationRow(count=1, severity="critical", category="bug",
+                         file_path="CritFile.py", line_start=1, line_end=1,
+                         description="crit"),
+            ViolationRow(count=50, severity="low", category="style",
+                         file_path="LowFile.py", line_start=2, line_end=2,
+                         description="low"),
+            ViolationRow(count=11, severity="high", category="bug",
+                         file_path="HighFile.py", line_start=3, line_end=3,
+                         description="high"),
+        ]
+        layout = render_layout(
+            str(tmp_path), tmp_path, tmp_path / "memory.db",
+            [], violations, now,
+            config_path="test.yaml", model_name="gemma3",
+            severity_counts={"critical": 1, "high": 11, "low": 50},
+        )
+        # The panel render_layout actually built for the patterns region:
+        panel = layout["body"]["left"].renderable
+        out = _render(panel, width=120)
+        i_low = out.index("LowFile.py")
+        i_high = out.index("HighFile.py")
+        i_crit = out.index("CritFile.py")
+        assert i_low < i_high < i_crit, out
+
+
 class TestViolationDBNewHelpers:
     def test_count_by_severity(self, tmp_path):
         db = ViolationDB(str(tmp_path / "m.db"))

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -379,6 +379,26 @@ class TestControlCenterPanels:
         panel = _footer_panel_v2()
         assert panel.border_style == "dim"
 
+    def test_vitals_strip_renders(self):
+        from ollama_sentinel.dashboard import _vitals_strip
+        stats = OverviewStats(
+            total_reviews=5, newest_review_age_s=30.0, total_unresolved=8,
+            config_path="test.yaml", model_name="gemma3",
+            watch_dir="/code", db_exists=True,
+        )
+        panel = _vitals_strip(stats, time.time())
+        text = _render(panel)
+        assert "gemma3" in text
+        assert "Active" in text                 # age 30s -> Active
+        assert panel.border_style == "bold cyan"
+
+    def test_vitals_strip_handles_empty(self):
+        from ollama_sentinel.dashboard import _vitals_strip
+        stats = OverviewStats(total_reviews=0, newest_review_age_s=None,
+                              total_unresolved=0)
+        panel = _vitals_strip(stats, time.time())   # must not raise
+        assert "unknown" in _render(panel)
+
 
 class TestRenderLayoutBackwardsCompat:
     def test_old_signature_produces_legacy_layout(self, tmp_path):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -437,6 +437,24 @@ class TestControlCenterPanels:
         assert "—" in text          # 🔥 — fallback rendered
         assert "ErasZoneView" not in text
 
+    def test_reviews_rail_compact_and_selection(self):
+        from ollama_sentinel.dashboard import _reviews_rail
+        now = time.time()
+        rows = [ReviewRow(rel_path="Sources/Vinyl/VinylAudioSourceSelector.md",
+                          mtime=now - 2760),
+                ReviewRow(rel_path="a/b/Left.md", mtime=now - 3000)]
+        panel = _reviews_rail(rows, now, selection=0, scroll=0)
+        text = _render(panel, width=40)
+        assert "46m" in text                         # 2760s -> 46m ago
+        assert "VinylAudioSourceSelector" in text    # basename kept
+        assert panel.border_style == "blue"
+        assert all(len(ln) <= 40 for ln in text.splitlines())
+
+    def test_reviews_rail_empty(self):
+        from ollama_sentinel.dashboard import _reviews_rail
+        panel = _reviews_rail([], time.time(), selection=-1, scroll=0)
+        assert "no reviews" in _render(panel).lower()
+
 
 class TestRenderLayoutBackwardsCompat:
     def test_old_signature_produces_legacy_layout(self, tmp_path):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -467,18 +467,19 @@ class TestRenderLayoutBackwardsCompat:
         assert layout["body"] is not None
         assert layout["footer"] is not None
 
-    def test_new_signature_produces_control_center(self, tmp_path):
+    def test_new_signature_produces_triage_layout(self, tmp_path):
         now = time.time()
         layout = render_layout(
             str(tmp_path), tmp_path, tmp_path / "memory.db",
             [], [], now,
-            config_path="test.yaml",
-            model_name="gemma3",
+            config_path="test.yaml", model_name="gemma3",
             severity_counts={"high": 2},
         )
         assert layout["header"] is not None
-        assert layout["body"]["left"]["overview"] is not None
+        assert layout["banner"] is not None
+        assert layout["body"]["left"] is not None
         assert layout["body"]["right"] is not None
+        assert layout["footer"] is not None
 
 
 class TestViolationDBNewHelpers:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -615,3 +615,25 @@ class TestPatternsSingleLine:
         body = [l for l in out.splitlines() if "ErasZoneView.swift" in l]
         assert len(body) == 1
         assert "…" in out
+
+
+class TestBuildLayoutWiring:
+    def _src(self):
+        import inspect
+        from ollama_sentinel.dashboard import run_dashboard
+        return inspect.getsource(run_dashboard)
+
+    def test_live_path_uses_triage_tree_and_blended_rank(self):
+        src = self._src()
+        assert "blended_rank(" in src
+        assert 'Layout(name="banner"' in src
+        assert "_vitals_strip(" in src
+        assert "_severity_banner(" in src
+        assert "_reviews_rail(" in src
+        assert "_overview_panel(" not in src
+        assert "_header_panel_v2(" not in src
+        assert "_reviews_panel_interactive(" not in src
+
+    def test_detail_mode_path_preserved(self):
+        src = self._src()
+        assert "Mode.DETAIL" in src and "_detail_panel(" in src

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -459,6 +459,17 @@ class TestViolationDBNewHelpers:
             db.close()
 
 
+class TestSeverityPalette:
+    def test_palette_is_bold_saturated_and_distinct(self):
+        from ollama_sentinel.dashboard import _SEVERITY_STYLE
+        s = _SEVERITY_STYLE
+        assert s["critical"] == "bold red"
+        assert s["high"] == "bold yellow"
+        assert s["medium"] == "cyan"
+        assert s["low"] == "dim"
+        assert len(set(s.values())) == 4
+
+
 class TestBlendedRank:
     def _vr(self, sev, count, fp="f.py", line=1):
         return ViolationRow(count=count, severity=sev, category="bug",


### PR DESCRIPTION
Rebuilds the `ollama-sentinel dashboard` v2 Rich TUI as a **triage console**. Brainstormed → spec'd → planned → executed subagent-driven (per-task spec + code-quality review, plus a final whole-implementation review).

## What changed

- **One-line vitals strip** (status dot · model · open count · clock) replaces the old three-line v2 header.
- **Bold severity banner** (size 4): `CRIT/HIGH/MED/LOW` color-weighted + `🔥 hottest-file ▸ next-action`; red border when criticals exist, OVERVIEW-focus highlight; all-clear / no-DB placeholders.
- **Dominant Patterns list** (left, ratio 3) ranked by **blended severity×recurrence** (`CRIT8/HIGH4/MED2/LOW1`, tie → count desc → file asc), **single-line ellipsised** rows (full text via Enter→detail).
- **Thin Recent-Reviews rail** (right, ratio 1), basename-biased.
- Bold/saturated `_SEVERITY_STYLE` (`critical=bold red, high=bold yellow, medium=cyan, low=dim`).
- Both v2 entry points rewired consistently (`render_layout` v2 branch + the `_build_layout` closure); superseded helpers (`_header_panel_v2`, `_overview_panel`, `_reviews_panel_interactive`) deleted.

**Zero `dashboard_input.py` changes** (same `q·Tab·j/k·Enter·/` model; Tab still cycles OVERVIEW→REVIEWS→PATTERNS, OVERVIEW focus highlights the banner). **Legacy two-panel path (`config_path==\"\"`) untouched and regression-locked.** Code confined to `ollama_sentinel/dashboard.py` + `tests/test_dashboard.py`.

## Tests

`pytest tests/ -q` → **496 passed, 15 skipped** (+~17 net dashboard tests vs master, −2 migrated orphans). Includes: `TestBlendedRank` (5 invariants), per-helper render tests with branch coverage (empty/all-clear/no-hottest/no-DB), `TestPatternsSingleLine` (real ellipsis guard), `TestBuildLayoutWiring` (closure source-grep guard — project closure-testing pattern), and `TestTriageRenderIntegration` (end-to-end lock: `render_layout` actually renders patterns in blended order).

## Verification

- ✅ Per-task spec-compliance + code-quality reviews (all 9 tasks); CHANGES-REQUESTED loops resolved (T4 branch coverage, T6 real ellipsis guard).
- ✅ Final whole-implementation review: **READY TO MERGE**, no Critical/Important.
- ⏳ **Manual TUI smoke (reviewer step — a Rich TUI can't be asserted headless):** run `ollama-sentinel dashboard <config.yaml>` against a project with a populated `.ollama_reviews/memory.db`; confirm vitals strip, bold banner with CRITICAL prominent + 🔥 line, dominant single-line Patterns, thin rail, and `Tab/j/k/Enter//` behave as before.

## Non-blocking follow-ups (from reviews)

- **F1:** extract `_build_layout` to a module-level `_build_interactive_layout(...)` so the interactive path (selection/scroll/filter/DETAIL/focus) is directly testable instead of only source-grep-guarded.
- **M2/M3:** add clarifying comments — DETAIL mode intentionally skips the OVERVIEW banner-border override; `render_layout` passes `selection=-1, scroll=0` to the rail by design (no UIState in the static path).

Spec: `docs/superpowers/specs/2026-05-17-dashboard-triage-revamp-design.md`
Plan: `docs/superpowers/plans/2026-05-17-dashboard-triage-revamp.md`