### PR TITLE
feat(sarif): Relocation.exact — distinguish whole-line vs fuzzy matches

### DIFF
--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -39,6 +39,9 @@ class Relocation:
     start_line: int
     end_line: int
     status: str  # "relocated" | "stored" | "stale"
+    exact: bool = False  # True only on a whole-line block match (not the
+    #                      word-sequence fallback, which can straddle lines).
+    #                      The write path (fix) proceeds only when exact.
 
 
 def _normalize_lines(text: str) -> List[str]:
@@ -97,7 +100,7 @@ def relocate_finding(content: str, finding: dict) -> Relocation:
             matches.append(i + 1)
     if matches:
         best = min(matches, key=lambda ln: abs(ln - stored_start))
-        return Relocation(best, best + n - 1, "relocated")
+        return Relocation(best, best + n - 1, "relocated", exact=True)
 
     # Fallback: the excerpt may have been flattened (newlines collapsed to
     # spaces) by the upstream verbatim-validation gate, so line-block matching
@@ -119,7 +122,7 @@ def relocate_finding(content: str, finding: dict) -> Relocation:
     best_start, best_end = min(
         word_matches, key=lambda se: abs(se[0] - stored_start)
     )
-    return Relocation(best_start, best_end, "relocated")
+    return Relocation(best_start, best_end, "relocated", exact=False)
 
 
 def _fingerprint(file_path: str, category: str, excerpt: str,

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -77,6 +77,32 @@ class TestRelocateFinding:
         assert reloc.status == "relocated"
         assert (reloc.start_line, reloc.end_line) == (3, 5)
 
+    def test_exact_whole_line_match_sets_exact_true(self):
+        content = "def f():\n    x = eval(data)\n    return x\n"
+        reloc = relocate_finding(content, _finding(line_start=2, line_end=2))
+        assert reloc.status == "relocated"
+        assert reloc.exact is True
+
+    def test_flattened_word_match_sets_exact_false(self):
+        # The word-sequence fallback relocates but is NOT a whole-line block
+        # match — its span can straddle line boundaries, so it is not exact.
+        content = "import os\n\ndef f():\n    a = 1\n    return secret(a)\n"
+        f = _finding(
+            line_start=10, line_end=11,
+            verbatim_excerpt="def f(): a = 1 return secret(a)",
+        )
+        reloc = relocate_finding(content, f)
+        assert reloc.status == "relocated"
+        assert reloc.exact is False
+
+    def test_stale_and_stored_are_not_exact(self):
+        stale = relocate_finding("def f():\n    return safe(data)\n", _finding())
+        assert stale.status == "stale" and stale.exact is False
+        stored = relocate_finding(
+            "anything\n", _finding(verbatim_excerpt="", line_start=7, line_end=9)
+        )
+        assert stored.status == "stored" and stored.exact is False
+
 
 class TestBuildSarif:
     def _located(self, **over):


### PR DESCRIPTION
**Remediate stack, Piece 0** (stacked on the spec/plan PR). Touches shipped `sarif.py`.

`relocate_finding` returned `status="relocated"` from both the exact whole-line block match and the word-sequence fallback (for newline-flattened excerpts), which can straddle line boundaries. The write path must splice only whole-line-verified spans, so add an **additive** `Relocation.exact` flag: True on the block match, False on the fuzzy fallback and stored/stale.

`status` semantics unchanged → `surface`/`generate_sarif_file` and their tests are unaffected; only `fix` consumes `exact`.