### PR TITLE
feat: surface findings as SARIF (actionability slice 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ ollama-sentinel confirm 42          # manually corroborate a Finding -> Incident
 ollama-sentinel incidents           # list corroborated events (table or -f json)
 ollama-sentinel install-hooks       # install the git post-commit hook
 ollama-sentinel record-commit       # link HEAD to open Findings (called by the hook)
+ollama-sentinel surface             # emit open Findings to .ollama_reviews/findings.sarif (editor Problems panel + CI)
 
 python -m research_agent.main query "question" --context file.py --output result.md
 python -m research_agent.main interactive
@@ -125,10 +126,11 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 | `ollama_sentinel/extractor.py` | LLM JSON extraction + regex fallback for parsing review findings |
 | `ollama_sentinel/watcher.py` | FileSentinel, file watching, ignore logic, pipeline orchestration |
 | `ollama_sentinel/models.py` | Pydantic v2 config models: Ollama/Embedding/Memory/Processing with validators |
-| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit |
+| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface |
 | `ollama_sentinel/pytest_plugin.py` | Opt-in pytest plugin: matches test failures to open Findings, records `test_failure` Incidents (`pytest11` entry point) |
 | `ollama_sentinel/hooks.py` | Git post-commit hook installer + `record_commit` (links commits to open Findings) |
 | `ollama_sentinel/dashboard.py` | Live Rich TUI for `ollama-sentinel dashboard` — polls reviews dir + ViolationDB read-only |
+| `ollama_sentinel/sarif.py` | SARIF 2.1.0 surface: excerpt-based `relocate_finding`, `build_sarif` document, `generate_sarif_file` (read-only orchestration) — backs the `surface` command + watcher auto-refresh |
 | `ollama_sentinel/context/assembler.py` | `Section` / `Priority` / `ContextItem` dataclasses + `assemble()` + `chunk_by_lines` — pure, token-budgeted |
 | `ollama_sentinel/context/tokens.py` | `TokenCounter` (tiktoken `cl100k_base` with char-based fallback) |
 | `ollama_sentinel/context/embeddings.py` | `OllamaEmbedder` — async `/api/embeddings` client, cache-backed, `EmbeddingUnavailable` on failure |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The "I always forget what to run" table.
 | Diagnose a failing log | `ollama-sentinel triage < pytest.log`<br>or `ollama-sentinel triage some.log -o out.md` | Markdown diagnosis with file:line references |
 | Corroborate a finding | `ollama-sentinel confirm 42` | Records a `manual_confirm` Incident; the Finding stays open |
 | See corroborated events | `ollama-sentinel incidents`<br>or `ollama-sentinel incidents -f json` | Incidents (test failures, confirmations, fix commits) as a table or JSON |
+| Surface findings in your editor | `ollama-sentinel surface` | Writes `.ollama_reviews/findings.sarif`; open it in VS Code/Cursor (SARIF Viewer → Problems panel) or upload it in CI for GitHub code scanning. Findings are re-anchored to current lines by excerpt; `run` refreshes it automatically |
 | Link commits to findings | `ollama-sentinel install-hooks` | Installs a git post-commit hook that records which commit touched each open Finding |
 | Auto-link test failures | add `ollama_sentinel = true` to your pytest config | A failing test on a flagged line becomes a `test_failure` Incident |
 | Create a config file | `ollama-sentinel init` | Writes `ollama-sentinel.yaml` in the current dir |

--- a/docs/superpowers/plans/2026-06-03-surface-findings-sarif.md
+++ b/docs/superpowers/plans/2026-06-03-surface-findings-sarif.md
@@ -1,0 +1,1065 @@
+# Surface Findings as SARIF — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serialize open `ViolationDB` findings to a `findings.sarif` artifact — re-anchored to current line numbers by verbatim excerpt — so they appear in the editor Problems panel and GitHub code scanning.
+
+**Architecture:** A new pure module `ollama_sentinel/sarif.py` (relocation + SARIF construction) plus one I/O orchestration function. A `surface` CLI command emits on demand; the watcher regenerates the file best-effort after each review. A required prerequisite makes the finding's `verbatim_excerpt` persistable, which it is not today.
+
+**Tech Stack:** Python 3.10+, SQLite (`ViolationDB`), Typer + Rich (CLI), pytest (`asyncio_mode = "auto"`, `tmp_path`).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-surface-findings-sarif-design.md`
+
+**Branch:** `feat/surface-findings-sarif` (already created; the spec commit is its first commit).
+
+**Stacking:** Four pieces, one PR each, stacked linearly. Piece 2 needs Piece 1's column; Piece 3 needs Piece 2's functions; Piece 4 needs Piece 3's orchestrator.
+
+---
+
+## File Structure
+
+| File | Responsibility | Piece |
+|------|----------------|-------|
+| `ollama_sentinel/violation_db.py` *(modify)* | Add `verbatim_excerpt` column + migration; write it in `persist_findings` | 1 |
+| `ollama_sentinel/sarif.py` *(create)* | Pure: `relocate_finding`, `build_sarif`. I/O: `generate_sarif_file`, `SurfaceSummary` | 2, 3 |
+| `ollama_sentinel/cli.py` *(modify)* | `surface` command | 3 |
+| `ollama_sentinel/watcher.py` *(modify)* | Best-effort SARIF refresh after persist | 4 |
+| `tests/test_violation_db.py` *(modify)* | Excerpt persistence + legacy migration | 1 |
+| `tests/test_sarif.py` *(create)* | Relocation, `build_sarif`, orchestration | 2, 3 |
+| `tests/test_cli.py` *(modify)* | `surface` happy path + no-DB | 3 |
+| `tests/test_watcher.py` *(modify)* | Auto-refresh + failure isolation | 4 |
+
+---
+
+## Piece 1: Persist the verbatim excerpt (PR 1)
+
+The `Finding` dataclass carries `verbatim_excerpt`, but the `findings` table has no such column and `persist_findings` discards it. Relocation needs it. Add the column (fresh + legacy DBs) and write it.
+
+### Task 1.1: Excerpt round-trips through persist + read
+
+**Files:**
+- Modify: `ollama_sentinel/violation_db.py` (`_CREATE_TABLE`, `_migrate`, `persist_findings`)
+- Test: `tests/test_violation_db.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_violation_db.py` (uses the existing `_make_finding` helper and `tmp_path`):
+
+```python
+class TestVerbatimExcerptPersistence:
+    """The finding's verbatim_excerpt must survive persist → read."""
+
+    def test_persist_stores_verbatim_excerpt(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings(
+                "src/app.py",
+                [_make_finding(verbatim_excerpt="x = eval(data)")],
+            )
+            rows = db.get_unresolved("src/app.py")
+        finally:
+            db.close()
+        assert rows[0]["verbatim_excerpt"] == "x = eval(data)"
+
+    def test_migration_adds_column_to_legacy_db(self, tmp_path):
+        # A pre-existing DB created WITHOUT verbatim_excerpt (pre-this-feature).
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute(
+            """
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL, line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL, category TEXT NOT NULL,
+                severity TEXT NOT NULL, description TEXT NOT NULL,
+                first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL DEFAULT 1,
+                resolved INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO findings (file_path, line_start, line_end, category, "
+            "severity, description, first_seen, last_seen) "
+            "VALUES ('a.py', 1, 2, 'bug', 'low', 'd', 't', 't')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = ViolationDB(str(p))  # __init__ runs _migrate
+        try:
+            rows = db.get_unresolved("a.py")
+        finally:
+            db.close()
+        assert "verbatim_excerpt" in rows[0]
+        assert rows[0]["verbatim_excerpt"] is None  # legacy row: no excerpt
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_violation_db.py::TestVerbatimExcerptPersistence -v`
+Expected: FAIL — `test_persist_stores_verbatim_excerpt` with `KeyError: 'verbatim_excerpt'` (column absent).
+
+- [ ] **Step 3: Add the column to the fresh-DB schema**
+
+In `ollama_sentinel/violation_db.py`, `_CREATE_TABLE`, add the column after `embed_text`:
+
+```python
+            embed_text      TEXT,
+            verbatim_excerpt TEXT
+```
+
+(Change the prior `embed_text TEXT` line to end with a comma.)
+
+- [ ] **Step 4: Add the legacy-DB migration**
+
+In `_migrate`, after the existing `fix_commit_sha` block and before the final `self._conn.commit()`:
+
+```python
+                if "verbatim_excerpt" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN verbatim_excerpt TEXT"
+                    )
+```
+
+- [ ] **Step 5: Write the excerpt in `persist_findings`**
+
+In the `else:` (insert) branch of `persist_findings`, change the INSERT to include the new column and value:
+
+```python
+                        cur.execute(
+                            """
+                            INSERT INTO findings
+                                (file_path, line_start, line_end, category,
+                                 severity, description, first_seen, last_seen,
+                                 embed_text, verbatim_excerpt)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                            (
+                                f.file_path,
+                                f.line_start,
+                                f.line_end,
+                                f.category,
+                                f.severity,
+                                f.description,
+                                now,
+                                now,
+                                embed_text,
+                                f.verbatim_excerpt,
+                            ),
+                        )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_violation_db.py -v`
+Expected: PASS (new class + all existing violation_db tests still green).
+
+- [ ] **Step 7: Run the full suite (no regressions)**
+
+Run: `pytest tests/ -q`
+Expected: all prior tests pass; 2 new tests added.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ollama_sentinel/violation_db.py tests/test_violation_db.py
+git commit -m "feat(violation_db): persist verbatim_excerpt for finding relocation"
+```
+
+---
+
+## Piece 2: SARIF pure core — relocation + document (PR 2)
+
+A new module with two pure functions and a `Relocation` dataclass. No I/O. This is the testable heart of the feature.
+
+### Task 2.1: `relocate_finding` re-anchors by excerpt
+
+**Files:**
+- Create: `ollama_sentinel/sarif.py`
+- Test: `tests/test_sarif.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_sarif.py`:
+
+```python
+"""Tests for ollama_sentinel.sarif — relocation and SARIF construction."""
+import json
+
+from ollama_sentinel.sarif import Relocation, build_sarif, relocate_finding
+
+
+def _finding(**over):
+    base = dict(
+        id=1, file_path="src/app.py", line_start=2, line_end=2,
+        category="security", severity="high",
+        description="eval on untrusted input",
+        verbatim_excerpt="x = eval(data)", occurrence_count=1,
+    )
+    base.update(over)
+    return base
+
+
+class TestRelocateFinding:
+    def test_exact_match_at_stored_line(self):
+        content = "def f():\n    x = eval(data)\n    return x\n"
+        reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
+        assert (reloc.start_line, reloc.end_line) == (2, 2)
+        assert reloc.status == "relocated"
+
+    def test_drifted_match_found_at_new_line(self):
+        # Two lines inserted above; excerpt now on line 4.
+        content = "import os\nimport sys\ndef f():\n    x = eval(data)\n"
+        reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
+        assert reloc.start_line == 4
+        assert reloc.status == "relocated"
+
+    def test_multiple_matches_picks_nearest_to_stored(self):
+        content = "x = eval(data)\n\n\nx = eval(data)\n"  # lines 1 and 4
+        reloc = relocate_finding(content, _finding(line_start=4, line_end=4))
+        assert reloc.start_line == 4
+
+    def test_excerpt_not_found_is_stale(self):
+        content = "def f():\n    return safe(data)\n"
+        reloc = relocate_finding(content, _finding())
+        assert reloc.status == "stale"
+
+    def test_empty_excerpt_falls_back_to_stored_lines(self):
+        content = "anything\n"
+        reloc = relocate_finding(
+            content, _finding(verbatim_excerpt="", line_start=7, line_end=9)
+        )
+        assert (reloc.start_line, reloc.end_line) == (7, 9)
+        assert reloc.status == "stored"
+
+    def test_reindented_excerpt_still_matches(self):
+        # Excerpt stored with 4-space indent; file now uses 8 spaces.
+        content = "def f():\n        x = eval(data)\n"
+        reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
+        assert reloc.status == "relocated"
+        assert reloc.start_line == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_sarif.py::TestRelocateFinding -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'ollama_sentinel.sarif'`.
+
+- [ ] **Step 3: Write `relocate_finding` + `Relocation`**
+
+Create `ollama_sentinel/sarif.py` with:
+
+```python
+"""SARIF 2.1.0 serialization for surfacing findings in editors and CI.
+
+Pure core (relocation + document construction) plus one I/O orchestration
+entry added in a later task. Findings store line numbers as of review time;
+those drift as files edit, so we re-anchor each finding by its verbatim
+excerpt rather than trusting the stored line range.
+"""
+import hashlib
+from dataclasses import dataclass
+from typing import FrozenSet, Iterable, List, Tuple
+
+SARIF_SCHEMA = (
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/"
+    "Schemata/sarif-schema-2.1.0.json"
+)
+SARIF_VERSION = "2.1.0"
+INFORMATION_URI = "https://github.com/Skidudeaa/ollama-sentinel"
+
+_SEVERITY_TO_LEVEL = {
+    "critical": "error",
+    "high": "error",
+    "medium": "warning",
+    "low": "note",
+}
+
+
+@dataclass
+class Relocation:
+    """Where a finding currently lives, and how confidently we know it."""
+    start_line: int
+    end_line: int
+    status: str  # "relocated" | "stored" | "stale"
+
+
+def _normalize_lines(text: str) -> List[str]:
+    """Split into lines with leading/trailing whitespace stripped per line."""
+    return [ln.strip() for ln in text.splitlines()]
+
+
+def _strip_blank_edges(lines: List[str]) -> List[str]:
+    """Drop blank lines from both ends, keeping internal blanks."""
+    start, end = 0, len(lines)
+    while start < end and not lines[start]:
+        start += 1
+    while end > start and not lines[end - 1]:
+        end -= 1
+    return lines[start:end]
+
+
+def relocate_finding(content: str, finding: dict) -> Relocation:
+    """Re-anchor a finding to its current line by its verbatim excerpt.
+
+    Whitespace is normalized per line so reindentation does not cause false
+    staleness. Empty excerpt → cannot relocate, fall back to stored lines
+    (status "stored"). Excerpt absent from the file → status "stale".
+    """
+    stored_start = int(finding.get("line_start") or 1)
+    stored_end = int(finding.get("line_end") or stored_start)
+    excerpt = (finding.get("verbatim_excerpt") or "").strip()
+    if not excerpt:
+        return Relocation(stored_start, stored_end, "stored")
+
+    file_lines = _normalize_lines(content)
+    excerpt_lines = _strip_blank_edges(_normalize_lines(excerpt))
+    if not excerpt_lines:
+        return Relocation(stored_start, stored_end, "stored")
+
+    n = len(excerpt_lines)
+    matches: List[int] = []  # 1-based start line of each contiguous match
+    for i in range(len(file_lines) - n + 1):
+        if file_lines[i:i + n] == excerpt_lines:
+            matches.append(i + 1)
+    if not matches:
+        return Relocation(stored_start, stored_end, "stale")
+
+    best = min(matches, key=lambda ln: abs(ln - stored_start))
+    return Relocation(best, best + n - 1, "relocated")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_sarif.py::TestRelocateFinding -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/sarif.py tests/test_sarif.py
+git commit -m "feat(sarif): relocate findings by verbatim excerpt"
+```
+
+### Task 2.2: `build_sarif` constructs the SARIF 2.1.0 document
+
+**Files:**
+- Modify: `ollama_sentinel/sarif.py`
+- Test: `tests/test_sarif.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_sarif.py`:
+
+```python
+class TestBuildSarif:
+    def _located(self, **over):
+        f = _finding(**over)
+        return [(f, relocate_finding("    x = eval(data)\n", f))]
+
+    def test_basic_document_shape(self):
+        doc = build_sarif(self._located(), tool_version="0.1.1")
+        assert doc["version"] == "2.1.0"
+        run = doc["runs"][0]
+        assert run["tool"]["driver"]["name"] == "ollama-sentinel"
+        assert run["tool"]["driver"]["version"] == "0.1.1"
+        assert len(run["results"]) == 1
+
+    def test_severity_maps_to_level(self):
+        cases = {"critical": "error", "high": "error",
+                 "medium": "warning", "low": "note", "weird": "warning"}
+        for severity, level in cases.items():
+            doc = build_sarif(self._located(severity=severity), tool_version="x")
+            assert doc["runs"][0]["results"][0]["level"] == level
+
+    def test_rules_deduped_by_category(self):
+        f1 = _finding(id=1, category="bug")
+        f2 = _finding(id=2, category="bug")
+        f3 = _finding(id=3, category="security")
+        located = [(f, relocate_finding("x = eval(data)\n", f)) for f in (f1, f2, f3)]
+        doc = build_sarif(located, tool_version="x")
+        rule_ids = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert rule_ids == {"ollama-sentinel/bug", "ollama-sentinel/security"}
+
+    def test_result_location_and_snippet(self):
+        doc = build_sarif(self._located(), tool_version="x")
+        loc = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "src/app.py"
+        assert loc["region"]["snippet"]["text"] == "x = eval(data)"
+
+    def test_fingerprint_stable_across_line_drift(self):
+        # Same finding, different stored lines → identical fingerprint.
+        a = _finding(line_start=2)
+        b = _finding(line_start=99)
+        fa = build_sarif([(a, relocate_finding("x = eval(data)\n", a))],
+                         tool_version="x")
+        fb = build_sarif([(b, relocate_finding("x = eval(data)\n", b))],
+                         tool_version="x")
+        fp_a = fa["runs"][0]["results"][0]["partialFingerprints"]["ollamaSentinel/v1"]
+        fp_b = fb["runs"][0]["results"][0]["partialFingerprints"]["ollamaSentinel/v1"]
+        assert fp_a == fp_b
+
+    def test_corroborated_flag_from_ids(self):
+        doc = build_sarif(self._located(id=7), tool_version="x",
+                          corroborated_ids=frozenset({7}))
+        assert doc["runs"][0]["results"][0]["properties"]["corroborated"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_sarif.py::TestBuildSarif -v`
+Expected: FAIL — `ImportError: cannot import name 'build_sarif'`.
+
+- [ ] **Step 3: Write `build_sarif`**
+
+Append to `ollama_sentinel/sarif.py`:
+
+```python
+def _fingerprint(file_path: str, category: str, excerpt: str,
+                 description: str) -> str:
+    """Stable across line drift: hash path+category+excerpt (never lines)."""
+    basis = excerpt.strip() or description.strip()
+    raw = f"{file_path}\x00{category}\x00{basis}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_sarif(
+    located_findings: Iterable[Tuple[dict, Relocation]],
+    *,
+    tool_version: str,
+    corroborated_ids: FrozenSet[int] = frozenset(),
+) -> dict:
+    """Build a SARIF 2.1.0 document from (finding, Relocation) pairs.
+
+    Callers must filter out stale relocations first — every pair here is
+    emitted as a result.
+    """
+    rules_by_id: dict = {}
+    results: List[dict] = []
+    for finding, reloc in located_findings:
+        category = str(finding.get("category") or "general")
+        severity = str(finding.get("severity") or "").lower()
+        level = _SEVERITY_TO_LEVEL.get(severity, "warning")
+        rule_id = f"ollama-sentinel/{category}"
+        if rule_id not in rules_by_id:
+            rules_by_id[rule_id] = {
+                "id": rule_id,
+                "name": category,
+                "shortDescription": {
+                    "text": f"Ollama Sentinel {category} finding"
+                },
+                "defaultConfiguration": {"level": level},
+            }
+
+        file_path = str(finding.get("file_path") or "")
+        excerpt = finding.get("verbatim_excerpt") or ""
+        region: dict = {"startLine": reloc.start_line, "endLine": reloc.end_line}
+        if excerpt.strip():
+            region["snippet"] = {"text": excerpt}
+
+        results.append({
+            "ruleId": rule_id,
+            "level": level,
+            "message": {"text": str(finding.get("description") or "")},
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {"uri": file_path, "uriBaseId": "SRCROOT"},
+                    "region": region,
+                }
+            }],
+            "partialFingerprints": {
+                "ollamaSentinel/v1": _fingerprint(
+                    file_path, category, excerpt,
+                    str(finding.get("description") or ""),
+                )
+            },
+            "properties": {
+                "severity": severity,
+                "occurrence_count": int(finding.get("occurrence_count") or 1),
+                "corroborated": finding.get("id") in corroborated_ids,
+                "relocation": reloc.status,
+            },
+        })
+
+    return {
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "ollama-sentinel",
+                    "version": tool_version,
+                    "informationUri": INFORMATION_URI,
+                    "rules": list(rules_by_id.values()),
+                }
+            },
+            "results": results,
+        }],
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_sarif.py -v`
+Expected: PASS (relocation + build_sarif classes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/sarif.py tests/test_sarif.py
+git commit -m "feat(sarif): build SARIF 2.1.0 document from located findings"
+```
+
+---
+
+## Piece 3: Orchestration + `surface` command (PR 3)
+
+The one I/O function that reads the DB and files, relocates, writes `findings.sarif`, and the CLI verb that drives it.
+
+### Task 3.1: `generate_sarif_file` orchestration
+
+**Files:**
+- Modify: `ollama_sentinel/sarif.py`
+- Test: `tests/test_sarif.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_sarif.py`:
+
+```python
+import pathlib
+
+import pytest
+
+from ollama_sentinel.sarif import generate_sarif_file
+from ollama_sentinel.violation_db import Finding, ViolationDB
+
+
+def _seed(db_path: pathlib.Path, file_path: str, findings):
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = ViolationDB(str(db_path))
+    db.persist_findings(file_path, findings)
+    db.close()
+
+
+class TestGenerateSarifFile:
+    def test_writes_sarif_for_open_findings(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text(
+            "def f():\n    x = eval(data)\n    return x\n"
+        )
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/app.py", [
+            Finding("src/app.py", 2, 2, "security", "high",
+                    "eval on untrusted input",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="0.1.1",
+            )
+        finally:
+            db.close()
+
+        assert summary.emitted == 1
+        assert summary.relocated == 1
+        assert summary.stale == 0
+        doc = json.loads(summary.path.read_text())
+        assert doc["runs"][0]["results"][0]["ruleId"] == "ollama-sentinel/security"
+
+    def test_stale_finding_excluded_and_counted(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        # File no longer contains the excerpt.
+        (tmp_path / "src" / "app.py").write_text("def f():\n    return ok\n")
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/app.py", [
+            Finding("src/app.py", 2, 2, "security", "high", "gone",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="x",
+            )
+        finally:
+            db.close()
+
+        assert summary.emitted == 0
+        assert summary.stale == 1
+        doc = json.loads(summary.path.read_text())
+        assert doc["runs"][0]["results"] == []
+
+    def test_missing_file_counts_as_stale(self, tmp_path):
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/gone.py", [
+            Finding("src/gone.py", 1, 1, "bug", "low", "x",
+                    verbatim_excerpt="whatever"),
+        ])
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="x",
+            )
+        finally:
+            db.close()
+        assert summary.stale == 1
+        assert summary.emitted == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_sarif.py::TestGenerateSarifFile -v`
+Expected: FAIL — `ImportError: cannot import name 'generate_sarif_file'`.
+
+- [ ] **Step 3: Write `generate_sarif_file` + `SurfaceSummary`**
+
+Append to `ollama_sentinel/sarif.py`. Add these imports at the top of the file (with the existing imports):
+
+```python
+import json
+import logging
+import pathlib
+
+from .utils import safe_read
+
+log = logging.getLogger("ollama-sentinel")
+```
+
+Then append:
+
+```python
+@dataclass
+class SurfaceSummary:
+    """Counts from one SARIF generation pass."""
+    emitted: int
+    relocated: int
+    stale: int
+    unverified: int
+    path: pathlib.Path
+
+
+def generate_sarif_file(
+    db,
+    watch_dir,
+    output_dir,
+    *,
+    tool_version: str,
+    out_path=None,
+) -> SurfaceSummary:
+    """Read open findings, relocate by excerpt, write findings.sarif.
+
+    Read-only with respect to the DB and source: stale findings are excluded
+    from the document and counted, never auto-resolved. ``out_path`` overrides
+    the default ``output_dir/findings.sarif`` destination.
+    """
+    watch_dir = pathlib.Path(watch_dir)
+    output_dir = pathlib.Path(output_dir)
+    rows = db.get_all_unresolved()
+
+    corroborated_ids: set = set()
+    paths = sorted({r["file_path"] for r in rows})
+    if paths:
+        try:
+            corroborated_ids = {
+                r["id"] for r in db.get_findings_with_incidents(paths)
+            }
+        except Exception as e:  # corroboration is enrichment; never fatal
+            log.warning("Corroboration lookup failed (%s); marking none.", e)
+
+    content_cache: dict = {}
+
+    def _content(rel: str):
+        # safe_read returns "" (never raises) for missing/unreadable/symlink/
+        # traversal, so check existence explicitly: a gone file is stale, an
+        # empty-but-present file goes through relocation like any other.
+        if rel not in content_cache:
+            abs_path = watch_dir / rel
+            content_cache[rel] = (
+                safe_read(abs_path, watch_dir) if abs_path.is_file() else None
+            )
+        return content_cache[rel]
+
+    located: list = []
+    relocated = stale = unverified = 0
+    for r in rows:
+        content = _content(r["file_path"])
+        if content is None:
+            stale += 1
+            continue
+        reloc = relocate_finding(content, r)
+        if reloc.status == "stale":
+            stale += 1
+            continue
+        if reloc.status == "stored":
+            unverified += 1
+        else:
+            relocated += 1
+        located.append((r, reloc))
+
+    doc = build_sarif(
+        located, tool_version=tool_version,
+        corroborated_ids=frozenset(corroborated_ids),
+    )
+    sarif_path = pathlib.Path(out_path) if out_path else output_dir / "findings.sarif"
+    sarif_path.parent.mkdir(parents=True, exist_ok=True)
+    sarif_path.write_text(json.dumps(doc, indent=2))
+
+    return SurfaceSummary(
+        emitted=len(located),
+        relocated=relocated,
+        stale=stale,
+        unverified=unverified,
+        path=sarif_path,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_sarif.py -v`
+Expected: PASS (all three classes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ollama_sentinel/sarif.py tests/test_sarif.py
+git commit -m "feat(sarif): generate_sarif_file orchestration (read-only)"
+```
+
+### Task 3.2: `ollama-sentinel surface` CLI command
+
+**Files:**
+- Modify: `ollama_sentinel/cli.py` (add command after `incidents`, near line 523)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_cli.py` (reuses `_make_report_config` and `_seed_db`):
+
+```python
+class TestSurfaceCommand:
+    """Tests for 'ollama-sentinel surface'."""
+
+    def test_surface_writes_sarif(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text(
+            "def f():\n    x = eval(data)\n"
+        )
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_db(db_path, [])  # creates the DB
+        db = ViolationDB(str(db_path))
+        db.persist_findings("src/app.py", [
+            Finding("src/app.py", 2, 2, "security", "high", "eval",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+        db.close()
+
+        result = runner.invoke(app, ["surface", "--config", str(cfg)])
+        assert result.exit_code == 0
+        sarif = tmp_path / ".ollama_reviews" / "findings.sarif"
+        assert sarif.exists()
+        doc = json.loads(sarif.read_text())
+        assert doc["version"] == "2.1.0"
+        assert "Wrote 1 findings" in result.output
+
+    def test_surface_no_db(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["surface", "--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No violation database" in result.output
+```
+
+Note: `_seed_db(db_path, [])` persists an empty list (a no-op insert that still creates the DB file via `ViolationDB.__init__`). The subsequent explicit `persist_findings` adds the row with an excerpt.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_cli.py::TestSurfaceCommand -v`
+Expected: FAIL — `surface` is not a registered command (non-zero exit / usage error).
+
+- [ ] **Step 3: Add the `surface` command**
+
+In `ollama_sentinel/cli.py`, after the `incidents` command (ends ~line 522) and before `triage`:
+
+```python
+@app.command()
+def surface(
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o",
+        help="SARIF output path (default: <reviews-dir>/findings.sarif)",
+    ),
+):
+    """Emit open findings as SARIF for editor Problems panels and CI.
+
+    Findings are re-anchored to their current line by verbatim excerpt;
+    stale findings (excerpt no longer present) are reported but excluded.
+    Read-only: never edits source, never changes finding state.
+    """
+    from . import __version__
+    from .sarif import generate_sarif_file
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    watch_dir = pathlib.Path(config.watch.directory).resolve()
+    db_path = watch_dir / config.memory.db_path
+    if not db_path.exists():
+        console.print(
+            "[yellow]No violation database found. Run some reviews first.[/yellow]"
+        )
+        raise typer.Exit()
+
+    output_dir = watch_dir / config.output.directory
+    out_path = pathlib.Path(output).resolve() if output else None
+
+    db = ViolationDB(str(db_path))
+    try:
+        summary = generate_sarif_file(
+            db, watch_dir, output_dir,
+            tool_version=__version__, out_path=out_path,
+        )
+    finally:
+        db.close()
+
+    console.print(
+        f"[green]Wrote {summary.emitted} findings → {summary.path}[/green] "
+        f"[dim]({summary.relocated} relocated, "
+        f"{summary.unverified} unverified, {summary.stale} stale)[/dim]"
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cli.py::TestSurfaceCommand -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pytest tests/ -q`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ollama_sentinel/cli.py tests/test_cli.py
+git commit -m "feat(cli): add 'surface' command to emit findings.sarif"
+```
+
+---
+
+## Piece 4: Watcher auto-refresh (PR 4)
+
+Keep `findings.sarif` fresh while `ollama-sentinel run` is active. Best-effort: a SARIF failure must never break review saving.
+
+### Task 4.1: Refresh SARIF after persist, isolate failures
+
+**Files:**
+- Modify: `ollama_sentinel/watcher.py` (`process_change`, after the persist block ~line 269, inside `if self.violation_db:`)
+- Test: `tests/test_watcher.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_watcher.py`. Add any missing imports at the top (`json`, `pathlib`, `yaml`, `Change`, `FileChange`, `FileSentinel`); the module already imports `watcher as w`.
+
+```python
+import json as _json
+import pathlib as _pathlib
+
+import yaml as _yaml
+
+from watchfiles import Change
+from ollama_sentinel.processor import FileChange
+from ollama_sentinel.watcher import FileSentinel
+
+
+def _watcher_cfg(tmp_path):
+    """Config rooted at tmp_path: memory on, embeddings off (no network)."""
+    cfg = {
+        "watch": {"directory": str(tmp_path), "recursive": True},
+        "ollama": {
+            "host": "http://localhost:11434",
+            "models": {"default": {"name": "m", "system_prompt": "p"}},
+            "request_timeout": 30,
+        },
+        "processing": {"git_diff_mode": False, "grounding": True},
+        "output": {"directory": ".ollama_reviews", "console_output": False},
+        "memory": {"enabled": True, "db_path": ".ollama_reviews/memory.db",
+                   "semantic_recall": False, "structural_recall": False},
+        "embedding": {"enabled": False},
+    }
+    p = tmp_path / "ollama-sentinel.yaml"
+    p.write_text(_yaml.dump(cfg, sort_keys=False))
+    return p
+
+
+def _fake_review(*_a, **_k):
+    async def _run(file_change, model_role="default"):
+        return {
+            "summary": "review",
+            "findings": [{
+                "line_start": 2, "line_end": 2, "category": "security",
+                "severity": "high", "verbatim_excerpt": "x = eval(data)",
+                "description": "eval on untrusted input",
+            }],
+        }
+    return _run
+
+
+class TestSarifAutoRefresh:
+    async def test_process_change_writes_sarif(self, tmp_path, monkeypatch):
+        cfg = _watcher_cfg(tmp_path)
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+
+        sentinel = FileSentinel(cfg)
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review())
+        try:
+            await sentinel.process_change(
+                FileChange(path=src, change_type=Change.modified)
+            )
+        finally:
+            await sentinel.processor.close()
+
+        sarif = tmp_path / ".ollama_reviews" / "findings.sarif"
+        assert sarif.exists()
+        doc = _json.loads(sarif.read_text())
+        assert doc["runs"][0]["results"][0]["ruleId"] == "ollama-sentinel/security"
+
+    async def test_sarif_failure_does_not_break_review(self, tmp_path, monkeypatch):
+        cfg = _watcher_cfg(tmp_path)
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+
+        sentinel = FileSentinel(cfg)
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review())
+
+        import ollama_sentinel.sarif as sarif_mod
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("sarif blew up")
+
+        monkeypatch.setattr(sarif_mod, "generate_sarif_file", _boom)
+        try:
+            # Must NOT raise despite the SARIF failure.
+            await sentinel.process_change(
+                FileChange(path=src, change_type=Change.modified)
+            )
+        finally:
+            await sentinel.processor.close()
+
+        # The review itself still saved.
+        assert (tmp_path / ".ollama_reviews" / "app.md").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_watcher.py::TestSarifAutoRefresh -v`
+Expected: FAIL — `test_process_change_writes_sarif` fails because no `findings.sarif` is written (the refresh hook does not exist yet).
+
+- [ ] **Step 3: Add the best-effort refresh hook**
+
+In `ollama_sentinel/watcher.py`, in `process_change`, immediately after the finding-persistence `try/except` block (the one ending with `log.warning(f"Finding persistence failed for {rel_path}: {e}")`) and still inside `if self.violation_db:`:
+
+```python
+            # Refresh the SARIF surface so editors/CI see current findings.
+            # Best-effort: a SARIF failure must never block review saving.
+            try:
+                from . import __version__
+                from .sarif import generate_sarif_file
+                await asyncio.to_thread(
+                    generate_sarif_file,
+                    self.violation_db,
+                    self.processor.watch_dir,
+                    self.processor.output_dir,
+                    tool_version=__version__,
+                )
+            except Exception as e:
+                log.warning(f"SARIF refresh failed for {rel_path}: {e}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_watcher.py::TestSarifAutoRefresh -v`
+Expected: PASS (2 tests). The failure-isolation test passes because the hook swallows the `RuntimeError` and `save_review` still runs.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pytest tests/ -q`
+Expected: all green (≈ 6 new tests beyond Pieces 1–3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ollama_sentinel/watcher.py tests/test_watcher.py
+git commit -m "feat(watcher): refresh findings.sarif after each review (best-effort)"
+```
+
+---
+
+## Final: docs + manual smoke
+
+### Task 5.1: Document the command
+
+**Files:**
+- Modify: `ollama_sentinel/CLAUDE.md` (Build & Run command list; module table for `sarif.py`)
+- Modify: `README.md` if it lists commands (check first: `grep -n "ollama-sentinel " README.md`)
+
+- [ ] **Step 1: Add to the CLAUDE.md command list**
+
+Under "Build & Run", add after the `incidents` line:
+
+```
+ollama-sentinel surface             # emit open findings to .ollama_reviews/findings.sarif
+```
+
+- [ ] **Step 2: Add `sarif.py` to the module table**
+
+In the `### Key modules` table:
+
+```
+| `ollama_sentinel/sarif.py` | SARIF 2.1.0 surface: excerpt-based relocation, document build, `generate_sarif_file` (read-only) + the `surface` command |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ollama_sentinel/CLAUDE.md README.md
+git commit -m "docs: document the surface command and sarif module"
+```
+
+### Task 5.2: Manual smoke (run once, not automated)
+
+- [ ] Against this repo: `ollama-sentinel surface` (after some reviews exist) writes `.ollama_reviews/findings.sarif`; open it in Cursor with the SARIF Viewer extension and confirm findings land in the Problems panel with click-to-jump.
+- [ ] Confirm `python -c "import json,sys; json.load(open('.ollama_reviews/findings.sarif'))"` parses.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `relocate_finding` (excerpt re-anchoring, drift, stale, empty) → Task 2.1 ✓
+- `build_sarif` (level map, rule dedup, fingerprints, snippet, corroborated, properties) → Task 2.2 ✓
+- `generate_sarif_file` (read DB, safe_read, exclude+count stale, write) → Task 3.1 ✓
+- `surface` CLI (config resolve, no-DB message, summary, `-o`) → Task 3.2 ✓
+- Watcher auto-refresh (best-effort, `asyncio.to_thread`, gated on `violation_db`) → Task 4.1 ✓
+- Severity→level mapping (5 cases) → Task 2.2 ✓
+- `partialFingerprints` stable across drift → Task 2.2 ✓
+- `corroborated` via `get_findings_with_incidents` → Tasks 2.2 + 3.1 ✓
+- **Required prerequisite — persist `verbatim_excerpt`** → Piece 1 ✓
+- Stale reported, never auto-resolved (read-only) → Task 3.1 (no `mark_resolved` call) ✓
+- Tests: relocation / build / orchestration / CLI / watcher → all pieces ✓
+- Docs → Task 5.1 ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✓
+
+**Type consistency:** `Relocation(start_line, end_line, status)`, `SurfaceSummary(emitted, relocated, stale, unverified, path)`, `generate_sarif_file(db, watch_dir, output_dir, *, tool_version, out_path=None)`, `build_sarif(located_findings, *, tool_version, corroborated_ids)` — names identical across the tasks that define and call them. `ruleId` namespace `ollama-sentinel/<category>` and fingerprint key `ollamaSentinel/v1` consistent between Task 2.2 and its tests. ✓
+
+**Note for the implementer:** `Finding` is positional `(file_path, line_start, line_end, category, severity, description, verbatim_excerpt="")` — the test seeds pass `verbatim_excerpt=` as a keyword, which matches the dataclass field order. Confirm before running Piece 3 tests.

--- a/docs/superpowers/specs/2026-06-03-surface-findings-sarif-design.md
+++ b/docs/superpowers/specs/2026-06-03-surface-findings-sarif-design.md
@@ -1,0 +1,256 @@
+# Surface findings as SARIF — design
+
+**Date:** 2026-06-03
+**Status:** Approved (brainstorm), pending implementation plan
+**Slice:** 1 of N in the "make findings actionable" arc
+
+## Problem
+
+Ollama Sentinel generates findings, dedupes them in `ViolationDB`, and
+corroborates a subset into Incidents. Today those findings drive exactly **one**
+thing: they are fed back into future review prompts as "prior violations"
+(`_get_ranked_prior_violations` → semantic / structural / single-file recall).
+
+They drive **zero developer-facing action**. There is no way to:
+
+- see a finding at its location in the editor,
+- act on a finding (fix it),
+- or even *close* a finding — `ViolationDB.mark_resolved` exists but no CLI verb
+  calls it.
+
+Findings accumulate in SQLite and dead-end in `.ollama_reviews/*.md`. This spec
+covers the cheapest, lowest-risk first step toward closing that loop: **surfacing
+open findings where the developer edits**, as a standard SARIF artifact.
+
+## Scope
+
+A `surface` command plus watcher auto-refresh that serializes the open findings
+in `ViolationDB` to `.ollama_reviews/findings.sarif` (SARIF 2.1.0), with each
+finding re-located to its *current* line by `verbatim_excerpt`.
+
+The artifact is consumed by:
+
+- **VS Code / Cursor** via the SARIF Viewer extension → Problems panel,
+  click-to-jump.
+- **GitHub code scanning** in CI via `github/codeql-action/upload-sarif` →
+  Security tab + inline PR annotations.
+
+### Explicitly out of scope (later slices)
+
+- **Triage verbs** (`resolve` / `dismiss`) — the slice that wires
+  `mark_resolved` to the CLI.
+- **Auto-resolving stale findings** — `surface` reports stale findings but never
+  mutates DB state. Auto-resolve belongs to the triage slice.
+- **Remediation** (`fix <id>` — model proposes a patch, applies on confirm).
+- **LSP diagnostics daemon** and **inline `# sentinel:` comments** — rejected
+  mechanisms (see "Decisions").
+
+## Design
+
+### Module: `ollama_sentinel/sarif.py`
+
+One cohesive module: a pure core (relocation + SARIF construction) and a thin
+I/O orchestration entry. The split keeps the SARIF logic unit-testable with
+in-memory data and isolates filesystem/DB access to one function.
+
+#### `relocate_finding(content: str, finding: dict) -> Relocation` *(pure)*
+
+Re-anchors a finding to its current position. Findings store line numbers as of
+review time; those numbers drift as the file edits, so we re-locate by the
+verbatim excerpt rather than trusting `line_start` / `line_end`.
+
+`Relocation` is a small dataclass: `start_line: int`, `end_line: int`,
+`status: str` where `status ∈ {"relocated", "stored", "stale"}`.
+
+Algorithm:
+
+1. **Empty excerpt** (legacy / ungrounded findings often have none) → cannot
+   relocate. Return stored `line_start` / `line_end` with `status="stored"`.
+2. Search `content` for the excerpt as a substring/line block.
+   - **Found exactly once** → use that line. `status="relocated"` (or `"stored"`
+     if it coincides with the stored line — cosmetic, treat as relocated).
+   - **Found multiple times** → pick the occurrence whose start line is nearest
+     to stored `line_start`. `status="relocated"`.
+   - **Not found** → `status="stale"`.
+
+Matching normalizes leading/trailing whitespace per line so reindentation does
+not produce false staleness. The excerpt is matched against raw file lines (the
+file is read without the prompt's `N: ` numbering).
+
+#### `build_sarif(located_findings, *, tool_version, corroborated_ids) -> dict` *(pure)*
+
+Builds a SARIF 2.1.0 document from findings that already carry a `Relocation`.
+
+- `version: "2.1.0"`, `$schema` set to the SARIF 2.1.0 schema URL.
+- `runs[0].tool.driver`:
+  - `name: "ollama-sentinel"`, `version: tool_version`,
+    `informationUri: "https://github.com/Skidudeaa/ollama-sentinel"`.
+  - `rules[]`: one rule per distinct `category`, deduped. Each rule:
+    `id` (e.g. `"ollama-sentinel/bug"`), `name`, `shortDescription.text`, and a
+    `defaultConfiguration.level` from the severity→level mapping below.
+- `runs[0].results[]`: one per finding.
+  - `ruleId` = `"ollama-sentinel/<category>"`.
+  - `level` from severity:
+    - `critical` → `"error"`
+    - `high` → `"error"`
+    - `medium` → `"warning"`
+    - `low` → `"note"`
+    - unknown / missing → `"warning"`
+  - `message.text` = `description`.
+  - `locations[0].physicalLocation`:
+    - `artifactLocation.uri` = `file_path` (already stored relative to
+      `watch_dir`), `uriBaseId: "SRCROOT"`.
+    - `region.startLine` / `region.endLine` from the `Relocation`.
+    - `region.snippet.text` = `verbatim_excerpt` (omitted when empty).
+  - `partialFingerprints`: `{"ollamaSentinel/v1": <sha256 hex>}` where the hash
+    is over `(file_path, category, normalized excerpt)` — **never line numbers**,
+    so code scanning tracks a finding across commits despite drift. When the
+    excerpt is empty, fall back to hashing `(file_path, category, description)`.
+  - `properties`: `{severity, occurrence_count, corroborated: bool,
+    relocation: status}`. `corroborated` is `True` when the finding id is in
+    `corroborated_ids`.
+
+#### `generate_sarif_file(db, watch_dir, output_dir, *, tool_version) -> SurfaceSummary` *(I/O)*
+
+Orchestration entry, the only function that touches the DB and filesystem.
+
+1. `rows = db.get_all_unresolved()`.
+2. `corroborated_ids = {f["id"] for f in db.get_findings_with_incidents(distinct_paths)}`
+   — one query, marks findings that already have ≥1 Incident.
+3. Group rows by `file_path`. For each file, read current content via
+   `safe_read(watch_dir / file_path, watch_dir)` for containment. A file that no
+   longer exists (or fails containment) → all its findings are `stale`.
+4. `relocate_finding` each row against its file content.
+5. **Exclude `stale` findings from the SARIF results** (don't surface ghosts);
+   count them. `stored` (empty-excerpt) and `relocated` findings are emitted.
+6. `build_sarif(...)` → write `output_dir / "findings.sarif"` (pretty JSON).
+7. Return `SurfaceSummary` dataclass: `emitted: int`, `relocated: int`,
+   `stale: int`, `unverified: int` (empty-excerpt → stored), `path: Path`.
+
+`surface` is strictly read-only: it does **not** call `mark_resolved` on stale
+findings, does not edit source, and writes only the one SARIF artifact.
+
+### CLI: `ollama-sentinel surface`
+
+Mirrors the `report` / `incidents` command shape in `cli.py`:
+
+```
+ollama-sentinel surface [-c CONFIG] [-o OUTPUT]
+```
+
+- Resolve config via `_load_config_or_exit`.
+- Resolve `db_path = watch_dir / config.memory.db_path`; friendly
+  `[yellow]No violation database found…[/]` message + exit if absent (matches
+  `report` / `incidents`).
+- Default output is `watch_dir / config.output.directory / findings.sarif`;
+  `-o/--output` overrides the SARIF path.
+- Open `ViolationDB`, call `generate_sarif_file`, close DB, print a summary line:
+  `Wrote 7 findings → findings.sarif (5 relocated, 2 stale)`.
+
+`tool_version` is `ollama_sentinel.__version__`.
+
+### Watcher auto-refresh
+
+After the existing best-effort persist block in
+`watcher.FileSentinel.process_change` (currently `watcher.py:263-269`, right
+after `persist_findings`), regenerate the SARIF so the Problems panel stays live
+while `run` is active:
+
+- Call `generate_sarif_file(self.violation_db, self.processor.watch_dir,
+  self.processor.output_dir, tool_version=__version__)` via
+  `asyncio.to_thread`.
+- **Best-effort**, gated on `self.violation_db` being set: wrap in
+  `try/except`, log a warning on failure, never raise. This matches the
+  project's "finding extraction and violation persistence never block review
+  saving" convention — a SARIF write failure must not break the review.
+- Runs whether or not *this* review produced new findings (a relocation may have
+  changed because the file edited), but only when `violation_db` exists.
+
+Performance note: each refresh re-reads every currently-flagged file to relocate
+excerpts. At local single-developer repo scale the flagged-file set is small and
+reads are OS-cached; full rebuild is chosen for correctness. If this ever
+becomes hot, a later optimization can relocate only the just-reviewed file and
+reuse stored lines elsewhere — out of scope here.
+
+## Data shapes
+
+`ViolationDB` rows are dicts with: `id`, `file_path` (relative to `watch_dir`),
+`line_start`, `line_end`, `category`, `severity`, `description`,
+`verbatim_excerpt` *(may be absent/empty on legacy rows)*, `occurrence_count`,
+`resolved`, `embed_text`. `get_all_unresolved()` returns `resolved = 0` rows.
+
+> **Required prerequisite — the excerpt is not persisted today.** The
+> `Finding` dataclass has a `verbatim_excerpt` field, but the `findings` table
+> has **no** `verbatim_excerpt` column and `persist_findings` never writes it
+> (it inserts `file_path, line_start, line_end, category, severity, description,
+> first_seen, last_seen, embed_text` — the excerpt is discarded). Relocation
+> therefore cannot work on existing rows. The plan **must**, as its first piece:
+> (1) add a nullable `verbatim_excerpt TEXT` column via an idempotent migration
+> (same pattern as the `embed_text` backfill in `_migrate`), and (2) make
+> `persist_findings` write `f.verbatim_excerpt`. Old rows and ungrounded findings
+> keep an empty excerpt and degrade to `status="stored"` (emitted at stored
+> lines, `properties.relocation="stored"`), so the feature functions during the
+> backfill period — only *newly persisted grounded* findings get true relocation
+> until the table refills.
+
+## Testing (before merge — project rule: all new features have tests)
+
+`tests/test_sarif.py`:
+
+- **Relocation** — exact match at stored line; drifted match (excerpt moved down
+  N lines); multiple matches → nearest-to-stored chosen; not-found → `stale`;
+  empty excerpt → `stored`; whitespace-only reindent → still matches (not stale).
+- **`build_sarif`** — severity→level mapping across all five cases; `rules`
+  deduped by category; `partialFingerprints` identical when only line numbers
+  differ (drift stability) and different when excerpt differs; relative
+  `artifactLocation.uri`; `properties.corroborated` set from `corroborated_ids`;
+  `region.snippet.text` present/omitted correctly.
+- **`generate_sarif_file`** (tmp_path + real `ViolationDB`) — persist findings,
+  run, assert `findings.sarif` exists and parses as JSON; stale finding excluded
+  from `results` but counted in summary; deleted file → its findings stale;
+  summary counts correct.
+
+`tests/test_cli.py` (or existing CLI test module):
+
+- `surface` happy path — DB with findings → file written, summary printed.
+- No DB → friendly message, clean exit.
+
+`tests/test_watcher.py` (or existing watcher tests):
+
+- After `process_change` persists findings, `findings.sarif` exists.
+- SARIF generation failure (monkeypatched to raise) does **not** break review
+  save — `save_review` still runs, no exception propagates.
+
+## Decisions
+
+- **SARIF over LSP / inline comments.** SARIF is the industry-standard
+  static-analysis interchange format: one file unlocks both the local editor
+  (SARIF Viewer → Problems panel) and CI (GitHub code scanning), with no daemon
+  and no source mutation. It fits the existing "write artifacts to
+  `.ollama_reviews/`" model. LSP gives live squiggles but costs a persistent
+  language-server process + editor wiring + protocol plumbing — too heavy for a
+  local single-dev tool. Inline `# sentinel:` comments mutate watched code,
+  re-trigger `awatch`, and pollute diffs/blame — they fight the read-only design.
+- **Read-only `surface`.** Stale findings are reported, not auto-resolved.
+  Mutating DB state in a surfacing command violates single responsibility and
+  surprises the user; auto-resolve is a clean triage-slice follow-up.
+- **Relocate by excerpt, not stored line.** Findings are anchored at review
+  time; line numbers go stale. Excerpt relocation keeps the SARIF accurate and
+  yields a free staleness signal (excerpt gone → stale) for the future triage
+  slice.
+- **`corroborated` enrichment included.** One extra `get_findings_with_incidents`
+  query marks findings that already have an Incident, letting the editor/CI
+  distinguish model-opinion from corroborated event. Cheap, high signal.
+- **Both emit triggers.** On-demand `surface` command + best-effort watcher
+  auto-refresh — a live Problems panel without an LSP daemon, plus a manual
+  command for one-off / CI use.
+
+## Risk
+
+Lowest of the three actionability slices. No source writes, no DB mutation, no
+new long-running process. New surface area: one module (`sarif.py`), one CLI
+command, ~5 lines in the watcher. The only real subtlety — line drift — is
+handled by excerpt relocation. The one hard prerequisite is confirmed: the
+`verbatim_excerpt` column does not exist and the excerpt is discarded at persist
+time, so the plan's first piece is the column + migration + `persist_findings`
+write (see "Data shapes"). Everything else degrades gracefully around it.

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -523,6 +523,54 @@ def incidents(
 
 
 @app.command()
+def surface(
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o",
+        help="SARIF output path (default: <reviews-dir>/findings.sarif)",
+    ),
+):
+    """Emit open findings as SARIF for editor Problems panels and CI.
+
+    Findings are re-anchored to their current line by verbatim excerpt;
+    stale findings (excerpt no longer present) are reported but excluded.
+    Read-only: never edits source, never changes finding state.
+    """
+    from .sarif import generate_sarif_file
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    watch_dir = pathlib.Path(config.watch.directory).resolve()
+    db_path = watch_dir / config.memory.db_path
+    if not db_path.exists():
+        console.print(
+            "[yellow]No violation database found. Run some reviews first.[/yellow]"
+        )
+        raise typer.Exit()
+
+    output_dir = watch_dir / config.output.directory
+    out_path = pathlib.Path(output).resolve() if output else None
+
+    db = ViolationDB(str(db_path))
+    try:
+        summary = generate_sarif_file(
+            db, watch_dir, output_dir,
+            tool_version=__version__, out_path=out_path,
+        )
+    finally:
+        db.close()
+
+    console.print(
+        f"[green]Wrote {summary.emitted} findings → {summary.path}[/green] "
+        f"[dim]({summary.relocated} relocated, "
+        f"{summary.unverified} unverified, {summary.stale} stale)[/dim]"
+    )
+
+
+@app.command()
 def triage(
     input_path: Optional[str] = typer.Argument(
         None,

--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -6,8 +6,15 @@ those drift as files edit, so we re-anchor each finding by its verbatim
 excerpt rather than trusting the stored line range.
 """
 import hashlib
+import json
+import logging
+import pathlib
 from dataclasses import dataclass
 from typing import FrozenSet, Iterable, List, Tuple
+
+from .utils import safe_read
+
+log = logging.getLogger("ollama-sentinel")
 
 SARIF_SCHEMA = (
     "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/"
@@ -164,3 +171,88 @@ def build_sarif(
             "results": results,
         }],
     }
+
+
+@dataclass
+class SurfaceSummary:
+    """Counts from one SARIF generation pass."""
+    emitted: int
+    relocated: int
+    stale: int
+    unverified: int
+    path: pathlib.Path
+
+
+def generate_sarif_file(
+    db,
+    watch_dir,
+    output_dir,
+    *,
+    tool_version: str,
+    out_path=None,
+) -> SurfaceSummary:
+    """Read open findings, relocate by excerpt, write findings.sarif.
+
+    Read-only with respect to the DB and source: stale findings are excluded
+    from the document and counted, never auto-resolved. ``out_path`` overrides
+    the default ``output_dir/findings.sarif`` destination.
+    """
+    watch_dir = pathlib.Path(watch_dir)
+    output_dir = pathlib.Path(output_dir)
+    rows = db.get_all_unresolved()
+
+    corroborated_ids: set = set()
+    paths = sorted({r["file_path"] for r in rows})
+    if paths:
+        try:
+            corroborated_ids = {
+                r["id"] for r in db.get_findings_with_incidents(paths)
+            }
+        except Exception as e:  # corroboration is enrichment; never fatal
+            log.warning("Corroboration lookup failed (%s); marking none.", e)
+
+    content_cache: dict = {}
+
+    def _content(rel: str):
+        # safe_read returns "" (never raises) for missing/unreadable/symlink/
+        # traversal, so check existence explicitly: a gone file is stale, an
+        # empty-but-present file goes through relocation like any other.
+        if rel not in content_cache:
+            abs_path = watch_dir / rel
+            content_cache[rel] = (
+                safe_read(abs_path, watch_dir) if abs_path.is_file() else None
+            )
+        return content_cache[rel]
+
+    located: list = []
+    relocated = stale = unverified = 0
+    for r in rows:
+        content = _content(r["file_path"])
+        if content is None:
+            stale += 1
+            continue
+        reloc = relocate_finding(content, r)
+        if reloc.status == "stale":
+            stale += 1
+            continue
+        if reloc.status == "stored":
+            unverified += 1
+        else:
+            relocated += 1
+        located.append((r, reloc))
+
+    doc = build_sarif(
+        located, tool_version=tool_version,
+        corroborated_ids=frozenset(corroborated_ids),
+    )
+    sarif_path = pathlib.Path(out_path) if out_path else output_dir / "findings.sarif"
+    sarif_path.parent.mkdir(parents=True, exist_ok=True)
+    sarif_path.write_text(json.dumps(doc, indent=2))
+
+    return SurfaceSummary(
+        emitted=len(located),
+        relocated=relocated,
+        stale=stale,
+        unverified=unverified,
+        path=sarif_path,
+    )

--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -75,3 +75,86 @@ def relocate_finding(content: str, finding: dict) -> Relocation:
 
     best = min(matches, key=lambda ln: abs(ln - stored_start))
     return Relocation(best, best + n - 1, "relocated")
+
+
+def _fingerprint(file_path: str, category: str, excerpt: str,
+                 description: str) -> str:
+    """Stable across line drift: hash path+category+excerpt (never lines)."""
+    basis = excerpt.strip() or description.strip()
+    raw = f"{file_path}\x00{category}\x00{basis}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_sarif(
+    located_findings: Iterable[Tuple[dict, Relocation]],
+    *,
+    tool_version: str,
+    corroborated_ids: FrozenSet[int] = frozenset(),
+) -> dict:
+    """Build a SARIF 2.1.0 document from (finding, Relocation) pairs.
+
+    Callers must filter out stale relocations first — every pair here is
+    emitted as a result.
+    """
+    rules_by_id: dict = {}
+    results: List[dict] = []
+    for finding, reloc in located_findings:
+        category = str(finding.get("category") or "general")
+        severity = str(finding.get("severity") or "").lower()
+        level = _SEVERITY_TO_LEVEL.get(severity, "warning")
+        rule_id = f"ollama-sentinel/{category}"
+        if rule_id not in rules_by_id:
+            rules_by_id[rule_id] = {
+                "id": rule_id,
+                "name": category,
+                "shortDescription": {
+                    "text": f"Ollama Sentinel {category} finding"
+                },
+                "defaultConfiguration": {"level": level},
+            }
+
+        file_path = str(finding.get("file_path") or "")
+        excerpt = finding.get("verbatim_excerpt") or ""
+        region: dict = {"startLine": reloc.start_line, "endLine": reloc.end_line}
+        if excerpt.strip():
+            region["snippet"] = {"text": excerpt}
+
+        results.append({
+            "ruleId": rule_id,
+            "level": level,
+            "message": {"text": str(finding.get("description") or "")},
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {"uri": file_path, "uriBaseId": "SRCROOT"},
+                    "region": region,
+                }
+            }],
+            "partialFingerprints": {
+                "ollamaSentinel/v1": _fingerprint(
+                    file_path, category, excerpt,
+                    str(finding.get("description") or ""),
+                )
+            },
+            "properties": {
+                "severity": severity,
+                "occurrence_count": int(finding.get("occurrence_count") or 1),
+                "corroborated": finding.get("id") in corroborated_ids,
+                "relocation": reloc.status,
+            },
+        })
+
+    return {
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "ollama-sentinel",
+                    "version": tool_version,
+                    "informationUri": INFORMATION_URI,
+                    "rules": list(rules_by_id.values()),
+                }
+            },
+            "results": results,
+        }],
+    }

--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -23,6 +23,8 @@ _SEVERITY_TO_LEVEL = {
     "low": "note",
 }
 
+_LEVEL_RANK = {"note": 0, "warning": 1, "error": 2}
+
 
 @dataclass
 class Relocation:
@@ -112,6 +114,10 @@ def build_sarif(
                 },
                 "defaultConfiguration": {"level": level},
             }
+        else:
+            existing = rules_by_id[rule_id]["defaultConfiguration"]["level"]
+            if _LEVEL_RANK.get(level, 1) > _LEVEL_RANK.get(existing, 1):
+                rules_by_id[rule_id]["defaultConfiguration"]["level"] = level
 
         file_path = str(finding.get("file_path") or "")
         excerpt = finding.get("verbatim_excerpt") or ""

--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -185,11 +185,11 @@ class SurfaceSummary:
 
 def generate_sarif_file(
     db,
-    watch_dir,
-    output_dir,
+    watch_dir: "pathlib.Path | str",
+    output_dir: "pathlib.Path | str",
     *,
     tool_version: str,
-    out_path=None,
+    out_path: "pathlib.Path | str | None" = None,
 ) -> SurfaceSummary:
     """Read open findings, relocate by excerpt, write findings.sarif.
 

--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -1,0 +1,77 @@
+"""SARIF 2.1.0 serialization for surfacing findings in editors and CI.
+
+Pure core (relocation + document construction) plus one I/O orchestration
+entry added in a later task. Findings store line numbers as of review time;
+those drift as files edit, so we re-anchor each finding by its verbatim
+excerpt rather than trusting the stored line range.
+"""
+import hashlib
+from dataclasses import dataclass
+from typing import FrozenSet, Iterable, List, Tuple
+
+SARIF_SCHEMA = (
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/"
+    "Schemata/sarif-schema-2.1.0.json"
+)
+SARIF_VERSION = "2.1.0"
+INFORMATION_URI = "https://github.com/Skidudeaa/ollama-sentinel"
+
+_SEVERITY_TO_LEVEL = {
+    "critical": "error",
+    "high": "error",
+    "medium": "warning",
+    "low": "note",
+}
+
+
+@dataclass
+class Relocation:
+    """Where a finding currently lives, and how confidently we know it."""
+    start_line: int
+    end_line: int
+    status: str  # "relocated" | "stored" | "stale"
+
+
+def _normalize_lines(text: str) -> List[str]:
+    """Split into lines with leading/trailing whitespace stripped per line."""
+    return [ln.strip() for ln in text.splitlines()]
+
+
+def _strip_blank_edges(lines: List[str]) -> List[str]:
+    """Drop blank lines from both ends, keeping internal blanks."""
+    start, end = 0, len(lines)
+    while start < end and not lines[start]:
+        start += 1
+    while end > start and not lines[end - 1]:
+        end -= 1
+    return lines[start:end]
+
+
+def relocate_finding(content: str, finding: dict) -> Relocation:
+    """Re-anchor a finding to its current line by its verbatim excerpt.
+
+    Whitespace is normalized per line so reindentation does not cause false
+    staleness. Empty excerpt → cannot relocate, fall back to stored lines
+    (status "stored"). Excerpt absent from the file → status "stale".
+    """
+    stored_start = int(finding.get("line_start") or 1)
+    stored_end = int(finding.get("line_end") or stored_start)
+    excerpt = (finding.get("verbatim_excerpt") or "").strip()
+    if not excerpt:
+        return Relocation(stored_start, stored_end, "stored")
+
+    file_lines = _normalize_lines(content)
+    excerpt_lines = _strip_blank_edges(_normalize_lines(excerpt))
+    if not excerpt_lines:
+        return Relocation(stored_start, stored_end, "stored")
+
+    n = len(excerpt_lines)
+    matches: List[int] = []  # 1-based start line of each contiguous match
+    for i in range(len(file_lines) - n + 1):
+        if file_lines[i:i + n] == excerpt_lines:
+            matches.append(i + 1)
+    if not matches:
+        return Relocation(stored_start, stored_end, "stale")
+
+    best = min(matches, key=lambda ln: abs(ln - stored_start))
+    return Relocation(best, best + n - 1, "relocated")

--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -56,6 +56,22 @@ def _strip_blank_edges(lines: List[str]) -> List[str]:
     return lines[start:end]
 
 
+def _word_linemap(text: str) -> Tuple[List[str], List[int]]:
+    """Whitespace-split *text* into words, tracking each word's source line.
+
+    Returns (words, line_per_word) where line_per_word[i] is the 1-based line
+    that words[i] came from. Used by the relocation fallback to match a
+    newline-flattened excerpt against the file and map back to a line span.
+    """
+    words: List[str] = []
+    line_per_word: List[int] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for w in line.split():
+            words.append(w)
+            line_per_word.append(lineno)
+    return words, line_per_word
+
+
 def relocate_finding(content: str, finding: dict) -> Relocation:
     """Re-anchor a finding to its current line by its verbatim excerpt.
 
@@ -79,11 +95,31 @@ def relocate_finding(content: str, finding: dict) -> Relocation:
     for i in range(len(file_lines) - n + 1):
         if file_lines[i:i + n] == excerpt_lines:
             matches.append(i + 1)
-    if not matches:
+    if matches:
+        best = min(matches, key=lambda ln: abs(ln - stored_start))
+        return Relocation(best, best + n - 1, "relocated")
+
+    # Fallback: the excerpt may have been flattened (newlines collapsed to
+    # spaces) by the upstream verbatim-validation gate, so line-block matching
+    # misses a genuinely-present multi-line excerpt. Match the excerpt's word
+    # sequence against the file's and map the span back to line numbers.
+    file_words, file_word_lines = _word_linemap(content)
+    excerpt_words = excerpt.split()
+    word_matches: List[Tuple[int, int]] = []  # (start_line, end_line) per match
+    if excerpt_words:
+        m = len(excerpt_words)
+        for i in range(len(file_words) - m + 1):
+            if file_words[i:i + m] == excerpt_words:
+                word_matches.append(
+                    (file_word_lines[i], file_word_lines[i + m - 1])
+                )
+    if not word_matches:
         return Relocation(stored_start, stored_end, "stale")
 
-    best = min(matches, key=lambda ln: abs(ln - stored_start))
-    return Relocation(best, best + n - 1, "relocated")
+    best_start, best_end = min(
+        word_matches, key=lambda se: abs(se[0] - stored_start)
+    )
+    return Relocation(best_start, best_end, "relocated")
 
 
 def _fingerprint(file_path: str, category: str, excerpt: str,

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -58,7 +58,8 @@ class ViolationDB:
             last_seen       TEXT    NOT NULL,
             occurrence_count INTEGER NOT NULL DEFAULT 1,
             resolved        INTEGER NOT NULL DEFAULT 0,
-            embed_text      TEXT
+            embed_text      TEXT,
+            verbatim_excerpt TEXT
         )
     """
 
@@ -117,6 +118,10 @@ class ViolationDB:
                     self._conn.execute(
                         "ALTER TABLE findings ADD COLUMN fix_commit_sha TEXT"
                     )
+                if "verbatim_excerpt" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN verbatim_excerpt TEXT"
+                    )
                 self._conn.commit()
         except sqlite3.DatabaseError as e:
             import logging
@@ -171,8 +176,9 @@ class ViolationDB:
                             """
                             INSERT INTO findings
                                 (file_path, line_start, line_end, category,
-                                 severity, description, first_seen, last_seen, embed_text)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                 severity, description, first_seen, last_seen,
+                                 embed_text, verbatim_excerpt)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                             """,
                             (
                                 f.file_path,
@@ -184,6 +190,7 @@ class ViolationDB:
                                 now,
                                 now,
                                 embed_text,
+                                f.verbatim_excerpt,
                             ),
                         )
                 self._conn.commit()

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -93,7 +93,7 @@ class ViolationDB:
         self._migrate()
 
     def _migrate(self) -> None:
-        """Idempotent migration: add the embed_text column and backfill values."""
+        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt)."""
         try:
             with self._lock:
                 cur = self._conn.execute("PRAGMA table_info(findings)")

--- a/ollama_sentinel/watcher.py
+++ b/ollama_sentinel/watcher.py
@@ -268,6 +268,21 @@ class FileSentinel:
                 except Exception as e:
                     log.warning(f"Finding persistence failed for {rel_path}: {e}")
 
+                # Refresh the SARIF surface so editors/CI see current findings.
+                # Best-effort: a SARIF failure must never block review saving.
+                try:
+                    from . import __version__
+                    from .sarif import generate_sarif_file
+                    await asyncio.to_thread(
+                        generate_sarif_file,
+                        self.violation_db,
+                        self.processor.watch_dir,
+                        self.processor.output_dir,
+                        tool_version=__version__,
+                    )
+                except Exception as e:
+                    log.warning(f"SARIF refresh failed for {rel_path}: {e}")
+
             # Save review (sync I/O, run in thread to avoid blocking event loop)
             output_path = await asyncio.to_thread(self.processor.save_review, file_change, review)
             log.info(f"Saved review to {output_path}")

--- a/ollama_sentinel/watcher.py
+++ b/ollama_sentinel/watcher.py
@@ -271,6 +271,8 @@ class FileSentinel:
                 # Refresh the SARIF surface so editors/CI see current findings.
                 # Best-effort: a SARIF failure must never block review saving.
                 try:
+                    # Imported lazily so the watcher module stays cheap to import
+                    # and to keep the SARIF dependency off the module-load path.
                     from . import __version__
                     from .sarif import generate_sarif_file
                     await asyncio.to_thread(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,3 +516,38 @@ class TestIncidentsCommand:
         result = runner.invoke(app, ["incidents", "--config", str(cfg)])
         assert result.exit_code == 0
         assert "No violation database" in result.output
+
+
+class TestSurfaceCommand:
+    """Tests for 'ollama-sentinel surface'."""
+
+    def test_surface_writes_sarif(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text(
+            "def f():\n    x = eval(data)\n"
+        )
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_db(db_path, [])  # creates the DB
+        db = ViolationDB(str(db_path))
+        db.persist_findings("src/app.py", [
+            Finding("src/app.py", 2, 2, "security", "high", "eval",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+        db.close()
+
+        result = runner.invoke(app, ["surface", "--config", str(cfg)])
+        assert result.exit_code == 0
+        sarif = tmp_path / ".ollama_reviews" / "findings.sarif"
+        assert sarif.exists()
+        doc = json.loads(sarif.read_text())
+        assert doc["version"] == "2.1.0"
+        assert "Wrote 1 findings" in result.output
+
+    def test_surface_no_db(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["surface", "--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No violation database" in result.output

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,0 +1,53 @@
+"""Tests for ollama_sentinel.sarif — relocation and SARIF construction."""
+from ollama_sentinel.sarif import Relocation, relocate_finding
+
+
+def _finding(**over):
+    base = dict(
+        id=1, file_path="src/app.py", line_start=2, line_end=2,
+        category="security", severity="high",
+        description="eval on untrusted input",
+        verbatim_excerpt="x = eval(data)", occurrence_count=1,
+    )
+    base.update(over)
+    return base
+
+
+class TestRelocateFinding:
+    def test_exact_match_at_stored_line(self):
+        content = "def f():\n    x = eval(data)\n    return x\n"
+        reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
+        assert (reloc.start_line, reloc.end_line) == (2, 2)
+        assert reloc.status == "relocated"
+
+    def test_drifted_match_found_at_new_line(self):
+        # Two lines inserted above; excerpt now on line 4.
+        content = "import os\nimport sys\ndef f():\n    x = eval(data)\n"
+        reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
+        assert reloc.start_line == 4
+        assert reloc.status == "relocated"
+
+    def test_multiple_matches_picks_nearest_to_stored(self):
+        content = "x = eval(data)\n\n\nx = eval(data)\n"  # lines 1 and 4
+        reloc = relocate_finding(content, _finding(line_start=4, line_end=4))
+        assert reloc.start_line == 4
+
+    def test_excerpt_not_found_is_stale(self):
+        content = "def f():\n    return safe(data)\n"
+        reloc = relocate_finding(content, _finding())
+        assert reloc.status == "stale"
+
+    def test_empty_excerpt_falls_back_to_stored_lines(self):
+        content = "anything\n"
+        reloc = relocate_finding(
+            content, _finding(verbatim_excerpt="", line_start=7, line_end=9)
+        )
+        assert (reloc.start_line, reloc.end_line) == (7, 9)
+        assert reloc.status == "stored"
+
+    def test_reindented_excerpt_still_matches(self):
+        # Excerpt stored with 4-space indent; file now uses 8 spaces.
+        content = "def f():\n        x = eval(data)\n"
+        reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
+        assert reloc.status == "relocated"
+        assert reloc.start_line == 2

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -54,6 +54,16 @@ class TestRelocateFinding:
         assert reloc.status == "relocated"
         assert reloc.start_line == 2
 
+    def test_multiline_excerpt_relocates_span(self):
+        content = "import os\n\ndef f():\n    a = 1\n    return secret(a)\n"
+        f = _finding(
+            line_start=10, line_end=11,  # stale stored lines
+            verbatim_excerpt="def f():\n    a = 1\n    return secret(a)",
+        )
+        reloc = relocate_finding(content, f)
+        assert reloc.status == "relocated"
+        assert (reloc.start_line, reloc.end_line) == (3, 5)
+
 
 class TestBuildSarif:
     def _located(self, **over):
@@ -106,3 +116,18 @@ class TestBuildSarif:
         doc = build_sarif(self._located(id=7), tool_version="x",
                           corroborated_ids=frozenset({7}))
         assert doc["runs"][0]["results"][0]["properties"]["corroborated"] is True
+
+    def test_rule_level_promotes_to_worst_severity(self):
+        # Same category, low then critical → rule badge must be "error".
+        f_lo = _finding(id=1, category="bug", severity="low")
+        f_hi = _finding(id=2, category="bug", severity="critical")
+        located = [(f, relocate_finding("x = eval(data)\n", f)) for f in (f_lo, f_hi)]
+        doc = build_sarif(located, tool_version="x")
+        rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        bug_rule = next(r for r in rules if r["id"] == "ollama-sentinel/bug")
+        assert bug_rule["defaultConfiguration"]["level"] == "error"
+
+    def test_snippet_omitted_when_excerpt_empty(self):
+        doc = build_sarif(self._located(verbatim_excerpt=""), tool_version="x")
+        region = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+        assert "snippet" not in region

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,7 +1,7 @@
 """Tests for ollama_sentinel.sarif — relocation and SARIF construction."""
 import json
 
-from ollama_sentinel.sarif import Relocation, build_sarif, relocate_finding
+from ollama_sentinel.sarif import build_sarif, relocate_finding
 
 
 def _finding(**over):
@@ -135,8 +135,6 @@ class TestBuildSarif:
 
 import pathlib
 
-import pytest
-
 from ollama_sentinel.sarif import generate_sarif_file
 from ollama_sentinel.violation_db import Finding, ViolationDB
 
@@ -213,3 +211,66 @@ class TestGenerateSarifFile:
             db.close()
         assert summary.stale == 1
         assert summary.emitted == 0
+
+    def test_empty_excerpt_counts_as_unverified(self, tmp_path):
+        # Finding with no verbatim_excerpt on a present file → status "stored"
+        # → unverified += 1, still emitted.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("def f():\n    pass\n")
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/app.py", [
+            Finding("src/app.py", 1, 1, "bug", "low", "no excerpt",
+                    verbatim_excerpt=""),
+        ])
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="x",
+            )
+        finally:
+            db.close()
+        assert summary.emitted == 1
+        assert summary.unverified == 1
+        assert summary.relocated == 0
+        assert summary.stale == 0
+
+    def test_empty_db_writes_valid_sarif_with_zero_results(self, tmp_path):
+        # No findings at all → SARIF document is valid but contains no results.
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="x",
+            )
+        finally:
+            db.close()
+        assert summary.emitted == 0
+        assert summary.stale == 0
+        doc = json.loads(summary.path.read_text())
+        assert doc["version"] == "2.1.0"
+        assert doc["runs"][0]["results"] == []
+
+    def test_out_path_override_honored(self, tmp_path):
+        # Passing out_path writes to the given location, not the default.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text(
+            "def f():\n    x = eval(data)\n"
+        )
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/app.py", [
+            Finding("src/app.py", 2, 2, "security", "high", "eval",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+        custom_out = tmp_path / "custom" / "out.sarif"
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews",
+                tool_version="x", out_path=custom_out,
+            )
+        finally:
+            db.close()
+        assert summary.path == custom_out
+        assert custom_out.exists()
+        assert not (tmp_path / ".ollama_reviews" / "findings.sarif").exists()

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,5 +1,7 @@
 """Tests for ollama_sentinel.sarif — relocation and SARIF construction."""
-from ollama_sentinel.sarif import Relocation, relocate_finding
+import json
+
+from ollama_sentinel.sarif import Relocation, build_sarif, relocate_finding
 
 
 def _finding(**over):
@@ -51,3 +53,56 @@ class TestRelocateFinding:
         reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
         assert reloc.status == "relocated"
         assert reloc.start_line == 2
+
+
+class TestBuildSarif:
+    def _located(self, **over):
+        f = _finding(**over)
+        return [(f, relocate_finding("    x = eval(data)\n", f))]
+
+    def test_basic_document_shape(self):
+        doc = build_sarif(self._located(), tool_version="0.1.1")
+        assert doc["version"] == "2.1.0"
+        run = doc["runs"][0]
+        assert run["tool"]["driver"]["name"] == "ollama-sentinel"
+        assert run["tool"]["driver"]["version"] == "0.1.1"
+        assert len(run["results"]) == 1
+
+    def test_severity_maps_to_level(self):
+        cases = {"critical": "error", "high": "error",
+                 "medium": "warning", "low": "note", "weird": "warning"}
+        for severity, level in cases.items():
+            doc = build_sarif(self._located(severity=severity), tool_version="x")
+            assert doc["runs"][0]["results"][0]["level"] == level
+
+    def test_rules_deduped_by_category(self):
+        f1 = _finding(id=1, category="bug")
+        f2 = _finding(id=2, category="bug")
+        f3 = _finding(id=3, category="security")
+        located = [(f, relocate_finding("x = eval(data)\n", f)) for f in (f1, f2, f3)]
+        doc = build_sarif(located, tool_version="x")
+        rule_ids = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert rule_ids == {"ollama-sentinel/bug", "ollama-sentinel/security"}
+
+    def test_result_location_and_snippet(self):
+        doc = build_sarif(self._located(), tool_version="x")
+        loc = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "src/app.py"
+        assert loc["region"]["snippet"]["text"] == "x = eval(data)"
+
+    def test_fingerprint_stable_across_line_drift(self):
+        # Same finding, different stored lines → identical fingerprint.
+        a = _finding(line_start=2)
+        b = _finding(line_start=99)
+        fa = build_sarif([(a, relocate_finding("x = eval(data)\n", a))],
+                         tool_version="x")
+        fb = build_sarif([(b, relocate_finding("x = eval(data)\n", b))],
+                         tool_version="x")
+        fp_a = fa["runs"][0]["results"][0]["partialFingerprints"]["ollamaSentinel/v1"]
+        fp_b = fb["runs"][0]["results"][0]["partialFingerprints"]["ollamaSentinel/v1"]
+        assert fp_a == fp_b
+
+    def test_corroborated_flag_from_ids(self):
+        doc = build_sarif(self._located(id=7), tool_version="x",
+                          corroborated_ids=frozenset({7}))
+        assert doc["runs"][0]["results"][0]["properties"]["corroborated"] is True

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -131,3 +131,85 @@ class TestBuildSarif:
         doc = build_sarif(self._located(verbatim_excerpt=""), tool_version="x")
         region = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
         assert "snippet" not in region
+
+
+import pathlib
+
+import pytest
+
+from ollama_sentinel.sarif import generate_sarif_file
+from ollama_sentinel.violation_db import Finding, ViolationDB
+
+
+def _seed(db_path: pathlib.Path, file_path: str, findings):
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = ViolationDB(str(db_path))
+    db.persist_findings(file_path, findings)
+    db.close()
+
+
+class TestGenerateSarifFile:
+    def test_writes_sarif_for_open_findings(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text(
+            "def f():\n    x = eval(data)\n    return x\n"
+        )
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/app.py", [
+            Finding("src/app.py", 2, 2, "security", "high",
+                    "eval on untrusted input",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="0.1.1",
+            )
+        finally:
+            db.close()
+
+        assert summary.emitted == 1
+        assert summary.relocated == 1
+        assert summary.stale == 0
+        doc = json.loads(summary.path.read_text())
+        assert doc["runs"][0]["results"][0]["ruleId"] == "ollama-sentinel/security"
+
+    def test_stale_finding_excluded_and_counted(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        # File no longer contains the excerpt.
+        (tmp_path / "src" / "app.py").write_text("def f():\n    return ok\n")
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/app.py", [
+            Finding("src/app.py", 2, 2, "security", "high", "gone",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="x",
+            )
+        finally:
+            db.close()
+
+        assert summary.emitted == 0
+        assert summary.stale == 1
+        doc = json.loads(summary.path.read_text())
+        assert doc["runs"][0]["results"] == []
+
+    def test_missing_file_counts_as_stale(self, tmp_path):
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "src/gone.py", [
+            Finding("src/gone.py", 1, 1, "bug", "low", "x",
+                    verbatim_excerpt="whatever"),
+        ])
+        db = ViolationDB(str(db_path))
+        try:
+            summary = generate_sarif_file(
+                db, tmp_path, tmp_path / ".ollama_reviews", tool_version="x",
+            )
+        finally:
+            db.close()
+        assert summary.stale == 1
+        assert summary.emitted == 0

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -64,6 +64,19 @@ class TestRelocateFinding:
         assert reloc.status == "relocated"
         assert (reloc.start_line, reloc.end_line) == (3, 5)
 
+    def test_multiline_flattened_excerpt_relocates(self):
+        # The model emitted a multi-line region as a single flattened line
+        # (newlines collapsed to spaces). Line-block matching misses it; the
+        # word-sequence fallback finds it and maps back to the line span.
+        content = "import os\n\ndef f():\n    a = 1\n    return secret(a)\n"
+        f = _finding(
+            line_start=10, line_end=11,  # stale stored lines
+            verbatim_excerpt="def f(): a = 1 return secret(a)",
+        )
+        reloc = relocate_finding(content, f)
+        assert reloc.status == "relocated"
+        assert (reloc.start_line, reloc.end_line) == (3, 5)
+
 
 class TestBuildSarif:
     def _located(self, **over):

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -664,3 +664,22 @@ class TestVerbatimExcerptPersistence:
             db.close()
         assert "verbatim_excerpt" in rows[0]
         assert rows[0]["verbatim_excerpt"] is None  # legacy row: no excerpt
+
+    def test_upsert_keeps_first_excerpt(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings(
+                "src/app.py",
+                [_make_finding(verbatim_excerpt="first = excerpt()")],
+            )
+            # Re-persist the SAME finding location/category with a new excerpt.
+            db.persist_findings(
+                "src/app.py",
+                [_make_finding(verbatim_excerpt="second = excerpt()")],
+            )
+            rows = db.get_unresolved("src/app.py")
+        finally:
+            db.close()
+        assert len(rows) == 1  # upserted, not duplicated
+        assert rows[0]["occurrence_count"] == 2
+        assert rows[0]["verbatim_excerpt"] == "first = excerpt()"

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -615,3 +615,52 @@ class TestIncidents:
             assert tbl is not None
         finally:
             db2.close()
+
+
+class TestVerbatimExcerptPersistence:
+    """The finding's verbatim_excerpt must survive persist -> read."""
+
+    def test_persist_stores_verbatim_excerpt(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings(
+                "src/app.py",
+                [_make_finding(verbatim_excerpt="x = eval(data)")],
+            )
+            rows = db.get_unresolved("src/app.py")
+        finally:
+            db.close()
+        assert rows[0]["verbatim_excerpt"] == "x = eval(data)"
+
+    def test_migration_adds_column_to_legacy_db(self, tmp_path):
+        # A pre-existing DB created WITHOUT verbatim_excerpt (pre-this-feature).
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute(
+            """
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL, line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL, category TEXT NOT NULL,
+                severity TEXT NOT NULL, description TEXT NOT NULL,
+                first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL DEFAULT 1,
+                resolved INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO findings (file_path, line_start, line_end, category, "
+            "severity, description, first_seen, last_seen) "
+            "VALUES ('a.py', 1, 2, 'bug', 'low', 'd', 't', 't')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = ViolationDB(str(p))  # __init__ runs _migrate
+        try:
+            rows = db.get_unresolved("a.py")
+        finally:
+            db.close()
+        assert "verbatim_excerpt" in rows[0]
+        assert rows[0]["verbatim_excerpt"] is None  # legacy row: no excerpt

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -402,7 +402,6 @@ class TestShouldRunLegacyExtractor:
 # ---------------------------------------------------------------------------
 
 import json as _json
-import pathlib as _pathlib
 
 import yaml as _yaml
 
@@ -431,17 +430,15 @@ def _watcher_cfg(tmp_path):
     return p
 
 
-def _fake_review(*_a, **_k):
-    async def _run(file_change, model_role="default"):
-        return {
-            "summary": "review",
-            "findings": [{
-                "line_start": 2, "line_end": 2, "category": "security",
-                "severity": "high", "verbatim_excerpt": "x = eval(data)",
-                "description": "eval on untrusted input",
-            }],
-        }
-    return _run
+async def _fake_review(file_change, model_role="default"):
+    return {
+        "summary": "review",
+        "findings": [{
+            "line_start": 2, "line_end": 2, "category": "security",
+            "severity": "high", "verbatim_excerpt": "x = eval(data)",
+            "description": "eval on untrusted input",
+        }],
+    }
 
 
 class TestSarifAutoRefresh:
@@ -451,7 +448,7 @@ class TestSarifAutoRefresh:
         src.write_text("def f():\n    x = eval(data)\n    return x\n")
 
         sentinel = FileSentinel(cfg)
-        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review())
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review)
         try:
             await sentinel.process_change(
                 FileChange(path=src, change_type=Change.modified)
@@ -470,7 +467,7 @@ class TestSarifAutoRefresh:
         src.write_text("def f():\n    x = eval(data)\n    return x\n")
 
         sentinel = FileSentinel(cfg)
-        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review())
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review)
 
         import ollama_sentinel.sarif as sarif_mod
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -395,3 +395,96 @@ class TestShouldRunLegacyExtractor:
         src = inspect.getsource(w.FileSentinel.process_change)
         assert "_should_run_legacy_extractor(" in src
         assert "elif not self.config.processing.grounding:" not in src
+
+
+# ---------------------------------------------------------------------------
+# SARIF auto-refresh
+# ---------------------------------------------------------------------------
+
+import json as _json
+import pathlib as _pathlib
+
+import yaml as _yaml
+
+from watchfiles import Change
+from ollama_sentinel.processor import FileChange
+from ollama_sentinel.watcher import FileSentinel
+
+
+def _watcher_cfg(tmp_path):
+    """Config rooted at tmp_path: memory on, embeddings off (no network)."""
+    cfg = {
+        "watch": {"directory": str(tmp_path), "recursive": True},
+        "ollama": {
+            "host": "http://localhost:11434",
+            "models": {"default": {"name": "m", "system_prompt": "p"}},
+            "request_timeout": 30,
+        },
+        "processing": {"git_diff_mode": False, "grounding": True},
+        "output": {"directory": ".ollama_reviews", "console_output": False},
+        "memory": {"enabled": True, "db_path": ".ollama_reviews/memory.db",
+                   "semantic_recall": False, "structural_recall": False},
+        "embedding": {"enabled": False},
+    }
+    p = tmp_path / "ollama-sentinel.yaml"
+    p.write_text(_yaml.dump(cfg, sort_keys=False))
+    return p
+
+
+def _fake_review(*_a, **_k):
+    async def _run(file_change, model_role="default"):
+        return {
+            "summary": "review",
+            "findings": [{
+                "line_start": 2, "line_end": 2, "category": "security",
+                "severity": "high", "verbatim_excerpt": "x = eval(data)",
+                "description": "eval on untrusted input",
+            }],
+        }
+    return _run
+
+
+class TestSarifAutoRefresh:
+    async def test_process_change_writes_sarif(self, tmp_path, monkeypatch):
+        cfg = _watcher_cfg(tmp_path)
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+
+        sentinel = FileSentinel(cfg)
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review())
+        try:
+            await sentinel.process_change(
+                FileChange(path=src, change_type=Change.modified)
+            )
+        finally:
+            await sentinel.processor.close()
+
+        sarif = tmp_path / ".ollama_reviews" / "findings.sarif"
+        assert sarif.exists()
+        doc = _json.loads(sarif.read_text())
+        assert doc["runs"][0]["results"][0]["ruleId"] == "ollama-sentinel/security"
+
+    async def test_sarif_failure_does_not_break_review(self, tmp_path, monkeypatch):
+        cfg = _watcher_cfg(tmp_path)
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+
+        sentinel = FileSentinel(cfg)
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review())
+
+        import ollama_sentinel.sarif as sarif_mod
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("sarif blew up")
+
+        monkeypatch.setattr(sarif_mod, "generate_sarif_file", _boom)
+        try:
+            # Must NOT raise despite the SARIF failure.
+            await sentinel.process_change(
+                FileChange(path=src, change_type=Change.modified)
+            )
+        finally:
+            await sentinel.processor.close()
+
+        # The review itself still saved.
+        assert (tmp_path / ".ollama_reviews" / "app.md").exists()


### PR DESCRIPTION
## What this does

Makes the findings Ollama Sentinel stores in its `ViolationDB` **actionable** for the first time. Until now findings only fed back into future review prompts (recall) — you couldn't see one in your editor, act on one, or even close one. This is slice 1 of the "make findings actionable" arc: **surface** them where you edit.

A new `surface` command (and automatic refresh while `run` is active) serializes open findings to `.ollama_reviews/findings.sarif` — the standard static-analysis format. One artifact, two consumers:

- **VS Code / Cursor** via the SARIF Viewer extension → Problems panel, click-to-jump.
- **GitHub code scanning** in CI via `upload-sarif` → Security tab + inline PR annotations.

Findings are **re-anchored to their current line by `verbatim_excerpt`**, not the stored line number, so line drift doesn't produce wrong locations. A finding whose excerpt is gone is reported as stale and excluded (never chased as a ghost).

```
$ ollama-sentinel surface
Wrote 7 findings → .ollama_reviews/findings.sarif (5 relocated, 0 unverified, 2 stale)
```

## How it's built (4 stacked pieces, TDD)

1. **Persist the excerpt** — `verbatim_excerpt` was discarded at persist time; added the column (fresh + legacy DBs via idempotent migration) and write it.
2. **SARIF pure core** — `relocate_finding` (excerpt re-anchoring; drift, reindent, multi-line, multi-match-nearest, stale) + `build_sarif` (SARIF 2.1.0; severity→level, rule dedup, drift-stable `partialFingerprints`, worst-severity rule levels).
3. **Orchestration + CLI** — `generate_sarif_file` (read-only: excludes+counts stale, never mutates state) + the `surface` command.
4. **Watcher auto-refresh** — best-effort hook so a SARIF failure can never break review saving (proven by a failure-isolation test).

## Design invariants

- **Read-only**: never edits source, never mutates finding/DB state. Stale findings are reported, not auto-resolved (that's the triage slice, later).
- **Failure-isolated**: SARIF refresh and corroboration lookup both degrade silently; review saving always proceeds.

## Verification

- 587 passed, 15 skipped.
- Real end-to-end CLI smoke: `surface` against a seeded DB produced valid SARIF 2.1.0 — finding relocated to its current line, planted stale finding correctly excluded + counted.
- Two-stage review (spec + quality) on every piece, plus a final whole-feature review.

The final review caught one integration seam (the upstream verbatim-validation gate collapses newlines while relocation required exact line-block equality, so a model-flattened multi-line excerpt could persist but relocate as a ghost). **Fixed in this PR** (`fix(sarif): relocate flattened multi-line excerpts via word-sequence fallback`) with a test.

## Docs

- Spec: `docs/superpowers/specs/2026-06-03-surface-findings-sarif-design.md`
- Plan: `docs/superpowers/plans/2026-06-03-surface-findings-sarif.md`
- `CLAUDE.md` + `README.md` updated with the command and module.

## Known minor follow-ups (non-blocking)

- `uriBaseId: "SRCROOT"` is set without a matching `originalUriBaseIds` — tolerated by GitHub/VSCode; relative URIs resolve against repo root.
- No end-to-end test of `properties.corroborated: true` through `generate_sarif_file` (the pure `build_sarif` path is covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)