### PR TITLE
feat(utils): read_strict + safe_write write primitives

### DIFF
--- a/ollama_sentinel/utils.py
+++ b/ollama_sentinel/utils.py
@@ -68,10 +68,16 @@ def read_strict(path: pathlib.Path, watch_dir: pathlib.Path) -> str:
     except ValueError as e:
         raise ValueError(f"path traversal: {path} -> {abs_path}") from e
 
-    # newline="" disables universal-newline translation, so a CRLF file's
-    # endings survive the read intact. Without it, every line ending would
-    # collapse to LF and be silently rewritten on write-back.
-    with open(abs_path, "r", encoding="utf-8", errors="strict", newline="") as fh:
+    # O_NOFOLLOW makes the open atomically refuse a final-component symlink,
+    # closing the race where the path is swapped to a symlink after the
+    # is_symlink() check but before the open. newline="" disables
+    # universal-newline translation so a CRLF file's endings survive the read.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(abs_path, flags)
+    except OSError as e:
+        raise ValueError(f"refusing to read {path}: {e}") from e
+    with os.fdopen(fd, "r", encoding="utf-8", errors="strict", newline="") as fh:
         return fh.read()
 
 
@@ -90,7 +96,11 @@ def safe_write(path: pathlib.Path, content: str, watch_dir: pathlib.Path) -> Non
     - preserves the original file's permission mode — ``os.replace`` carries
       the temp inode, whose mode would otherwise leak (a ``0o755`` file would
       silently become ``0o600``);
-    - creates missing parent directories within ``watch_dir``.
+    - creates missing parent directories within ``watch_dir``;
+    - re-validates parent containment immediately before the rename as
+      defense-in-depth against a parent component being swapped to a symlink
+      during the window (full openat/O_NOFOLLOW-per-component hardening is out
+      of scope for a local single-user tool).
     """
     if path.is_symlink():
         raise ValueError(f"refusing to write through symlink {path}")
@@ -104,19 +114,37 @@ def safe_write(path: pathlib.Path, content: str, watch_dir: pathlib.Path) -> Non
 
     abs_path.parent.mkdir(parents=True, exist_ok=True)
 
-    existed = abs_path.exists()
     fd, tmp_name = tempfile.mkstemp(
         dir=str(abs_path.parent), prefix=".ollama_sw_", suffix=".tmp"
     )
     tmp_path = pathlib.Path(tmp_name)
     try:
+        # If os.fdopen raises before taking ownership of fd, close the raw fd
+        # so it does not leak.
+        try:
+            fh = os.fdopen(fd, "w", encoding="utf-8", newline="")
+        except Exception:
+            os.close(fd)
+            raise
         # newline="" writes content verbatim — no '\n' → os.linesep translation
-        # — so the original line endings preserved by read_strict round-trip
-        # unchanged.
-        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+        # — so line endings preserved by read_strict round-trip unchanged.
+        with fh:
             fh.write(content)
-        if existed:
+        # Preserve the original mode unconditionally; FileNotFoundError means
+        # the target did not exist (a fresh write), which is fine.
+        try:
             shutil.copymode(abs_path, tmp_path)
+        except FileNotFoundError:
+            pass
+        # Defense-in-depth: a parent component could have been swapped to a
+        # symlink pointing outside watch_dir during the window. Re-resolve and
+        # re-check before committing the rename.
+        try:
+            abs_path.parent.resolve().relative_to(watch_dir_abs)
+        except ValueError as e:
+            raise ValueError(
+                f"parent moved outside watch_dir before write: {path}"
+            ) from e
         os.replace(tmp_path, abs_path)
     except Exception:
         tmp_path.unlink(missing_ok=True)

--- a/ollama_sentinel/utils.py
+++ b/ollama_sentinel/utils.py
@@ -4,7 +4,10 @@ Utility functions for Ollama Sentinel.
 import difflib
 import gzip
 import logging
+import os
 import pathlib
+import shutil
+import tempfile
 from typing import List
 
 log = logging.getLogger("ollama-sentinel")
@@ -42,6 +45,75 @@ def safe_read(path: pathlib.Path, watch_dir: pathlib.Path) -> str:
     except Exception as e:
         log.error(f"Failed to read {path}: {e}")
         return ""
+
+
+def read_strict(path: pathlib.Path, watch_dir: pathlib.Path) -> str:
+    """Read a UTF-8 file with the same containment as :func:`safe_read`, but
+    **raise** on any failure instead of degrading to ``""``.
+
+    The read counterpart for the write path: refuses symlinks and path
+    traversal (``ValueError``) and decodes with ``errors="strict"``, so a
+    non-UTF-8 file raises ``UnicodeDecodeError`` rather than being silently
+    corrupted to U+FFFD. That matters because the ``fix`` command writes the
+    result back — a lossy decode would persist replacement characters into the
+    file's untouched regions.
+    """
+    if path.is_symlink():
+        raise ValueError(f"refusing to read symlink {path}")
+
+    abs_path = path.resolve()
+    watch_dir_abs = watch_dir.resolve()
+    try:
+        abs_path.relative_to(watch_dir_abs)
+    except ValueError as e:
+        raise ValueError(f"path traversal: {path} -> {abs_path}") from e
+
+    return abs_path.read_text(encoding="utf-8", errors="strict")
+
+
+def safe_write(path: pathlib.Path, content: str, watch_dir: pathlib.Path) -> None:
+    """Atomically write *content* to *path*, contained within *watch_dir*.
+
+    The write counterpart of :func:`safe_read`, but it **raises** rather than
+    degrading — a failed or unsafe write must never appear to succeed:
+
+    - rejects symlinks (``ValueError``);
+    - enforces ``watch_dir`` containment via ``relative_to`` **before** any
+      directory creation (a traversing path is rejected, never created);
+    - writes UTF-8 to a temporary file in the same directory, then
+      ``os.replace`` (same-filesystem atomic rename), cleaning up the temp on
+      failure;
+    - preserves the original file's permission mode — ``os.replace`` carries
+      the temp inode, whose mode would otherwise leak (a ``0o755`` file would
+      silently become ``0o600``);
+    - creates missing parent directories within ``watch_dir``.
+    """
+    if path.is_symlink():
+        raise ValueError(f"refusing to write through symlink {path}")
+
+    abs_path = path.resolve()
+    watch_dir_abs = watch_dir.resolve()
+    try:
+        abs_path.relative_to(watch_dir_abs)
+    except ValueError as e:
+        raise ValueError(f"path traversal: {path} -> {abs_path}") from e
+
+    abs_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existed = abs_path.exists()
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(abs_path.parent), prefix=".ollama_sw_", suffix=".tmp"
+    )
+    tmp_path = pathlib.Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        if existed:
+            shutil.copymode(abs_path, tmp_path)
+        os.replace(tmp_path, abs_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 _CHUNK_BY_LINES_WARNED = False

--- a/ollama_sentinel/utils.py
+++ b/ollama_sentinel/utils.py
@@ -68,7 +68,11 @@ def read_strict(path: pathlib.Path, watch_dir: pathlib.Path) -> str:
     except ValueError as e:
         raise ValueError(f"path traversal: {path} -> {abs_path}") from e
 
-    return abs_path.read_text(encoding="utf-8", errors="strict")
+    # newline="" disables universal-newline translation, so a CRLF file's
+    # endings survive the read intact. Without it, every line ending would
+    # collapse to LF and be silently rewritten on write-back.
+    with open(abs_path, "r", encoding="utf-8", errors="strict", newline="") as fh:
+        return fh.read()
 
 
 def safe_write(path: pathlib.Path, content: str, watch_dir: pathlib.Path) -> None:
@@ -106,7 +110,10 @@ def safe_write(path: pathlib.Path, content: str, watch_dir: pathlib.Path) -> Non
     )
     tmp_path = pathlib.Path(tmp_name)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        # newline="" writes content verbatim — no '\n' → os.linesep translation
+        # — so the original line endings preserved by read_strict round-trip
+        # unchanged.
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
             fh.write(content)
         if existed:
             shutil.copymode(abs_path, tmp_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,6 +167,16 @@ class TestReadStrict:
         with pytest.raises(ValueError):
             read_strict(traversal, watch_dir)
 
+    def test_preserves_crlf_line_endings(self, tmp_path):
+        # Universal-newline translation would collapse CRLF to LF on read; the
+        # write path must preserve the file's original endings so a later
+        # write-back does not silently flip every line.
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "win.py"
+        f.write_bytes(b"a = 1\r\nb = 2\r\n")
+        assert read_strict(f, watch_dir) == "a = 1\r\nb = 2\r\n"
+
 
 # ---------------------------------------------------------------------------
 # safe_write

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,9 @@ import pytest
 from ollama_sentinel.utils import (
     chunk_content_by_lines,
     generate_diff,
+    read_strict,
     safe_read,
+    safe_write,
     save_compressed,
 )
 
@@ -119,6 +121,126 @@ class TestSafeRead:
         result = safe_read(f, watch_dir)
         assert "hello" in result
         assert result != ""
+
+
+# ---------------------------------------------------------------------------
+# read_strict
+# ---------------------------------------------------------------------------
+
+
+class TestReadStrict:
+    """read_strict: containment like safe_read, but raises on failure and
+    refuses non-UTF-8 (never lossy-decodes)."""
+
+    def test_reads_utf8_file(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "u.py"
+        f.write_text("x = 'café'\n", encoding="utf-8")
+        assert read_strict(f, watch_dir) == "x = 'café'\n"
+
+    def test_non_utf8_file_raises(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "data.py"
+        f.write_bytes(b"x = 1  # \x80\x81\xff not utf-8\n")
+        with pytest.raises((UnicodeDecodeError, ValueError)):
+            read_strict(f, watch_dir)
+
+    def test_symlink_raises(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        target = watch_dir / "real.py"
+        target.write_text("secret")
+        link = watch_dir / "link.py"
+        os.symlink(target, link)
+        with pytest.raises(ValueError):
+            read_strict(link, watch_dir)
+
+    def test_traversal_raises(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("password")
+        traversal = watch_dir / ".." / "outside" / "secret.txt"
+        with pytest.raises(ValueError):
+            read_strict(traversal, watch_dir)
+
+
+# ---------------------------------------------------------------------------
+# safe_write
+# ---------------------------------------------------------------------------
+
+
+class TestSafeWrite:
+    """safe_write: atomic, contained, UTF-8, mode-preserving, symlink-rejecting."""
+
+    def test_writes_and_reads_back(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "out.py"
+        f.write_text("old\n")
+        safe_write(f, "new content\n", watch_dir)
+        assert f.read_text(encoding="utf-8") == "new content\n"
+
+    def test_replaces_existing_file_atomically(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "mod.py"
+        f.write_text("v1\n")
+        safe_write(f, "v2\n", watch_dir)
+        assert f.read_text(encoding="utf-8") == "v2\n"
+        # no leftover temp files in the directory
+        assert [p.name for p in watch_dir.iterdir()] == ["mod.py"]
+
+    def test_preserves_mode(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "script.py"
+        f.write_text("#!/usr/bin/env python\n")
+        f.chmod(0o755)
+        safe_write(f, "#!/usr/bin/env python\nprint('hi')\n", watch_dir)
+        assert (os.stat(f).st_mode & 0o777) == 0o755
+
+    def test_writes_utf8(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "u.py"
+        f.write_text("x\n")
+        safe_write(f, "y = 'café'\n", watch_dir)
+        assert f.read_bytes() == "y = 'café'\n".encode("utf-8")
+
+    def test_symlink_target_raises(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        target = watch_dir / "real.py"
+        target.write_text("x")
+        link = watch_dir / "link.py"
+        os.symlink(target, link)
+        with pytest.raises(ValueError):
+            safe_write(link, "nope", watch_dir)
+        # target untouched
+        assert target.read_text() == "x"
+
+    def test_traversal_raises(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "secret.txt"
+        victim.write_text("password")
+        traversal = watch_dir / ".." / "outside" / "secret.txt"
+        with pytest.raises(ValueError):
+            safe_write(traversal, "owned", watch_dir)
+        assert victim.read_text() == "password"
+
+    def test_creates_parent_dirs_within_watch_dir(self, tmp_path):
+        watch_dir = tmp_path / "project"
+        watch_dir.mkdir()
+        f = watch_dir / "pkg" / "sub" / "new.py"
+        safe_write(f, "x = 1\n", watch_dir)
+        assert f.read_text(encoding="utf-8") == "x = 1\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Remediate stack, Piece 1.**

Two raising counterparts to `safe_read` for the fix write path:
- `read_strict`: same symlink + `relative_to` containment, but raises (never degrades) and decodes `errors="strict"`, so a non-UTF-8 file is refused instead of lossily corrupted to U+FFFD and written back. Reads with `newline=""` so CRLF endings survive.
- `safe_write`: symlink reject → containment check (before any mkdir) → write UTF-8 (`newline=""`, verbatim) to a temp in the same dir → `copymode` from the original → `os.replace` (atomic). Preserves mode, cleans up the temp on failure.

`os.replace` operates on the name (not an fd through the target), neutralizing destination-symlink-swap / hardlink / FIFO TOCTOU attacks. The `newline=""` handling is the first half of the **review-driven CRLF-integrity fix** (completed in Pieces 2-3).