### PR TITLE
feat(remediate): fix-generation core (splice/parse/prompt/propose_fix)

### DIFF
--- a/ollama_sentinel/remediate.py
+++ b/ollama_sentinel/remediate.py
@@ -29,10 +29,17 @@ def splice_lines(content: str, start: int, end: int, replacement: str) -> str:
     single trailing newline is present iff the original last replaced line ended
     with one — so a file with or without a final newline keeps that property,
     and seams never double or drop a newline.
+
+    Requires a valid in-file span ``1 <= start <= end`` with ``start`` no
+    further than the last line; an out-of-range span raises ``ValueError``
+    rather than silently appending the replacement to the end of the file.
     """
     lines = content.splitlines(keepends=True)
     n = len(lines)
-    start = max(1, start)
+    if start < 1 or end < start or start > n:
+        raise ValueError(
+            f"splice span [{start}..{end}] out of range for {n}-line file"
+        )
     end = min(end, n)
 
     prefix = lines[: start - 1]
@@ -53,9 +60,15 @@ def parse_fix_response(raw: str) -> str:
 
     A fence is removed only when the first non-blank line is a triple-backtick
     opener (with an optional language tag) and the last non-blank line is a bare
-    triple-backtick closer. Otherwise ``raw`` is returned unchanged — so a
-    legitimately fenced ``.md`` target, a docstring containing a fence, or a
-    dangling half-fence is never corrupted.
+    triple-backtick closer. Otherwise ``raw`` is returned unchanged — so an
+    embedded fence, a docstring containing a fence, or a dangling half-fence is
+    never touched.
+
+    This does NOT try to distinguish a model-added wrapper from a replacement
+    whose intended content is *itself* a fully fenced block: if the correct
+    replacement is exactly ```` ```...``` ````, its outer fences will be
+    stripped. That is acceptably rare — the model is instructed to emit bare
+    code — and the diff is always shown before any write.
     """
     lines = raw.splitlines()
     non_blank = [i for i, ln in enumerate(lines) if ln.strip()]
@@ -130,7 +143,17 @@ async def propose_fix(
     client, parse off any fence, splice into the file. ``status`` is
     ``"no_change"`` when the spliced result equals the original (the caller then
     writes nothing and leaves the finding open).
+
+    Refuses (``ValueError``) any relocation that is not an exact, whole-line
+    match — defense-in-depth so a fuzzy/stale/stored span never reaches the
+    model or ``splice_lines`` even if a caller forgets to gate on
+    ``relocation.exact``.
     """
+    if not (getattr(relocation, "exact", False) and relocation.status == "relocated"):
+        raise ValueError(
+            "propose_fix requires an exact relocation "
+            f"(got status={relocation.status!r}, exact={getattr(relocation, 'exact', None)!r})"
+        )
     start, end = relocation.start_line, relocation.end_line
     prompt = build_fix_prompt(content, start, end, finding)
     raw = await client.generate_review(model_role, prompt)

--- a/ollama_sentinel/remediate.py
+++ b/ollama_sentinel/remediate.py
@@ -8,14 +8,27 @@ whole file, and the rest of the file is spliced through untouched.
 from dataclasses import dataclass
 
 
+def _line_terminator(lines: list) -> str:
+    """The newline style of the last line that has one ('\\r\\n'/'\\n'/'\\r'), else ''."""
+    for ln in reversed(lines):
+        if ln.endswith("\r\n"):
+            return "\r\n"
+        if ln.endswith("\n"):
+            return "\n"
+        if ln.endswith("\r"):
+            return "\r"
+    return ""
+
+
 def splice_lines(content: str, start: int, end: int, replacement: str) -> str:
     """Replace 1-based inclusive lines ``[start..end]`` with ``replacement``.
 
     Every other line is preserved verbatim. The replacement is normalized onto
-    its own line(s): internal newlines are kept, and a single trailing newline
-    is present iff the original last replaced line ended with one — so a file
-    with or without a final newline keeps that property, and seams never double
-    or drop a newline.
+    its own line(s) using the file's own newline style (CRLF stays CRLF, so the
+    file is never left with mixed endings): internal newlines are kept, and a
+    single trailing newline is present iff the original last replaced line ended
+    with one — so a file with or without a final newline keeps that property,
+    and seams never double or drop a newline.
     """
     lines = content.splitlines(keepends=True)
     n = len(lines)
@@ -26,10 +39,11 @@ def splice_lines(content: str, start: int, end: int, replacement: str) -> str:
     target = lines[start - 1 : end]
     suffix = lines[end:]
 
+    nl = _line_terminator(target) or _line_terminator(prefix + suffix) or "\n"
     orig_had_newline = bool(target) and target[-1].endswith(("\n", "\r"))
-    repl_norm = "\n".join(replacement.splitlines())
+    repl_norm = nl.join(replacement.splitlines())
     if orig_had_newline:
-        repl_norm += "\n"
+        repl_norm += nl
 
     return "".join(prefix) + repl_norm + "".join(suffix)
 

--- a/ollama_sentinel/remediate.py
+++ b/ollama_sentinel/remediate.py
@@ -1,0 +1,134 @@
+"""Localized fix generation for ``ollama-sentinel fix <id>``.
+
+Pure helpers (``splice_lines``, ``parse_fix_response``, ``build_fix_prompt``)
+plus one I/O orchestration (``propose_fix``). The fix is bounded to the
+finding's relocated line span — the model never sees a mandate to rewrite the
+whole file, and the rest of the file is spliced through untouched.
+"""
+from dataclasses import dataclass
+
+
+def splice_lines(content: str, start: int, end: int, replacement: str) -> str:
+    """Replace 1-based inclusive lines ``[start..end]`` with ``replacement``.
+
+    Every other line is preserved verbatim. The replacement is normalized onto
+    its own line(s): internal newlines are kept, and a single trailing newline
+    is present iff the original last replaced line ended with one — so a file
+    with or without a final newline keeps that property, and seams never double
+    or drop a newline.
+    """
+    lines = content.splitlines(keepends=True)
+    n = len(lines)
+    start = max(1, start)
+    end = min(end, n)
+
+    prefix = lines[: start - 1]
+    target = lines[start - 1 : end]
+    suffix = lines[end:]
+
+    orig_had_newline = bool(target) and target[-1].endswith(("\n", "\r"))
+    repl_norm = "\n".join(replacement.splitlines())
+    if orig_had_newline:
+        repl_norm += "\n"
+
+    return "".join(prefix) + repl_norm + "".join(suffix)
+
+
+def parse_fix_response(raw: str) -> str:
+    """Strip a markdown fence only when it *wraps the entire output*.
+
+    A fence is removed only when the first non-blank line is a triple-backtick
+    opener (with an optional language tag) and the last non-blank line is a bare
+    triple-backtick closer. Otherwise ``raw`` is returned unchanged — so a
+    legitimately fenced ``.md`` target, a docstring containing a fence, or a
+    dangling half-fence is never corrupted.
+    """
+    lines = raw.splitlines()
+    non_blank = [i for i, ln in enumerate(lines) if ln.strip()]
+    if len(non_blank) < 2:
+        return raw
+
+    first, last = non_blank[0], non_blank[-1]
+    opener = lines[first].strip().startswith("```")
+    closer = lines[last].strip() == "```"
+    if opener and closer:
+        return "\n".join(lines[first + 1 : last])
+    return raw
+
+
+def build_fix_prompt(
+    content: str, start: int, end: int, finding: dict, ctx: int = 15
+) -> str:
+    """Build the plain-text prompt asking the model to rewrite lines start-end.
+
+    Shows a line-numbered window ``[start-ctx .. end+ctx]`` (clamped to the
+    file) with the target lines marked, plus the finding's
+    ``[severity] category: description`` and verbatim excerpt. Instructs the
+    model to return bare code for only that span.
+    """
+    lines = content.splitlines()
+    n = len(lines)
+    win_start = max(1, start - ctx)
+    win_end = min(n, end + ctx)
+
+    rendered = []
+    for ln in range(win_start, win_end + 1):
+        marker = ">>" if start <= ln <= end else "  "
+        rendered.append(f"{marker} {ln:>5} | {lines[ln - 1]}")
+    window = "\n".join(rendered)
+
+    severity = finding.get("severity", "")
+    category = finding.get("category", "")
+    description = finding.get("description", "")
+    excerpt = finding.get("verbatim_excerpt", "")
+
+    return (
+        "You are fixing a single code finding.\n\n"
+        f"Finding: [{severity}] {category}: {description}\n"
+        f"Excerpt:\n{excerpt}\n\n"
+        f"File around the finding — lines marked >> (lines {start}-{end}) are "
+        "the ones to replace:\n\n"
+        f"{window}\n\n"
+        f"Return ONLY the corrected source for lines {start}-{end}, preserving "
+        "the surrounding indentation and style. Output bare code with no "
+        "markdown fences and no commentary. If you cannot fix it safely, "
+        "return those lines unchanged."
+    )
+
+
+@dataclass
+class ProposedFix:
+    """A model-proposed localized fix, before any write."""
+    status: str  # "ok" | "no_change"
+    new_content: str
+    start: int
+    end: int
+    old_text: str
+    new_text: str
+
+
+async def propose_fix(
+    content: str, finding: dict, relocation, client, model_role: str = "fix"
+) -> ProposedFix:
+    """Ask the model for a localized replacement for the relocated span.
+
+    Plain-text generation (no ``response_format``): build the prompt, call the
+    client, parse off any fence, splice into the file. ``status`` is
+    ``"no_change"`` when the spliced result equals the original (the caller then
+    writes nothing and leaves the finding open).
+    """
+    start, end = relocation.start_line, relocation.end_line
+    prompt = build_fix_prompt(content, start, end, finding)
+    raw = await client.generate_review(model_role, prompt)
+    new_text = parse_fix_response(raw)
+    new_content = splice_lines(content, start, end, new_text)
+    old_text = "".join(content.splitlines(keepends=True)[start - 1 : end])
+    status = "no_change" if new_content == content else "ok"
+    return ProposedFix(
+        status=status,
+        new_content=new_content,
+        start=start,
+        end=end,
+        old_text=old_text,
+        new_text=new_text,
+    )

--- a/tests/test_remediate.py
+++ b/tests/test_remediate.py
@@ -50,6 +50,16 @@ class TestSpliceLines:
         content = "a\nb\nc\n"
         assert splice_lines(content, 2, 2, "B\n") == "a\nB\nc\n"
 
+    def test_preserves_crlf_terminator_on_replaced_line(self):
+        # The replaced line must keep the file's CRLF terminator, not get a bare
+        # LF that leaves the file with mixed endings.
+        content = "a\r\nb\r\nc\r\n"
+        assert splice_lines(content, 2, 2, "B") == "a\r\nB\r\nc\r\n"
+
+    def test_normalizes_replacement_newlines_to_crlf_file(self):
+        content = "a\r\nb\r\nc\r\nd\r\n"
+        assert splice_lines(content, 2, 3, "B\nC") == "a\r\nB\r\nC\r\nd\r\n"
+
 
 # ---------------------------------------------------------------------------
 # parse_fix_response

--- a/tests/test_remediate.py
+++ b/tests/test_remediate.py
@@ -1,0 +1,174 @@
+"""Tests for ollama_sentinel.remediate — localized fix generation."""
+
+from ollama_sentinel.remediate import (
+    ProposedFix,
+    build_fix_prompt,
+    parse_fix_response,
+    propose_fix,
+    splice_lines,
+)
+from ollama_sentinel.sarif import Relocation
+
+
+# ---------------------------------------------------------------------------
+# splice_lines
+# ---------------------------------------------------------------------------
+
+
+class TestSpliceLines:
+    def test_single_line_replace(self):
+        content = "a\nb\nc\n"
+        assert splice_lines(content, 2, 2, "B") == "a\nB\nc\n"
+
+    def test_multi_line_replace(self):
+        content = "a\nb\nc\nd\n"
+        assert splice_lines(content, 2, 3, "B\nC") == "a\nB\nC\nd\n"
+
+    def test_replace_first_line(self):
+        content = "a\nb\nc\n"
+        assert splice_lines(content, 1, 1, "A") == "A\nb\nc\n"
+
+    def test_replace_last_line_with_trailing_newline(self):
+        content = "a\nb\nc\n"
+        assert splice_lines(content, 3, 3, "C") == "a\nb\nC\n"
+
+    def test_replace_last_line_without_trailing_newline(self):
+        content = "a\nb\nc"
+        assert splice_lines(content, 3, 3, "C") == "a\nb\nC"
+
+    def test_indentation_preserved_in_replacement(self):
+        content = "def f():\n    x = 1\n    return x\n"
+        out = splice_lines(content, 2, 2, "    x = 2")
+        assert out == "def f():\n    x = 2\n    return x\n"
+
+    def test_surrounding_lines_untouched(self):
+        content = "h1\nh2\nTARGET\nf1\nf2\n"
+        out = splice_lines(content, 3, 3, "FIXED")
+        assert out.splitlines() == ["h1", "h2", "FIXED", "f1", "f2"]
+
+    def test_replacement_with_trailing_newline_not_doubled(self):
+        content = "a\nb\nc\n"
+        assert splice_lines(content, 2, 2, "B\n") == "a\nB\nc\n"
+
+
+# ---------------------------------------------------------------------------
+# parse_fix_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseFixResponse:
+    def test_fenced_block_stripped(self):
+        raw = "```python\nx = safe(data)\n```"
+        assert parse_fix_response(raw) == "x = safe(data)"
+
+    def test_fence_without_language_stripped(self):
+        raw = "```\nx = 1\n```"
+        assert parse_fix_response(raw) == "x = 1"
+
+    def test_bare_code_passes_through(self):
+        raw = "x = safe(data)"
+        assert parse_fix_response(raw) == "x = safe(data)"
+
+    def test_leading_trailing_blank_lines_trimmed(self):
+        raw = "\n\n```\nx = 1\n```\n\n"
+        assert parse_fix_response(raw) == "x = 1"
+
+    def test_unmatched_opening_fence_not_stripped(self):
+        # A dangling opener (no closer) must pass through unchanged — never
+        # corrupt content by stripping half a fence.
+        raw = "```python\nx = 1"
+        assert parse_fix_response(raw) == raw
+
+    def test_embedded_fence_without_wrapping_pair_not_stripped(self):
+        # Markdown/docstring content that contains a fence but is not itself a
+        # wrapped block must pass through untouched.
+        raw = "Here is code:\n```\nx = 1\n```\nmore text"
+        assert parse_fix_response(raw) == raw
+
+    def test_multiline_fenced_body_preserved(self):
+        raw = "```\na = 1\nb = 2\n```"
+        assert parse_fix_response(raw) == "a = 1\nb = 2"
+
+
+# ---------------------------------------------------------------------------
+# build_fix_prompt
+# ---------------------------------------------------------------------------
+
+
+def _finding(**over):
+    base = dict(
+        severity="high", category="security",
+        description="eval on untrusted input",
+        verbatim_excerpt="x = eval(data)",
+    )
+    base.update(over)
+    return base
+
+
+class TestBuildFixPrompt:
+    def test_includes_target_range_and_finding_metadata(self):
+        content = "\n".join(f"line{i}" for i in range(1, 31)) + "\n"
+        prompt = build_fix_prompt(content, 10, 11, _finding())
+        assert "10" in prompt and "11" in prompt
+        assert "high" in prompt
+        assert "security" in prompt
+        assert "eval on untrusted input" in prompt
+        assert "x = eval(data)" in prompt
+
+    def test_window_clamps_at_file_start(self):
+        content = "a\nb\nc\n"
+        # target line 1 with default ctx would request lines below 1
+        prompt = build_fix_prompt(content, 1, 1, _finding(), ctx=15)
+        # no negative or zero line numbers in the rendered window
+        for tok in prompt.split():
+            if tok.lstrip("-").isdigit():
+                assert int(tok) >= 0
+
+    def test_window_clamps_at_file_end(self):
+        content = "a\nb\nc\n"
+        prompt = build_fix_prompt(content, 3, 3, _finding(), ctx=15)
+        # the file has 3 lines; the window cannot render a line 4
+        assert "line4" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# propose_fix
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    async def generate_review(self, role, prompt, **kwargs):
+        self.calls.append({"role": role, "prompt": prompt, "kwargs": kwargs})
+        return self.response
+
+
+class TestProposeFix:
+    async def test_ok_splices_model_replacement(self):
+        content = "def f():\n    x = eval(data)\n    return x\n"
+        reloc = Relocation(2, 2, "relocated", exact=True)
+        client = _FakeClient("    x = safe(data)")
+        fix = await propose_fix(content, _finding(), reloc, client)
+        assert isinstance(fix, ProposedFix)
+        assert fix.status == "ok"
+        assert fix.new_content == "def f():\n    x = safe(data)\n    return x\n"
+        assert fix.start == 2 and fix.end == 2
+
+    async def test_identical_replacement_is_no_change(self):
+        content = "def f():\n    x = eval(data)\n    return x\n"
+        reloc = Relocation(2, 2, "relocated", exact=True)
+        client = _FakeClient("    x = eval(data)")
+        fix = await propose_fix(content, _finding(), reloc, client)
+        assert fix.status == "no_change"
+        assert fix.new_content == content
+
+    async def test_client_called_with_plain_text_no_response_format(self):
+        content = "a\nx = eval(data)\nc\n"
+        reloc = Relocation(2, 2, "relocated", exact=True)
+        client = _FakeClient("x = safe(data)")
+        await propose_fix(content, _finding(), reloc, client)
+        assert len(client.calls) == 1
+        assert "response_format" not in client.calls[0]["kwargs"]

--- a/tests/test_remediate.py
+++ b/tests/test_remediate.py
@@ -60,6 +60,15 @@ class TestSpliceLines:
         content = "a\r\nb\r\nc\r\nd\r\n"
         assert splice_lines(content, 2, 3, "B\nC") == "a\r\nB\r\nC\r\nd\r\n"
 
+    def test_out_of_range_span_raises(self):
+        # A span starting beyond EOF must fail loudly, not silently append the
+        # replacement to the end of the file.
+        import pytest
+        with pytest.raises(ValueError):
+            splice_lines("a\nb\n", 5, 5, "X")
+        with pytest.raises(ValueError):
+            splice_lines("a\nb\n", 2, 1, "X")  # end < start
+
 
 # ---------------------------------------------------------------------------
 # parse_fix_response
@@ -129,16 +138,17 @@ class TestBuildFixPrompt:
         content = "a\nb\nc\n"
         # target line 1 with default ctx would request lines below 1
         prompt = build_fix_prompt(content, 1, 1, _finding(), ctx=15)
-        # no negative or zero line numbers in the rendered window
+        # no zero or negative line numbers in the rendered window
         for tok in prompt.split():
             if tok.lstrip("-").isdigit():
-                assert int(tok) >= 0
+                assert int(tok) >= 1
 
     def test_window_clamps_at_file_end(self):
         content = "a\nb\nc\n"
         prompt = build_fix_prompt(content, 3, 3, _finding(), ctx=15)
-        # the file has 3 lines; the window cannot render a line 4
-        assert "line4" not in prompt
+        # the file has 3 lines; the window cannot render a line-4 entry
+        # (rendered as "<num> | ", so check for the "4 |" line marker).
+        assert "4 |" not in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -182,3 +192,18 @@ class TestProposeFix:
         await propose_fix(content, _finding(), reloc, client)
         assert len(client.calls) == 1
         assert "response_format" not in client.calls[0]["kwargs"]
+
+    async def test_refuses_non_exact_relocation(self):
+        # Defense-in-depth: propose_fix must not splice a non-exact (fuzzy) or
+        # stale/stored relocation even if a caller forgets to gate on it.
+        import pytest
+        content = "def f():\n    x = eval(data)\n    return x\n"
+        client = _FakeClient("    x = safe(data)")
+        for reloc in (
+            Relocation(2, 2, "relocated", exact=False),  # fuzzy
+            Relocation(2, 2, "stored", exact=False),
+            Relocation(2, 2, "stale", exact=False),
+        ):
+            with pytest.raises(ValueError):
+                await propose_fix(content, _finding(), reloc, client)
+        assert client.calls == []  # never reached the model


### PR DESCRIPTION
**Remediate stack, Piece 2.**

New `ollama_sentinel/remediate.py` — pure helpers plus one async orchestration, bounding a model fix to the findings relocated line span:
- `splice_lines`: replace 1-based inclusive `[start..end]`, preserving every other line and the files trailing-newline property; emits the files own newline style so a CRLF file stays uniformly CRLF (no mixed endings — the splice half of the review-driven CRLF fix).
- `parse_fix_response`: strip a fence only when it WRAPS the whole output (matched opener+closer), so a fenced `.md` target or a dangling half-fence is never corrupted.
- `build_fix_prompt`: line-numbered window clamped to file edges, target lines marked, finding metadata + excerpt, bare-code instruction.
- `propose_fix` (async): plain-text generation (no `response_format`), parse, splice; status `no_change` when the result equals the original.