### PR TITLE
fix(violation_db): stable id ASC tiebreak in get_open_findings

### DIFF
--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -400,7 +400,9 @@ class ViolationDB:
     ) -> List[dict]:
         """Return unresolved findings, filtered and ranked for triage.
 
-        Ordered by severity (critical → low) then ``occurrence_count`` DESC.
+        Ordered by severity (critical → low), then ``occurrence_count`` DESC,
+        then ``id`` ASC as a final tiebreak so ``limit`` truncates a stable,
+        specified subset across SQLite versions and vacuum state.
         ``severity`` is an exact match; ``file_substr`` is a case-insensitive
         substring of ``file_path`` (matched with SQL ``LIKE``, so any ``%`` or
         ``_`` in the term act as wildcards — only ever broadening the match,
@@ -429,7 +431,8 @@ class ViolationDB:
                         WHEN 'low'      THEN 1
                         ELSE 0
                     END DESC,
-                    occurrence_count DESC
+                    occurrence_count DESC,
+                    id ASC
                 LIMIT ?
                 """,
                 tuple(params),

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -1017,3 +1017,24 @@ class TestGetOpenFindings:
             db.close()
         assert rows[0]["severity"] == "low"
         assert rows[-1]["severity"] == "custom"
+
+    def test_ties_broken_by_id_ascending(self, tmp_path):
+        """Full ties (same severity + occurrence_count) resolve deterministically
+        by id ascending, so --limit truncates a stable, specified subset rather
+        than an unspecified one."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            # Insert in DESCENDING line order so insertion order != natural id
+            # order would only coincide via the explicit id tiebreak.
+            for i in reversed(range(5)):
+                db.persist_findings("a.py", [
+                    _make_finding(file_path="a.py", line_start=i + 1,
+                                  severity="high", category=f"c{i}",
+                                  description=f"f{i}"),
+                ])
+            all_ids = [r["id"] for r in db.get_open_findings()]
+            limited = [r["id"] for r in db.get_open_findings(limit=3)]
+        finally:
+            db.close()
+        assert all_ids == sorted(all_ids)
+        assert limited == sorted(all_ids)[:3]


### PR DESCRIPTION
Ordering ended at `occurrence_count DESC` with no final tiebreak, so under a full tie (same severity + occurrence_count) the rows that survive `--limit` were unspecified and could vary across SQLite versions / vacuum state. Append `id ASC` so the truncated subset is deterministic.

Transparent note: the contract test documents id-ascending tie ordering but cannot go RED in-process (SQLite incidentally returns rowid order here) — this is a portability hardening, not an observable-behavior change.