### PR TITLE
fix(cli): guard findings corroboration lookup (best-effort, never fatal)

### DIFF
--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -635,9 +635,12 @@ def findings(
         corroborated: set = set()
         if rows:
             paths = sorted({r["file_path"] for r in rows})
-            corroborated = {
-                r["id"] for r in db.get_findings_with_incidents(paths)
-            }
+            try:
+                corroborated = {
+                    r["id"] for r in db.get_findings_with_incidents(paths)
+                }
+            except Exception as e:  # corroboration is enrichment; never fatal
+                log.warning("Corroboration lookup failed (%s); marking none.", e)
     finally:
         db.close()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -643,6 +643,25 @@ class TestFindingsCommand:
         assert result.exit_code == 0
         assert len(json.loads(result.output)) == 2
 
+    def test_corroboration_failure_does_not_abort_listing(self, tmp_path, monkeypatch):
+        """Corroboration is best-effort enrichment (as in surface/sarif): if the
+        incident lookup raises, findings still lists the open findings."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_db(db_path, [
+            Finding("src/app.py", 10, 12, "bug", "high", "Null deref risk"),
+        ])
+
+        def _boom(self, *a, **k):
+            raise RuntimeError("corroboration query failed")
+
+        monkeypatch.setattr(ViolationDB, "get_findings_with_incidents", _boom)
+        result = runner.invoke(app, ["findings", "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        assert "Open findings" in result.output
+        assert "Null" in result.output
+
     def test_corroborated_mark_renders(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("COLUMNS", "200")


### PR DESCRIPTION
**Stacked on #(fix/idempotent-close)** — both touch `cli.py`.

TDD (genuine RED→GREEN). The `findings` command called `get_findings_with_incidents` bare, so a failure in the corroboration query aborted the whole listing — inconsistent with `generate_sarif_file`, which wraps the identical call as "enrichment; never fatal". Mirror that guard: on failure, log a warning and render findings with no corroboration marks.