### PR TITLE
feat: findings triage — list / resolve / dismiss (actionability slice 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ ollama-sentinel incidents           # list corroborated events (table or -f json
 ollama-sentinel install-hooks       # install the git post-commit hook
 ollama-sentinel record-commit       # link HEAD to open Findings (called by the hook)
 ollama-sentinel surface             # emit open Findings to .ollama_reviews/findings.sarif (editor Problems panel + CI)
+ollama-sentinel findings            # list open Findings with ids (filter: --severity/--file)
+ollama-sentinel resolve 42          # close Finding 42 as fixed (resolution='fixed')
+ollama-sentinel dismiss 31          # close Finding 31 as false-positive (resolution='dismissed')
 
 python -m research_agent.main query "question" --context file.py --output result.md
 python -m research_agent.main interactive
@@ -126,7 +129,7 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 | `ollama_sentinel/extractor.py` | LLM JSON extraction + regex fallback for parsing review findings |
 | `ollama_sentinel/watcher.py` | FileSentinel, file watching, ignore logic, pipeline orchestration |
 | `ollama_sentinel/models.py` | Pydantic v2 config models: Ollama/Embedding/Memory/Processing with validators |
-| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface |
+| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss |
 | `ollama_sentinel/pytest_plugin.py` | Opt-in pytest plugin: matches test failures to open Findings, records `test_failure` Incidents (`pytest11` entry point) |
 | `ollama_sentinel/hooks.py` | Git post-commit hook installer + `record_commit` (links commits to open Findings) |
 | `ollama_sentinel/dashboard.py` | Live Rich TUI for `ollama-sentinel dashboard` — polls reviews dir + ViolationDB read-only |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The "I always forget what to run" table.
 | Corroborate a finding | `ollama-sentinel confirm 42` | Records a `manual_confirm` Incident; the Finding stays open |
 | See corroborated events | `ollama-sentinel incidents`<br>or `ollama-sentinel incidents -f json` | Incidents (test failures, confirmations, fix commits) as a table or JSON |
 | Surface findings in your editor | `ollama-sentinel surface` | Writes `.ollama_reviews/findings.sarif`; open it in VS Code/Cursor (SARIF Viewer → Problems panel) or upload it in CI for GitHub code scanning. Findings are re-anchored to current lines by excerpt; `run` refreshes it automatically |
+| List open findings | `ollama-sentinel findings`<br>or `… --severity high --file foo.py` | Table with ids, ranked by severity then frequency; `-f json` for machine-readable |
+| Close a finding | `ollama-sentinel resolve 42` / `ollama-sentinel dismiss 31` | `resolve` = fixed, `dismiss` = false-positive; records why so the dismiss rate is a usable signal |
 | Link commits to findings | `ollama-sentinel install-hooks` | Installs a git post-commit hook that records which commit touched each open Finding |
 | Auto-link test failures | add `ollama_sentinel = true` to your pytest config | A failing test on a flagged line becomes a `test_failure` Incident |
 | Create a config file | `ollama-sentinel init` | Writes `ollama-sentinel.yaml` in the current dir |

--- a/docs/superpowers/plans/2026-06-03-findings-triage.md
+++ b/docs/superpowers/plans/2026-06-03-findings-triage.md
@@ -1,0 +1,901 @@
+# Findings Triage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let developers list open findings with IDs and close them — `resolve` (fixed) / `dismiss` (false-positive) — recording why each closed.
+
+**Architecture:** One nullable `resolution` column on the `findings` table, an extended `mark_resolved` (gains a `resolution` kwarg, returns a row count), two new read methods (`get_finding`, `get_open_findings`), and three CLI commands (`findings`, `resolve`, `dismiss`) that mirror the existing `report`/`incidents`/`confirm` commands.
+
+**Tech Stack:** Python 3.10+, SQLite (`ViolationDB`), Typer + Rich (CLI), pytest (`tmp_path`, class-based).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-findings-triage-design.md`
+
+**Branch:** `feat/findings-triage` (already created; the spec commit `c137b5d` is its first commit).
+
+**Stacking:** Three pieces, one PR each, stacked linearly. Pieces 2 and 3 both depend on Piece 1's column + methods.
+
+---
+
+## File Structure
+
+| File | Responsibility | Piece |
+|------|----------------|-------|
+| `ollama_sentinel/violation_db.py` *(modify)* | `resolution` column + migration; `mark_resolved` gains `resolution`, returns count; new `get_finding`, `get_open_findings` | 1 |
+| `ollama_sentinel/cli.py` *(modify)* | `findings` list command; `resolve`/`dismiss` commands + shared `_close_finding` helper | 2, 3 |
+| `tests/test_violation_db.py` *(modify)* | resolution persistence, migration, `get_finding`, `get_open_findings` | 1 |
+| `tests/test_cli.py` *(modify)* | `findings`, `resolve`, `dismiss` command tests | 2, 3 |
+| `CLAUDE.md` + `README.md` *(modify)* | document the three commands | docs |
+
+---
+
+## Piece 1: Schema + DB methods (PR 1)
+
+### Task 1.1: `resolution` column + `mark_resolved` records it and returns a count
+
+**Files:**
+- Modify: `ollama_sentinel/violation_db.py` (`_CREATE_TABLE`, `_migrate`, `mark_resolved`)
+- Test: `tests/test_violation_db.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_violation_db.py` (it already imports `sqlite3`, `pytest`, and `Finding, ViolationDB`, and defines `_make_finding(**overrides)`):
+
+```python
+def _read_row(db, finding_id):
+    """Read one findings row as a dict via raw SQL (avoids depending on
+    get_finding, which is implemented in a later task)."""
+    cur = db._conn.execute("SELECT * FROM findings WHERE id = ?", (finding_id,))
+    cols = [d[0] for d in cur.description]
+    row = cur.fetchone()
+    return dict(zip(cols, row)) if row else None
+
+
+class TestResolution:
+    """resolution column + mark_resolved behavior."""
+
+    def test_mark_resolved_records_fixed(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            n = db.mark_resolved(fid, resolution="fixed")
+            row = _read_row(db, fid)
+        finally:
+            db.close()
+        assert n == 1
+        assert row["resolved"] == 1
+        assert row["resolution"] == "fixed"
+
+    def test_mark_resolved_records_dismissed(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, resolution="dismissed")
+            row = _read_row(db, fid)
+        finally:
+            db.close()
+        assert row["resolution"] == "dismissed"
+
+    def test_mark_resolved_no_reason_leaves_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            n = db.mark_resolved(fid)
+            row = _read_row(db, fid)
+        finally:
+            db.close()
+        assert n == 1
+        assert row["resolved"] == 1
+        assert row["resolution"] is None
+
+    def test_mark_resolved_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.mark_resolved(424242, resolution="fixed") == 0
+        finally:
+            db.close()
+
+    def test_mark_resolved_fix_commit_still_creates_incident(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, fix_commit="abc123")
+            row = _read_row(db, fid)
+            incidents = db.get_incidents_for_finding(fid)
+        finally:
+            db.close()
+        assert row["resolved"] == 1
+        assert row["fix_commit_sha"] == "abc123"
+        assert len(incidents) == 1
+        assert incidents[0]["confirming_signal"] == "fix_commit"
+
+    def test_mark_resolved_fix_commit_and_resolution_together(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, fix_commit="abc123", resolution="fixed")
+            row = _read_row(db, fid)
+            incidents = db.get_incidents_for_finding(fid)
+        finally:
+            db.close()
+        assert row["fix_commit_sha"] == "abc123"
+        assert row["resolution"] == "fixed"
+        assert len(incidents) == 1
+
+    def test_migration_adds_resolution_column_to_legacy_db(self, tmp_path):
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute(
+            """
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL, line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL, category TEXT NOT NULL,
+                severity TEXT NOT NULL, description TEXT NOT NULL,
+                first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL DEFAULT 1,
+                resolved INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO findings (file_path, line_start, line_end, category, "
+            "severity, description, first_seen, last_seen) "
+            "VALUES ('a.py', 1, 2, 'bug', 'low', 'd', 't', 't')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = ViolationDB(str(p))  # __init__ runs _migrate
+        try:
+            row = _read_row(db, 1)
+        finally:
+            db.close()
+        assert "resolution" in row
+        assert row["resolution"] is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_violation_db.py::TestResolution -v`
+Expected: FAIL — `mark_resolved()` rejects the `resolution=` kwarg (`TypeError: unexpected keyword argument 'resolution'`).
+
+- [ ] **Step 3: Add the column to the fresh-DB schema**
+
+In `_CREATE_TABLE`, change the `verbatim_excerpt TEXT` line to end with a comma and add the new column:
+
+```python
+            embed_text      TEXT,
+            verbatim_excerpt TEXT,
+            resolution      TEXT
+```
+
+- [ ] **Step 4: Add the legacy-DB migration**
+
+In `_migrate`, after the existing `verbatim_excerpt` block and before the final `self._conn.commit()`:
+
+```python
+                if "resolution" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN resolution TEXT"
+                    )
+```
+
+- [ ] **Step 5: Rewrite `mark_resolved`**
+
+Replace the entire `mark_resolved` method with this version (adds `resolution`, returns the row count, preserves the `fix_commit` Incident path):
+
+```python
+    def mark_resolved(
+        self,
+        finding_id: int,
+        *,
+        fix_commit: Optional[str] = None,
+        resolution: Optional[str] = None,
+    ) -> int:
+        """Set ``resolved=1`` for the given finding; return rows updated.
+
+        Optionally records a ``resolution`` reason ('fixed' | 'dismissed' |
+        'stale') and/or a ``fix_commit``. When ``fix_commit`` is provided, also
+        sets ``fix_commit_sha`` and inserts an Incident with
+        ``confirming_signal='fix_commit'`` (unchanged from v0.2). ``fix_commit``
+        and ``resolution`` may both be supplied and both apply. Returns the
+        number of finding rows updated — 0 means no finding has that id.
+        """
+        sets = ["resolved = 1"]
+        params: list = []
+        if resolution is not None:
+            sets.append("resolution = ?")
+            params.append(resolution)
+        if fix_commit is not None:
+            sets.append("fix_commit_sha = ?")
+            params.append(fix_commit)
+        params.append(finding_id)
+
+        with self._lock:
+            cur = self._conn.execute(
+                f"UPDATE findings SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
+            )
+            self._conn.commit()
+            rowcount = cur.rowcount
+
+        if fix_commit is not None:
+            self.persist_incident(
+                Incident(
+                    finding_id=finding_id,
+                    confirming_signal="fix_commit",
+                    confirming_artifact=fix_commit,
+                    fix_commit=fix_commit,
+                )
+            )
+        return rowcount
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_violation_db.py -v`
+Expected: PASS (new `TestResolution` class + all existing violation_db tests, including any that call the old `mark_resolved` shape).
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `pytest tests/ -q`
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ollama_sentinel/violation_db.py tests/test_violation_db.py
+git commit -m "feat(violation_db): record resolution reason; mark_resolved returns count"
+```
+
+### Task 1.2: `get_finding` + `get_open_findings`
+
+**Files:**
+- Modify: `ollama_sentinel/violation_db.py` (add two read methods near the other read methods, e.g. after `get_unresolved`)
+- Test: `tests/test_violation_db.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_violation_db.py`:
+
+```python
+class TestGetFinding:
+    def test_returns_row_for_real_id(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            row = db.get_finding(fid)
+        finally:
+            db.close()
+        assert row is not None
+        assert row["id"] == fid
+        assert row["file_path"] == "a.py"
+
+    def test_returns_none_for_missing_id(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.get_finding(424242) is None
+        finally:
+            db.close()
+
+
+class TestGetOpenFindings:
+    def test_orders_by_severity_critical_first(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=1, severity="low",
+                              category="style"),
+            ])
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=2, severity="critical",
+                              category="security"),
+            ])
+            rows = db.get_open_findings()
+        finally:
+            db.close()
+        assert rows[0]["severity"] == "critical"
+        assert rows[-1]["severity"] == "low"
+
+    def test_orders_by_count_within_severity(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            # Same severity; finding A seen 3x, finding B seen 1x.
+            for _ in range(3):
+                db.persist_findings("a.py", [
+                    _make_finding(file_path="a.py", line_start=1, severity="high",
+                                  category="bug", description="A"),
+                ])
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=2, severity="high",
+                              category="bug", description="B"),
+            ])
+            rows = db.get_open_findings()
+        finally:
+            db.close()
+        assert rows[0]["occurrence_count"] == 3
+        assert rows[0]["description"] == "A"
+
+    def test_severity_filter(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=1, severity="high",
+                              description="HighOnly"),
+            ])
+            db.persist_findings("b.py", [
+                _make_finding(file_path="b.py", line_start=2, severity="low",
+                              description="LowOnly", category="style"),
+            ])
+            rows = db.get_open_findings(severity="low")
+        finally:
+            db.close()
+        assert len(rows) == 1
+        assert rows[0]["description"] == "LowOnly"
+
+    def test_file_substr_filter_case_insensitive(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("src/App.py", [
+                _make_finding(file_path="src/App.py", line_start=1,
+                              description="inApp"),
+            ])
+            db.persist_findings("other.py", [
+                _make_finding(file_path="other.py", line_start=2,
+                              description="inOther", category="style"),
+            ])
+            rows = db.get_open_findings(file_substr="app")
+        finally:
+            db.close()
+        assert len(rows) == 1
+        assert rows[0]["description"] == "inApp"
+
+    def test_excludes_resolved(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=1, description="open"),
+            ])
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=2, description="closed",
+                              category="style"),
+            ])
+            closed_id = next(
+                r["id"] for r in db.get_unresolved("a.py")
+                if r["description"] == "closed"
+            )
+            db.mark_resolved(closed_id, resolution="fixed")
+            rows = db.get_open_findings()
+        finally:
+            db.close()
+        descs = {r["description"] for r in rows}
+        assert descs == {"open"}
+
+    def test_limit_caps_rows(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            for i in range(3):
+                db.persist_findings("a.py", [
+                    _make_finding(file_path="a.py", line_start=i + 1,
+                                  category=f"c{i}"),
+                ])
+            rows = db.get_open_findings(limit=2)
+        finally:
+            db.close()
+        assert len(rows) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_violation_db.py::TestGetFinding tests/test_violation_db.py::TestGetOpenFindings -v`
+Expected: FAIL — `AttributeError: 'ViolationDB' object has no attribute 'get_finding'`.
+
+- [ ] **Step 3: Add the two read methods**
+
+In `ollama_sentinel/violation_db.py`, add after the `get_unresolved` method:
+
+```python
+    def get_finding(self, finding_id: int) -> Optional[dict]:
+        """Return the single findings row for *finding_id*, or None.
+
+        Returns the row regardless of resolved state — callers use it to detect
+        a bad id before mutating.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM findings WHERE id = ?", (finding_id,)
+            )
+            rows = self._rows_to_dicts(cur)
+        return rows[0] if rows else None
+
+    def get_open_findings(
+        self,
+        *,
+        severity: Optional[str] = None,
+        file_substr: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[dict]:
+        """Return unresolved findings, filtered and ranked for triage.
+
+        Ordered by severity (critical → low) then ``occurrence_count`` DESC.
+        ``severity`` is an exact match; ``file_substr`` is a case-insensitive
+        substring of ``file_path``. ``limit`` caps the rows returned.
+        """
+        clauses = ["resolved = 0"]
+        params: list = []
+        if severity is not None:
+            clauses.append("severity = ?")
+            params.append(severity)
+        if file_substr is not None:
+            clauses.append("LOWER(file_path) LIKE ?")
+            params.append(f"%{file_substr.lower()}%")
+        where = " AND ".join(clauses)
+        params.append(limit)
+        with self._lock:
+            cur = self._conn.execute(
+                f"""
+                SELECT * FROM findings
+                WHERE {where}
+                ORDER BY
+                    CASE severity
+                        WHEN 'critical' THEN 4
+                        WHEN 'high'     THEN 3
+                        WHEN 'medium'   THEN 2
+                        WHEN 'low'      THEN 1
+                        ELSE 0
+                    END DESC,
+                    occurrence_count DESC
+                LIMIT ?
+                """,
+                tuple(params),
+            )
+            return self._rows_to_dicts(cur)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_violation_db.py -v`
+Expected: PASS (TestGetFinding + TestGetOpenFindings + everything prior).
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pytest tests/ -q`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ollama_sentinel/violation_db.py tests/test_violation_db.py
+git commit -m "feat(violation_db): add get_finding and get_open_findings"
+```
+
+---
+
+## Piece 2: `findings` list command (PR 2)
+
+### Task 2.1: `ollama-sentinel findings`
+
+**Files:**
+- Modify: `ollama_sentinel/cli.py` (add `findings` command after the `incidents` command, before `surface`)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_cli.py` (it has `_make_report_config`, `_seed_db`, `runner`, `json`, and imports `Finding, ViolationDB`):
+
+```python
+class TestFindingsCommand:
+    """Tests for 'ollama-sentinel findings'."""
+
+    def test_lists_open_findings_with_ids(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_db(db_path, [
+            Finding("src/app.py", 10, 12, "bug", "high", "Null deref risk"),
+        ])
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        assert "Null" in result.output and "deref" in result.output
+        assert "high" in result.output
+
+    def test_json_format(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_db(db_path, [Finding("src/app.py", 1, 2, "bug", "high", "d")])
+        result = runner.invoke(app, ["findings", "--config", str(cfg), "-f", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert data[0]["severity"] == "high"
+
+    def test_severity_filter(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        db.persist_findings("a.py", [Finding("a.py", 1, 1, "bug", "high", "HighOnly")])
+        db.persist_findings("b.py", [Finding("b.py", 2, 2, "style", "low", "LowOnly")])
+        db.close()
+        result = runner.invoke(app, ["findings", "--config", str(cfg), "--severity", "low"])
+        assert result.exit_code == 0
+        assert "LowOnly" in result.output
+        assert "HighOnly" not in result.output
+
+    def test_file_filter(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        db.persist_findings("src/app.py", [Finding("src/app.py", 1, 1, "bug", "high", "inApp")])
+        db.persist_findings("other.py", [Finding("other.py", 2, 2, "style", "low", "inOther")])
+        db.close()
+        result = runner.invoke(app, ["findings", "--config", str(cfg), "--file", "app"])
+        assert result.exit_code == 0
+        assert "inApp" in result.output
+        assert "inOther" not in result.output
+
+    def test_empty_db(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No open findings" in result.output
+
+    def test_no_db_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No violation database" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_cli.py::TestFindingsCommand -v`
+Expected: FAIL — `findings` is not a registered command.
+
+- [ ] **Step 3: Add the `findings` command**
+
+In `ollama_sentinel/cli.py`, after the `incidents` command (ends with its `console.print(table)`) and before the `surface` command:
+
+```python
+@app.command()
+def findings(
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    severity: Optional[str] = typer.Option(
+        None, "--severity", help="Filter by exact severity (e.g. high)",
+    ),
+    file_substr: Optional[str] = typer.Option(
+        None, "--file", help="Filter by file-path substring (case-insensitive)",
+    ),
+    limit: int = typer.Option(
+        50, "--limit", "-l", help="Maximum number of findings to show",
+    ),
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="Output format: table or json",
+    ),
+):
+    """List open (unresolved) findings with their ids for resolve/dismiss."""
+    import json as json_mod
+
+    from rich.table import Table
+
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    db_path = pathlib.Path(config.watch.directory).resolve() / config.memory.db_path
+    if not db_path.exists():
+        console.print(
+            "[yellow]No violation database found. Run some reviews first.[/yellow]"
+        )
+        raise typer.Exit()
+
+    db = ViolationDB(str(db_path))
+    try:
+        rows = db.get_open_findings(
+            severity=severity, file_substr=file_substr, limit=limit,
+        )
+        corroborated: set = set()
+        if rows:
+            paths = sorted({r["file_path"] for r in rows})
+            corroborated = {
+                r["id"] for r in db.get_findings_with_incidents(paths)
+            }
+    finally:
+        db.close()
+
+    if not rows:
+        console.print("[green]No open findings.[/green]")
+        raise typer.Exit()
+
+    if output_format == "json":
+        console.print(json_mod.dumps(rows, indent=2))
+        return
+
+    table = Table(title=f"Open findings ({len(rows)})")
+    table.add_column("ID", style="bold", width=5)
+    table.add_column("Sev", width=9)
+    table.add_column("Cat", width=10)
+    table.add_column("Location", style="cyan")
+    table.add_column("Count", width=6)
+    table.add_column("Corr", width=5)
+    table.add_column("Description")
+
+    for r in rows:
+        table.add_row(
+            str(r["id"]),
+            r["severity"],
+            r["category"],
+            f"{r['file_path']}:{r['line_start']}",
+            str(r["occurrence_count"]),
+            "✓" if r["id"] in corroborated else "",
+            (r["description"] or "")[:60],
+        )
+    console.print(table)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cli.py::TestFindingsCommand -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pytest tests/ -q`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ollama_sentinel/cli.py tests/test_cli.py
+git commit -m "feat(cli): add 'findings' command to list open findings with ids"
+```
+
+---
+
+## Piece 3: `resolve` / `dismiss` commands (PR 3)
+
+### Task 3.1: `ollama-sentinel resolve` / `dismiss`
+
+**Files:**
+- Modify: `ollama_sentinel/cli.py` (add a `_close_finding` module-level helper + the two commands, after the `confirm` command)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_cli.py` (uses the existing `_seed_one_finding_id` helper):
+
+```python
+class TestResolveCommand:
+    """Tests for 'ollama-sentinel resolve'."""
+
+    def test_resolve_marks_fixed(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+        result = runner.invoke(app, ["resolve", str(fid), "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        db = ViolationDB(str(db_path))
+        try:
+            row = db.get_finding(fid)
+            assert row["resolved"] == 1
+            assert row["resolution"] == "fixed"
+            assert db.get_open_findings() == []
+        finally:
+            db.close()
+
+    def test_resolve_missing_id(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        result = runner.invoke(app, ["resolve", "99999", "--config", str(cfg)])
+        assert result.exit_code == 1
+        assert "No finding with id" in result.output
+
+    def test_resolve_no_db(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["resolve", "1", "--config", str(cfg)])
+        assert result.exit_code == 1
+        assert "No violation database" in result.output
+
+
+class TestDismissCommand:
+    """Tests for 'ollama-sentinel dismiss'."""
+
+    def test_dismiss_marks_dismissed(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+        result = runner.invoke(app, ["dismiss", str(fid), "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        db = ViolationDB(str(db_path))
+        try:
+            row = db.get_finding(fid)
+            assert row["resolved"] == 1
+            assert row["resolution"] == "dismissed"
+            assert db.get_open_findings() == []
+        finally:
+            db.close()
+
+    def test_dismiss_missing_id(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        result = runner.invoke(app, ["dismiss", "99999", "--config", str(cfg)])
+        assert result.exit_code == 1
+        assert "No finding with id" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_cli.py::TestResolveCommand tests/test_cli.py::TestDismissCommand -v`
+Expected: FAIL — `resolve`/`dismiss` are not registered commands.
+
+- [ ] **Step 3: Add the shared helper + the two commands**
+
+In `ollama_sentinel/cli.py`, after the `confirm` command, add:
+
+```python
+def _close_finding(
+    finding_id: int, config_path: str, *, resolution: str, past: str, tail: str
+) -> None:
+    """Shared body for resolve/dismiss: validate id, mark_resolved, report.
+
+    ``resolution`` is the stored reason ('fixed'/'dismissed'); ``past`` and
+    ``tail`` shape the success line, e.g. "Resolved finding 42 (fixed)."
+    """
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    db_path = pathlib.Path(config.watch.directory).resolve() / config.memory.db_path
+    if not db_path.exists():
+        console.print("[red]No violation database found.[/red]")
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        if db.get_finding(finding_id) is None:
+            console.print(f"[red]No finding with id {finding_id}.[/red]")
+            raise typer.Exit(code=1)
+        db.mark_resolved(finding_id, resolution=resolution)
+    finally:
+        db.close()
+
+    console.print(f"[green]{past} finding {finding_id} ({tail}).[/green]")
+
+
+@app.command()
+def resolve(
+    finding_id: int = typer.Argument(..., help="ID of the Finding to resolve"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Mark a Finding resolved (fixed). Records resolution='fixed'."""
+    _close_finding(
+        finding_id, config_path, resolution="fixed",
+        past="Resolved", tail="fixed",
+    )
+
+
+@app.command()
+def dismiss(
+    finding_id: int = typer.Argument(..., help="ID of the Finding to dismiss"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Dismiss a Finding as a false-positive / won't-fix. Records resolution='dismissed'."""
+    _close_finding(
+        finding_id, config_path, resolution="dismissed",
+        past="Dismissed", tail="false-positive",
+    )
+```
+
+Note: `typer.Exit(code=1)` raised inside the `try` still runs the `finally` (`db.close()`) before propagating — exit code 1 is preserved.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cli.py::TestResolveCommand tests/test_cli.py::TestDismissCommand -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pytest tests/ -q`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ollama_sentinel/cli.py tests/test_cli.py
+git commit -m "feat(cli): add 'resolve' and 'dismiss' commands to close findings"
+```
+
+---
+
+## Final: docs
+
+### Task 4.1: Document the three commands
+
+**Files:**
+- Modify: `CLAUDE.md` (Build & Run command list; `cli.py` module-table row)
+- Modify: `README.md` (Common tasks table)
+
+- [ ] **Step 1: Add to the CLAUDE.md command list**
+
+In `CLAUDE.md`, under "Build & Run", after the `ollama-sentinel surface` line, add:
+
+```
+ollama-sentinel findings            # list open Findings with ids (filter: --severity/--file)
+ollama-sentinel resolve 42          # close Finding 42 as fixed (resolution='fixed')
+ollama-sentinel dismiss 31          # close Finding 31 as false-positive (resolution='dismissed')
+```
+
+- [ ] **Step 2: Update the `cli.py` module-table row in CLAUDE.md**
+
+Change the `cli.py` row's verb list to append `findings, resolve, dismiss`:
+
+```
+| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss |
+```
+
+- [ ] **Step 3: Add README "Common tasks" rows**
+
+In `README.md`, after the `Surface findings in your editor` row, add:
+
+```
+| List open findings | `ollama-sentinel findings`<br>or `… --severity high --file foo.py` | Table with ids, ranked by severity then frequency; `-f json` for machine-readable |
+| Close a finding | `ollama-sentinel resolve 42` / `ollama-sentinel dismiss 31` | `resolve` = fixed, `dismiss` = false-positive; records why so the dismiss rate is a usable signal |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: document findings/resolve/dismiss commands"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `resolution` column (fresh + legacy migration) → Task 1.1 ✓
+- `mark_resolved(resolution=, returns int)`, `fix_commit` path preserved → Task 1.1 ✓
+- `get_finding` → Task 1.2 ✓
+- `get_open_findings` (severity exact, file substring case-insensitive, severity-then-count ordering, limit, excludes resolved) → Task 1.2 ✓
+- `findings` command (filters, table/json, corroborated ✓, no-DB, empty, pure DB read) → Task 2.1 ✓
+- `resolve`/`dismiss` (single id, validate via get_finding, resolution recorded, no Incident, friendly messages, exit codes) → Task 3.1 ✓
+- Manual close creates no Incident → Task 3.1 (`_close_finding` calls `mark_resolved` with only `resolution=`, never `fix_commit=`) ✓
+- Docs → Task 4.1 ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✓
+
+**Type consistency:** `mark_resolved(finding_id, *, fix_commit=None, resolution=None) -> int`, `get_finding(finding_id) -> Optional[dict]`, `get_open_findings(*, severity=None, file_substr=None, limit=50) -> List[dict]`, `_close_finding(finding_id, config_path, *, resolution, past, tail)` — names/signatures identical across defining and calling tasks. The `findings` command reads dict keys (`id`, `severity`, `category`, `file_path`, `line_start`, `occurrence_count`, `description`) that `get_open_findings` returns via `_rows_to_dicts`. ✓
+
+**Note for the implementer:** `Finding`'s positional constructor is `(file_path, line_start, line_end, category, severity, description, verbatim_excerpt="")`. The test seeds use that order. `_make_finding(**overrides)` in `test_violation_db.py` defaults `file_path="src/app.py"`, so tests that persist under a different path pass `file_path=` explicitly AND vary `line_start`/`category` so the upsert key differs (otherwise persisting "two" findings just increments one row's `occurrence_count`).

--- a/docs/superpowers/specs/2026-06-03-findings-triage-design.md
+++ b/docs/superpowers/specs/2026-06-03-findings-triage-design.md
@@ -1,0 +1,185 @@
+# Findings triage — design
+
+**Date:** 2026-06-03
+**Status:** Approved (brainstorm), pending implementation plan
+**Slice:** 2 of N in the "make findings actionable" arc (after surface/SARIF, PR #14)
+
+## Problem
+
+`ViolationDB` accumulates findings forever. `mark_resolved` exists but **no CLI
+command calls it** — there is no way to close a finding, and no way to list
+open findings with the IDs you'd need to act on one. The surface slice made
+findings *visible*; this slice makes them *closeable*, and records why each one
+closed so the dismiss rate becomes a usable signal of model quality (this
+project has known AI-slop issues, so "how often is the model wrong" matters).
+
+> Naming: the slice is internally called "triage," but `triage` is already a
+> command (log diagnosis). This slice's commands are **`findings`**,
+> **`resolve`**, **`dismiss`** — no collision.
+
+## Scope
+
+Three commands plus the schema + DB methods they need:
+
+- **`findings`** — list open findings with IDs.
+- **`resolve <id>`** — mark a finding fixed.
+- **`dismiss <id>`** — mark a finding a false-positive / won't-fix.
+
+### Explicitly out of scope (later or never)
+
+- **Stale auto-resolve / `prune`** — its own follow-up slice; it's a
+  relocation-driven batch automation (reuses `sarif.relocate_finding`) with its
+  own design. The `resolution` column reserves `'stale'` for it.
+- **Reopen / unresolve** — YAGNI.
+- **Batch ids** (`resolve 42 31 12`) — single id per call, matching `confirm`.
+- **Free-form `--note`** — would need another column; the fixed/dismissed
+  reason is the signal.
+- **Listing resolved findings** (`findings --resolved`) — `findings` lists open
+  findings only. Reporting on closed findings is a separate concern.
+
+## Design
+
+### Piece 1 — schema + DB methods (`ollama_sentinel/violation_db.py`)
+
+**Column.** Add one nullable column to the `findings` table, via the same
+two-place idempotent pattern used for `verbatim_excerpt`/`embed_text` (add to
+`_CREATE_TABLE` for fresh DBs; add to `_migrate` guarded by the existing `cols`
+check for legacy DBs):
+
+- `resolution TEXT` — `'fixed' | 'dismissed'` (reserves `'stale'` for the prune
+  slice). NULL for open findings and legacy rows.
+
+**`mark_resolved` gains a `resolution` parameter and returns a count.** New
+signature:
+
+```
+mark_resolved(finding_id, *, fix_commit=None, resolution=None) -> int
+```
+
+Behavior:
+- Always sets `resolved = 1` for the row with `finding_id`.
+- When `resolution` is not None, also sets `resolution = <value>`.
+- When `fix_commit` is not None, also sets `fix_commit_sha` and inserts a
+  `fix_commit` Incident — unchanged from today. `fix_commit` and `resolution`
+  may both be supplied and both apply.
+- Returns the number of finding rows updated (`cursor.rowcount`): **0** means no
+  finding has that id. Existing callers that ignore the return value are
+  unaffected (None → int is backward-safe).
+
+A manual close records lifecycle state on the finding row and creates **no
+Incident** (Incidents are for objective corroboration; a human closing a finding
+is not corroboration). This matches the existing single-arg `mark_resolved`.
+
+**Two new read methods:**
+
+- `get_finding(finding_id) -> Optional[dict]` — return the single row (any
+  `resolved` state) or None. Used by `resolve`/`dismiss` to detect a bad id
+  before mutating.
+- `get_open_findings(*, severity=None, file_substr=None, limit=50) -> List[dict]`
+  — unresolved findings, optionally filtered by exact `severity` and by
+  `file_substr` (case-insensitive `LIKE %substr%` on `file_path`), ordered by
+  severity rank then `occurrence_count DESC`. Severity rank is a SQL `CASE`:
+  critical=4, high=3, medium=2, low=1, else 0. `limit` caps rows.
+
+### Piece 2 — `findings` list command (`ollama_sentinel/cli.py`)
+
+Mirrors the `report` / `incidents` command shape: `_load_config_or_exit`,
+`db_path = watch_dir / config.memory.db_path`, friendly
+`No violation database found` message + clean exit when the DB is absent,
+open + `try/finally` close.
+
+```
+ollama-sentinel findings [-c CONFIG] [--severity SEV] [--file SUBSTR]
+                         [--limit N] [-f table|json]
+```
+
+- Calls `get_open_findings(severity=..., file_substr=..., limit=...)`.
+- Corroborated flag: one `get_findings_with_incidents([...paths...])` call; a
+  finding id in that set renders a `✓` in a "Corr" column.
+- Pure DB read — no file I/O. (Staleness needs file reads + relocation and
+  belongs to the prune slice.)
+- Table columns: `ID, Sev, Cat, Location (file:line_start), Count, Corr,
+  Description (truncated)`. `json` format prints the raw list (include
+  `resolution: null` naturally since it's an open-finding row).
+- Empty result → green "No open findings." and clean exit.
+
+### Piece 3 — `resolve` / `dismiss` commands (`ollama_sentinel/cli.py`)
+
+Both follow the `confirm` command's structure (single positional id,
+`_load_config_or_exit`, no-DB guard, `try/finally` close):
+
+```
+ollama-sentinel resolve <finding_id> [-c CONFIG]
+ollama-sentinel dismiss <finding_id> [-c CONFIG]
+```
+
+- Resolve `db_path`; if absent → red "No violation database found." + exit 1.
+- `get_finding(finding_id)`; if None → red
+  `No finding with id <n>; nothing to <verb>.` + exit 1.
+- Else `mark_resolved(finding_id, resolution='fixed')` (resolve) or
+  `resolution='dismissed'` (dismiss).
+- Success message:
+  - resolve → green `Resolved finding 42 (fixed).`
+  - dismiss → green `Dismissed finding 31 (false-positive).`
+- Re-resolving an already-closed finding is idempotent (still exit 0; the row
+  exists so `get_finding` is non-None and the UPDATE re-applies the same state).
+
+## Data shapes
+
+`ViolationDB` rows are dicts with `id`, `file_path`, `line_start`, `line_end`,
+`category`, `severity`, `description`, `verbatim_excerpt`, `occurrence_count`,
+`resolved`, `embed_text`, `triggering_commit_sha`, `fix_commit_sha`, and (new)
+`resolution`. `get_open_findings` returns `resolved = 0` rows; those always have
+`resolution IS NULL`.
+
+## Testing
+
+`tests/test_violation_db.py`:
+- `resolution` round-trips: `mark_resolved(id, resolution='fixed')` then read →
+  `resolved == 1`, `resolution == 'fixed'`; same for `'dismissed'`.
+- `mark_resolved` with no `resolution` leaves `resolution` NULL (backward compat)
+  and still resolves.
+- `mark_resolved` returns 1 for an existing id, 0 for a missing id.
+- `fix_commit` + `resolution` together: both `fix_commit_sha`, `resolution` set,
+  and a `fix_commit` Incident created (existing behavior preserved).
+- Legacy migration: a pre-column DB opened via `ViolationDB` gains a NULL
+  `resolution` column on existing rows.
+- `get_finding`: returns the row for a real id, None for a missing id.
+- `get_open_findings`: severity filter (exact), file_substr filter
+  (case-insensitive substring), ordering (critical before low; within a
+  severity, higher `occurrence_count` first), `limit`, and that resolved
+  findings are excluded.
+
+`tests/test_cli.py`:
+- `findings`: table output shows seeded findings with their ids; `-f json`
+  parses to a list; `--severity` and `--file` filter; empty DB → "No open
+  findings"; no DB file → "No violation database"; `--limit` caps.
+- `resolve <id>`: exit 0, success message, and the finding's `resolution` is
+  `'fixed'` and it no longer appears in `get_open_findings`.
+- `dismiss <id>`: exit 0, `resolution == 'dismissed'`, leaves the open list.
+- `resolve`/`dismiss` on a nonexistent id: exit 1 + "No finding with id".
+
+## Decisions
+
+- **Record the reason (`resolution` column), not a bare flag.** `resolve` and
+  `dismiss` are semantically different; collapsing both to `resolved=1` loses
+  the false-positive signal this project specifically cares about. One nullable
+  column is cheap and mirrors the migration we just did.
+- **Manual close is lifecycle, not an Incident.** Incidents corroborate that a
+  finding is real; a human resolving/dismissing is the opposite kind of event.
+  Keep it on the finding row. (`fix_commit`-driven resolution still makes an
+  Incident — a commit is objective evidence — and that path is untouched.)
+- **`findings` is a pure DB read.** No file I/O, no staleness column — that
+  needs relocation and is the prune slice's job. Keeps `findings` fast and
+  consistent with `report`/`incidents`.
+- **Single id, no note, open-only, no reopen.** YAGNI; each is a clean future
+  add if needed. Matches the `confirm` command's shape.
+
+## Risk
+
+Low. One nullable column (idempotent migration, legacy-safe), one extended
+method (backward-compatible — new kwarg, return type None→int), two new read
+methods, three CLI commands that mirror existing ones. No file writes, no new
+process. The only behavioral subtlety — `mark_resolved` now returns a count and
+accepts `resolution` — is additive and covered by tests that also assert the
+existing `fix_commit` Incident path is preserved.

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -440,6 +440,64 @@ def confirm(
     )
 
 
+def _close_finding(
+    finding_id: int, config_path: str, *, resolution: str, past: str, tail: str
+) -> None:
+    """Shared body for resolve/dismiss: validate id, mark_resolved, report.
+
+    ``resolution`` is the stored reason ('fixed'/'dismissed'); ``past`` and
+    ``tail`` shape the success line, e.g. "Resolved finding 42 (fixed)."
+    """
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    db_path = pathlib.Path(config.watch.directory).resolve() / config.memory.db_path
+    if not db_path.exists():
+        console.print("[red]No violation database found.[/red]")
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        if db.get_finding(finding_id) is None:
+            console.print(f"[red]No finding with id {finding_id}.[/red]")
+            raise typer.Exit(code=1)
+        db.mark_resolved(finding_id, resolution=resolution)
+    finally:
+        db.close()
+
+    console.print(f"[green]{past} finding {finding_id} ({tail}).[/green]")
+
+
+@app.command()
+def resolve(
+    finding_id: int = typer.Argument(..., help="ID of the Finding to resolve"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Mark a Finding resolved (fixed). Records resolution='fixed'."""
+    _close_finding(
+        finding_id, config_path, resolution="fixed",
+        past="Resolved", tail="fixed",
+    )
+
+
+@app.command()
+def dismiss(
+    finding_id: int = typer.Argument(..., help="ID of the Finding to dismiss"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Dismiss a Finding as a false-positive / won't-fix. Records resolution='dismissed'."""
+    _close_finding(
+        finding_id, config_path, resolution="dismissed",
+        past="Dismissed", tail="false-positive",
+    )
+
+
 @app.command()
 def incidents(
     config_path: str = typer.Option(

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -441,12 +441,14 @@ def confirm(
 
 
 def _close_finding(
-    finding_id: int, config_path: str, *, resolution: str, past: str, tail: str
+    finding_id: int, config_path: str, *,
+    resolution: str, action: str, past: str, tail: str,
 ) -> None:
     """Shared body for resolve/dismiss: validate id, mark_resolved, report.
 
-    ``resolution`` is the stored reason ('fixed'/'dismissed'); ``past`` and
-    ``tail`` shape the success line, e.g. "Resolved finding 42 (fixed)."
+    ``resolution`` is the stored reason ('fixed'/'dismissed'); ``action`` is the
+    bare verb for the not-found message; ``past`` and ``tail`` shape the success
+    line, e.g. "Resolved finding 42 (fixed)."
     """
     from .violation_db import ViolationDB
 
@@ -459,7 +461,10 @@ def _close_finding(
     db = ViolationDB(str(db_path))
     try:
         if db.get_finding(finding_id) is None:
-            console.print(f"[red]No finding with id {finding_id}.[/red]")
+            console.print(
+                f"[red]No finding with id {finding_id}; "
+                f"nothing to {action}.[/red]"
+            )
             raise typer.Exit(code=1)
         db.mark_resolved(finding_id, resolution=resolution)
     finally:
@@ -479,7 +484,7 @@ def resolve(
     """Mark a Finding resolved (fixed). Records resolution='fixed'."""
     _close_finding(
         finding_id, config_path, resolution="fixed",
-        past="Resolved", tail="fixed",
+        action="resolve", past="Resolved", tail="fixed",
     )
 
 
@@ -494,7 +499,7 @@ def dismiss(
     """Dismiss a Finding as a false-positive / won't-fix. Records resolution='dismissed'."""
     _close_finding(
         finding_id, config_path, resolution="dismissed",
-        past="Dismissed", tail="false-positive",
+        action="dismiss", past="Dismissed", tail="false-positive",
     )
 
 

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -523,6 +523,84 @@ def incidents(
 
 
 @app.command()
+def findings(
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    severity: Optional[str] = typer.Option(
+        None, "--severity", help="Filter by exact severity (e.g. high)",
+    ),
+    file_substr: Optional[str] = typer.Option(
+        None, "--file", help="Filter by file-path substring (case-insensitive)",
+    ),
+    limit: int = typer.Option(
+        50, "--limit", "-l", help="Maximum number of findings to show",
+    ),
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="Output format: table or json",
+    ),
+):
+    """List open (unresolved) findings with their ids for resolve/dismiss."""
+    import json as json_mod
+
+    from rich.table import Table
+
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    db_path = pathlib.Path(config.watch.directory).resolve() / config.memory.db_path
+    if not db_path.exists():
+        console.print(
+            "[yellow]No violation database found. Run some reviews first.[/yellow]"
+        )
+        raise typer.Exit()
+
+    db = ViolationDB(str(db_path))
+    try:
+        rows = db.get_open_findings(
+            severity=severity, file_substr=file_substr, limit=limit,
+        )
+        corroborated: set = set()
+        if rows:
+            paths = sorted({r["file_path"] for r in rows})
+            corroborated = {
+                r["id"] for r in db.get_findings_with_incidents(paths)
+            }
+    finally:
+        db.close()
+
+    if not rows:
+        console.print("[green]No open findings.[/green]")
+        raise typer.Exit()
+
+    if output_format == "json":
+        console.print(json_mod.dumps(rows, indent=2))
+        return
+
+    table = Table(title=f"Open findings ({len(rows)})")
+    table.add_column("ID", style="bold", width=5)
+    table.add_column("Sev", width=9)
+    table.add_column("Cat", width=10)
+    table.add_column("Location", style="cyan")
+    table.add_column("Count", width=6)
+    table.add_column("Corr", width=5)
+    table.add_column("Description")
+
+    for r in rows:
+        table.add_row(
+            str(r["id"]),
+            r["severity"],
+            r["category"],
+            f"{r['file_path']}:{r['line_start']}",
+            str(r["occurrence_count"]),
+            "✓" if r["id"] in corroborated else "",
+            (r["description"] or "")[:60],
+        )
+    console.print(table)
+
+
+@app.command()
 def surface(
     config_path: str = typer.Option(
         "ollama-sentinel.yaml", "--config", "-c",

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -402,7 +402,9 @@ class ViolationDB:
 
         Ordered by severity (critical → low) then ``occurrence_count`` DESC.
         ``severity`` is an exact match; ``file_substr`` is a case-insensitive
-        substring of ``file_path``. ``limit`` caps the rows returned.
+        substring of ``file_path`` (matched with SQL ``LIKE``, so any ``%`` or
+        ``_`` in the term act as wildcards — only ever broadening the match,
+        never missing one). ``limit`` caps the rows returned.
         """
         clauses = ["resolved = 0"]
         params: list = []

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -94,7 +94,7 @@ class ViolationDB:
         self._migrate()
 
     def _migrate(self) -> None:
-        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt)."""
+        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt, resolution)."""
         try:
             with self._lock:
                 cur = self._conn.execute("PRAGMA table_info(findings)")
@@ -237,7 +237,7 @@ class ViolationDB:
             self._conn.commit()
             rowcount = cur.rowcount
 
-        if fix_commit is not None:
+        if fix_commit is not None and rowcount > 0:
             self.persist_incident(
                 Incident(
                     finding_id=finding_id,

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -59,7 +59,8 @@ class ViolationDB:
             occurrence_count INTEGER NOT NULL DEFAULT 1,
             resolved        INTEGER NOT NULL DEFAULT 0,
             embed_text      TEXT,
-            verbatim_excerpt TEXT
+            verbatim_excerpt TEXT,
+            resolution      TEXT
         )
     """
 
@@ -121,6 +122,10 @@ class ViolationDB:
                 if "verbatim_excerpt" not in cols:
                     self._conn.execute(
                         "ALTER TABLE findings ADD COLUMN verbatim_excerpt TEXT"
+                    )
+                if "resolution" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN resolution TEXT"
                     )
                 self._conn.commit()
         except sqlite3.DatabaseError as e:
@@ -199,36 +204,49 @@ class ViolationDB:
                 raise
 
     def mark_resolved(
-        self, finding_id: int, *, fix_commit: Optional[str] = None
-    ) -> None:
-        """Set ``resolved=1`` for the given finding.
+        self,
+        finding_id: int,
+        *,
+        fix_commit: Optional[str] = None,
+        resolution: Optional[str] = None,
+    ) -> int:
+        """Set ``resolved=1`` for the given finding; return rows updated.
 
-        Behavioral change (v0.2): when ``fix_commit`` is provided, also
-        records ``fix_commit_sha`` on the finding and inserts an Incident
-        with ``confirming_signal='fix_commit'``. The old single-argument
-        call shape is unchanged and creates no Incident.
+        Optionally records a ``resolution`` reason ('fixed' | 'dismissed' |
+        'stale') and/or a ``fix_commit``. When ``fix_commit`` is provided, also
+        sets ``fix_commit_sha`` and inserts an Incident with
+        ``confirming_signal='fix_commit'`` (unchanged from v0.2). ``fix_commit``
+        and ``resolution`` may both be supplied and both apply. Returns the
+        number of finding rows updated — 0 means no finding has that id.
         """
+        sets = ["resolved = 1"]
+        params: list = []
+        if resolution is not None:
+            sets.append("resolution = ?")
+            params.append(resolution)
+        if fix_commit is not None:
+            sets.append("fix_commit_sha = ?")
+            params.append(fix_commit)
+        params.append(finding_id)
+
         with self._lock:
-            if fix_commit is None:
-                self._conn.execute(
-                    "UPDATE findings SET resolved = 1 WHERE id = ?",
-                    (finding_id,),
-                )
-                self._conn.commit()
-                return
-            self._conn.execute(
-                "UPDATE findings SET resolved = 1, fix_commit_sha = ? WHERE id = ?",
-                (fix_commit, finding_id),
+            cur = self._conn.execute(
+                f"UPDATE findings SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
             )
             self._conn.commit()
-        self.persist_incident(
-            Incident(
-                finding_id=finding_id,
-                confirming_signal="fix_commit",
-                confirming_artifact=fix_commit,
-                fix_commit=fix_commit,
+            rowcount = cur.rowcount
+
+        if fix_commit is not None:
+            self.persist_incident(
+                Incident(
+                    finding_id=finding_id,
+                    confirming_signal="fix_commit",
+                    confirming_artifact=fix_commit,
+                    fix_commit=fix_commit,
+                )
             )
-        )
+        return rowcount
 
     def persist_incident(self, incident: Incident) -> int:
         """Insert an Incident row and return its new id. Never upserts."""

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -378,6 +378,62 @@ class ViolationDB:
             )
             return self._rows_to_dicts(cur)
 
+    def get_finding(self, finding_id: int) -> Optional[dict]:
+        """Return the single findings row for *finding_id*, or None.
+
+        Returns the row regardless of resolved state — callers use it to detect
+        a bad id before mutating.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM findings WHERE id = ?", (finding_id,)
+            )
+            rows = self._rows_to_dicts(cur)
+        return rows[0] if rows else None
+
+    def get_open_findings(
+        self,
+        *,
+        severity: Optional[str] = None,
+        file_substr: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[dict]:
+        """Return unresolved findings, filtered and ranked for triage.
+
+        Ordered by severity (critical → low) then ``occurrence_count`` DESC.
+        ``severity`` is an exact match; ``file_substr`` is a case-insensitive
+        substring of ``file_path``. ``limit`` caps the rows returned.
+        """
+        clauses = ["resolved = 0"]
+        params: list = []
+        if severity is not None:
+            clauses.append("severity = ?")
+            params.append(severity)
+        if file_substr is not None:
+            clauses.append("LOWER(file_path) LIKE ?")
+            params.append(f"%{file_substr.lower()}%")
+        where = " AND ".join(clauses)
+        params.append(limit)
+        with self._lock:
+            cur = self._conn.execute(
+                f"""
+                SELECT * FROM findings
+                WHERE {where}
+                ORDER BY
+                    CASE severity
+                        WHEN 'critical' THEN 4
+                        WHEN 'high'     THEN 3
+                        WHEN 'medium'   THEN 2
+                        WHEN 'low'      THEN 1
+                        ELSE 0
+                    END DESC,
+                    occurrence_count DESC
+                LIMIT ?
+                """,
+                tuple(params),
+            )
+            return self._rows_to_dicts(cur)
+
     def get_all_unresolved(self) -> List[dict]:
         """Return every unresolved finding across all files."""
         with self._lock:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -551,3 +551,75 @@ class TestSurfaceCommand:
         result = runner.invoke(app, ["surface", "--config", str(cfg)])
         assert result.exit_code == 0
         assert "No violation database" in result.output
+
+
+class TestFindingsCommand:
+    """Tests for 'ollama-sentinel findings'."""
+
+    def test_lists_open_findings_with_ids(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_db(db_path, [
+            Finding("src/app.py", 10, 12, "bug", "high", "Null deref risk"),
+        ])
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        assert "Null" in result.output and "deref" in result.output
+        assert "high" in result.output
+
+    def test_json_format(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_db(db_path, [Finding("src/app.py", 1, 2, "bug", "high", "d")])
+        result = runner.invoke(app, ["findings", "--config", str(cfg), "-f", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert data[0]["severity"] == "high"
+
+    def test_severity_filter(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        db.persist_findings("a.py", [Finding("a.py", 1, 1, "bug", "high", "HighOnly")])
+        db.persist_findings("b.py", [Finding("b.py", 2, 2, "style", "low", "LowOnly")])
+        db.close()
+        result = runner.invoke(app, ["findings", "--config", str(cfg), "--severity", "low"])
+        assert result.exit_code == 0
+        assert "LowOnly" in result.output
+        assert "HighOnly" not in result.output
+
+    def test_file_filter(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        db.persist_findings("src/app.py", [Finding("src/app.py", 1, 1, "bug", "high", "inApp")])
+        db.persist_findings("other.py", [Finding("other.py", 2, 2, "style", "low", "inOther")])
+        db.close()
+        result = runner.invoke(app, ["findings", "--config", str(cfg), "--file", "app"])
+        assert result.exit_code == 0
+        assert "inApp" in result.output
+        assert "inOther" not in result.output
+
+    def test_empty_db(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No open findings" in result.output
+
+    def test_no_db_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No violation database" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -623,3 +623,33 @@ class TestFindingsCommand:
         result = runner.invoke(app, ["findings", "--config", str(cfg)])
         assert result.exit_code == 0
         assert "No violation database" in result.output
+
+    def test_limit_caps_results(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        # Three distinct findings (different line numbers so upsert creates 3 rows).
+        db.persist_findings("a.py", [
+            Finding("a.py", 1, 1, "bug", "high", "F1"),
+            Finding("a.py", 2, 2, "bug", "high", "F2"),
+            Finding("a.py", 3, 3, "bug", "high", "F3"),
+        ])
+        db.close()
+        result = runner.invoke(
+            app, ["findings", "--config", str(cfg), "-f", "json", "--limit", "2"]
+        )
+        assert result.exit_code == 0
+        assert len(json.loads(result.output)) == 2
+
+    def test_corroborated_mark_renders(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("COLUMNS", "200")
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+        _seed_incident(db_path, finding_id=fid)
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        assert "✓" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,3 +653,75 @@ class TestFindingsCommand:
         result = runner.invoke(app, ["findings", "--config", str(cfg)])
         assert result.exit_code == 0, result.output
         assert "✓" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Task 3.1 — `ollama-sentinel resolve` / `dismiss`
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCommand:
+    """Tests for 'ollama-sentinel resolve'."""
+
+    def test_resolve_marks_fixed(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+        result = runner.invoke(app, ["resolve", str(fid), "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        db = ViolationDB(str(db_path))
+        try:
+            row = db.get_finding(fid)
+            assert row["resolved"] == 1
+            assert row["resolution"] == "fixed"
+            assert db.get_open_findings() == []
+        finally:
+            db.close()
+
+    def test_resolve_missing_id(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        result = runner.invoke(app, ["resolve", "99999", "--config", str(cfg)])
+        assert result.exit_code == 1
+        assert "No finding with id" in result.output
+
+    def test_resolve_no_db(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["resolve", "1", "--config", str(cfg)])
+        assert result.exit_code == 1
+        assert "No violation database" in result.output
+
+
+class TestDismissCommand:
+    """Tests for 'ollama-sentinel dismiss'."""
+
+    def test_dismiss_marks_dismissed(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+        result = runner.invoke(app, ["dismiss", str(fid), "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        db = ViolationDB(str(db_path))
+        try:
+            row = db.get_finding(fid)
+            assert row["resolved"] == 1
+            assert row["resolution"] == "dismissed"
+            assert db.get_open_findings() == []
+        finally:
+            db.close()
+
+    def test_dismiss_missing_id(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        result = runner.invoke(app, ["dismiss", "99999", "--config", str(cfg)])
+        assert result.exit_code == 1
+        assert "No finding with id" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -676,6 +676,8 @@ class TestResolveCommand:
             assert row["resolved"] == 1
             assert row["resolution"] == "fixed"
             assert db.get_open_findings() == []
+            # CRITICAL invariant: manual close must NOT create an Incident
+            assert db.get_incidents_for_finding(fid) == []
         finally:
             db.close()
 
@@ -713,6 +715,8 @@ class TestDismissCommand:
             assert row["resolved"] == 1
             assert row["resolution"] == "dismissed"
             assert db.get_open_findings() == []
+            # CRITICAL invariant: manual close must NOT create an Incident
+            assert db.get_incidents_for_finding(fid) == []
         finally:
             db.close()
 

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -683,3 +683,121 @@ class TestVerbatimExcerptPersistence:
         assert len(rows) == 1  # upserted, not duplicated
         assert rows[0]["occurrence_count"] == 2
         assert rows[0]["verbatim_excerpt"] == "first = excerpt()"
+
+
+def _read_row(db, finding_id):
+    """Read one findings row as a dict via raw SQL (avoids depending on
+    get_finding, which is implemented in a later task)."""
+    cur = db._conn.execute("SELECT * FROM findings WHERE id = ?", (finding_id,))
+    cols = [d[0] for d in cur.description]
+    row = cur.fetchone()
+    return dict(zip(cols, row)) if row else None
+
+
+class TestResolution:
+    """resolution column + mark_resolved behavior."""
+
+    def test_mark_resolved_records_fixed(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            n = db.mark_resolved(fid, resolution="fixed")
+            row = _read_row(db, fid)
+        finally:
+            db.close()
+        assert n == 1
+        assert row["resolved"] == 1
+        assert row["resolution"] == "fixed"
+
+    def test_mark_resolved_records_dismissed(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, resolution="dismissed")
+            row = _read_row(db, fid)
+        finally:
+            db.close()
+        assert row["resolution"] == "dismissed"
+
+    def test_mark_resolved_no_reason_leaves_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            n = db.mark_resolved(fid)
+            row = _read_row(db, fid)
+        finally:
+            db.close()
+        assert n == 1
+        assert row["resolved"] == 1
+        assert row["resolution"] is None
+
+    def test_mark_resolved_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.mark_resolved(424242, resolution="fixed") == 0
+        finally:
+            db.close()
+
+    def test_mark_resolved_fix_commit_still_creates_incident(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, fix_commit="abc123")
+            row = _read_row(db, fid)
+            incidents = db.get_incidents_for_finding(fid)
+        finally:
+            db.close()
+        assert row["resolved"] == 1
+        assert row["fix_commit_sha"] == "abc123"
+        assert len(incidents) == 1
+        assert incidents[0]["confirming_signal"] == "fix_commit"
+
+    def test_mark_resolved_fix_commit_and_resolution_together(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, fix_commit="abc123", resolution="fixed")
+            row = _read_row(db, fid)
+            incidents = db.get_incidents_for_finding(fid)
+        finally:
+            db.close()
+        assert row["fix_commit_sha"] == "abc123"
+        assert row["resolution"] == "fixed"
+        assert len(incidents) == 1
+
+    def test_migration_adds_resolution_column_to_legacy_db(self, tmp_path):
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute(
+            """
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL, line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL, category TEXT NOT NULL,
+                severity TEXT NOT NULL, description TEXT NOT NULL,
+                first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL DEFAULT 1,
+                resolved INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO findings (file_path, line_start, line_end, category, "
+            "severity, description, first_seen, last_seen) "
+            "VALUES ('a.py', 1, 2, 'bug', 'low', 'd', 't', 't')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = ViolationDB(str(p))  # __init__ runs _migrate
+        try:
+            row = _read_row(db, 1)
+        finally:
+            db.close()
+        assert "resolution" in row
+        assert row["resolution"] is None

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -802,6 +802,36 @@ class TestResolution:
         assert "resolution" in row
         assert row["resolution"] is None
 
+    def test_mark_resolved_already_resolved_rowcount_stays_one(self, tmp_path):
+        """Re-resolving an already-resolved finding reports rowcount 1 (SQLite
+        updates the row even when the value is unchanged). Documents this
+        semantics so callers aren't surprised.
+        """
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, resolution="fixed")
+            n2 = db.mark_resolved(fid, resolution="dismissed")
+        finally:
+            db.close()
+        assert n2 == 1  # row found; SQLite reports rowcount=1 even if already resolved
+
+    def test_mark_resolved_missing_id_with_fix_commit_returns_zero_no_incident(
+        self, tmp_path
+    ):
+        """fix_commit on a nonexistent finding_id must return 0, not raise IntegrityError,
+        and must not create a dangling Incident row.
+        """
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            n = db.mark_resolved(424242, fix_commit="abc123")
+            incidents = db.get_incidents_for_finding(424242)
+        finally:
+            db.close()
+        assert n == 0
+        assert incidents == []
+
 
 # ---------------------------------------------------------------------------
 # Task 1.2: get_finding + get_open_findings
@@ -827,6 +857,20 @@ class TestGetFinding:
             assert db.get_finding(424242) is None
         finally:
             db.close()
+
+    def test_returns_resolved_finding_too(self, tmp_path):
+        """get_finding must return the row regardless of resolved state."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.mark_resolved(fid, resolution="stale")
+            row = db.get_finding(fid)
+        finally:
+            db.close()
+        assert row is not None
+        assert row["resolved"] == 1
+        assert row["resolution"] == "stale"
 
 
 class TestGetOpenFindings:
@@ -933,3 +977,43 @@ class TestGetOpenFindings:
         finally:
             db.close()
         assert len(rows) == 2
+
+    def test_both_filters_together(self, tmp_path):
+        """severity= and file_substr= both applied simultaneously."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("src/auth.py", [
+                _make_finding(file_path="src/auth.py", line_start=1,
+                              severity="critical", description="auth-critical"),
+            ])
+            db.persist_findings("src/auth.py", [
+                _make_finding(file_path="src/auth.py", line_start=2,
+                              severity="low", description="auth-low", category="style"),
+            ])
+            db.persist_findings("other/util.py", [
+                _make_finding(file_path="other/util.py", line_start=1,
+                              severity="critical", description="util-critical"),
+            ])
+            rows = db.get_open_findings(severity="critical", file_substr="src")
+        finally:
+            db.close()
+        assert len(rows) == 1
+        assert rows[0]["description"] == "auth-critical"
+
+    def test_unknown_severity_sorts_last(self, tmp_path):
+        """Severities not in the CASE expression (ELSE 0) rank below 'low'."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=1, severity="low",
+                              description="known-low"),
+            ])
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=2, severity="custom",
+                              description="unknown-sev"),
+            ])
+            rows = db.get_open_findings()
+        finally:
+            db.close()
+        assert rows[0]["severity"] == "low"
+        assert rows[-1]["severity"] == "custom"

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -801,3 +801,135 @@ class TestResolution:
             db.close()
         assert "resolution" in row
         assert row["resolution"] is None
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2: get_finding + get_open_findings
+# ---------------------------------------------------------------------------
+
+
+class TestGetFinding:
+    def test_returns_row_for_real_id(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [_make_finding(file_path="a.py")])
+            fid = db.get_unresolved("a.py")[0]["id"]
+            row = db.get_finding(fid)
+        finally:
+            db.close()
+        assert row is not None
+        assert row["id"] == fid
+        assert row["file_path"] == "a.py"
+
+    def test_returns_none_for_missing_id(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.get_finding(424242) is None
+        finally:
+            db.close()
+
+
+class TestGetOpenFindings:
+    def test_orders_by_severity_critical_first(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=1, severity="low",
+                              category="style"),
+            ])
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=2, severity="critical",
+                              category="security"),
+            ])
+            rows = db.get_open_findings()
+        finally:
+            db.close()
+        assert rows[0]["severity"] == "critical"
+        assert rows[-1]["severity"] == "low"
+
+    def test_orders_by_count_within_severity(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            # Same severity; finding A seen 3x, finding B seen 1x.
+            for _ in range(3):
+                db.persist_findings("a.py", [
+                    _make_finding(file_path="a.py", line_start=1, severity="high",
+                                  category="bug", description="A"),
+                ])
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=2, severity="high",
+                              category="bug", description="B"),
+            ])
+            rows = db.get_open_findings()
+        finally:
+            db.close()
+        assert rows[0]["occurrence_count"] == 3
+        assert rows[0]["description"] == "A"
+
+    def test_severity_filter(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=1, severity="high",
+                              description="HighOnly"),
+            ])
+            db.persist_findings("b.py", [
+                _make_finding(file_path="b.py", line_start=2, severity="low",
+                              description="LowOnly", category="style"),
+            ])
+            rows = db.get_open_findings(severity="low")
+        finally:
+            db.close()
+        assert len(rows) == 1
+        assert rows[0]["description"] == "LowOnly"
+
+    def test_file_substr_filter_case_insensitive(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("src/App.py", [
+                _make_finding(file_path="src/App.py", line_start=1,
+                              description="inApp"),
+            ])
+            db.persist_findings("other.py", [
+                _make_finding(file_path="other.py", line_start=2,
+                              description="inOther", category="style"),
+            ])
+            rows = db.get_open_findings(file_substr="app")
+        finally:
+            db.close()
+        assert len(rows) == 1
+        assert rows[0]["description"] == "inApp"
+
+    def test_excludes_resolved(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=1, description="open"),
+            ])
+            db.persist_findings("a.py", [
+                _make_finding(file_path="a.py", line_start=2, description="closed",
+                              category="style"),
+            ])
+            closed_id = next(
+                r["id"] for r in db.get_unresolved("a.py")
+                if r["description"] == "closed"
+            )
+            db.mark_resolved(closed_id, resolution="fixed")
+            rows = db.get_open_findings()
+        finally:
+            db.close()
+        descs = {r["description"] for r in rows}
+        assert descs == {"open"}
+
+    def test_limit_caps_rows(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            for i in range(3):
+                db.persist_findings("a.py", [
+                    _make_finding(file_path="a.py", line_start=i + 1,
+                                  category=f"c{i}"),
+                ])
+            rows = db.get_open_findings(limit=2)
+        finally:
+            db.close()
+        assert len(rows) == 2


### PR DESCRIPTION
## What this does

Slice 2 of the "make findings actionable" arc (after surface/SARIF, #14). Findings could be *seen* but not *closed* — `mark_resolved` existed with no CLI caller, so findings accumulated forever and there was no way to list them with the IDs you'd need to act on one. This adds that.

Three commands:

```
$ ollama-sentinel findings                    # list open findings, ranked by severity then frequency
 ID  Sev       Cat       Location          Count  Corr  Description
 1   critical  security  src/app.py:2      1            num_ctx set unconditionally…
 7   high      bug       processor.py:178  3      ✓      eval on untrusted input…

$ ollama-sentinel resolve 7    # → Resolved finding 7 (fixed).
$ ollama-sentinel dismiss 1    # → Dismissed finding 1 (false-positive).
```

`findings` supports `--severity`, `--file`, `--limit`, `-f json`. `resolve`/`dismiss` take a single id and validate it (bad id → exit 1, no silent no-op).

## Why record *why* it closed

A new nullable `resolution` column distinguishes `resolve` (`'fixed'`) from `dismiss` (`'dismissed'`). This project has known model-quality issues, so the **dismiss rate is the signal** for how often the model is wrong — collapsing both to a bare `resolved` flag would throw that away. The column reserves `'stale'` for the next slice.

## How it's built (3 stacked pieces, TDD)

1. **Schema + DB methods** — `resolution` column (+ idempotent legacy migration); `mark_resolved(id, *, fix_commit=None, resolution=None) -> int` (returns a row count, preserves the `fix_commit` Incident path, and now guards `persist_incident` on `rowcount > 0` so a missing-id + fix_commit no longer raises an FK error); new `get_finding` + `get_open_findings`.
2. **`findings`** — pure DB read, mirrors `report`/`incidents`, corroborated `✓` from incidents.
3. **`resolve`/`dismiss`** — shared `_close_finding` helper, mirrors `confirm`.

## Design invariants

- **Manual close is lifecycle, not corroboration** — `resolve`/`dismiss` record `resolution` and create **no Incident** (Incidents stay for objective corroboration; the `fix_commit`-driven close still makes one). Regression-locked by a test asserting `get_incidents_for_finding == []` after a manual close.
- **`findings` is a pure DB read** — no file I/O; staleness/relocation belongs to the next slice.

## Verification

- 620 passed, 15 skipped.
- Real end-to-end CLI smoke: `findings` lists two findings (critical ranked first), `resolve` records `resolution='fixed'` and drops it from the open list, a bad-id `dismiss` exits 1.
- Two-stage review (spec + quality) on each piece, plus a final whole-feature review (opus). Quality review caught and fixed the FK-on-missing-id bug; the final review caught a message regression (now restored to match `confirm`'s `; nothing to <verb>.`).

## Docs

- Spec: `docs/superpowers/specs/2026-06-03-findings-triage-design.md`
- Plan: `docs/superpowers/plans/2026-06-03-findings-triage.md`
- `CLAUDE.md` + `README.md` updated.

## Next slice (not in this PR)

Stale auto-resolve / `prune` — resolve findings whose excerpt is gone (reusing `sarif.relocate_finding`), recording `resolution='stale'`. The column already reserves the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)