### PR TITLE
fix(cli): idempotent resolve/dismiss on already-closed findings

### DIFF
--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -460,12 +460,20 @@ def _close_finding(
 
     db = ViolationDB(str(db_path))
     try:
-        if db.get_finding(finding_id) is None:
+        row = db.get_finding(finding_id)
+        if row is None:
             console.print(
                 f"[red]No finding with id {finding_id}; "
                 f"nothing to {action}.[/red]"
             )
             raise typer.Exit(code=1)
+        if row["resolved"]:
+            prior = row["resolution"] or "closed"
+            console.print(
+                f"[yellow]Finding {finding_id} is already closed "
+                f"({prior}); leaving it unchanged.[/yellow]"
+            )
+            return
         db.mark_resolved(finding_id, resolution=resolution)
     finally:
         db.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -720,6 +720,27 @@ class TestDismissCommand:
         finally:
             db.close()
 
+    def test_close_already_resolved_is_idempotent(self, tmp_path, monkeypatch):
+        """Closing an already-closed finding reports the existing closure and
+        leaves the recorded resolution unchanged (resolve then dismiss must not
+        flip 'fixed' to 'dismissed')."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        fid = _seed_one_finding_id(db_path)
+        r1 = runner.invoke(app, ["resolve", str(fid), "--config", str(cfg)])
+        assert r1.exit_code == 0, r1.output
+        r2 = runner.invoke(app, ["dismiss", str(fid), "--config", str(cfg)])
+        assert r2.exit_code == 0, r2.output
+        assert "already" in r2.output.lower()
+        db = ViolationDB(str(db_path))
+        try:
+            row = db.get_finding(fid)
+            assert row["resolved"] == 1
+            assert row["resolution"] == "fixed"  # NOT flipped to dismissed
+        finally:
+            db.close()
+
     def test_dismiss_missing_id(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         cfg = _make_report_config(tmp_path)


### PR DESCRIPTION
TDD (genuine RED→GREEN).

`_close_finding` only guarded against a missing id, then unconditionally `mark_resolved`d. So `resolve 42` followed by `dismiss 42` silently flipped the recorded resolution from `fixed` to `dismissed` while printing a success line. Reuse the row `get_finding` already returns: if it is already resolved, print an idempotency notice and exit 0 without re-writing. Leaves the original resolution reason intact.