### PR TITLE
feat(cli): fix command — localized, confirmed, contained source edit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ ollama-sentinel surface             # emit open Findings to .ollama_reviews/find
 ollama-sentinel findings            # list open Findings with ids (filter: --severity/--file)
 ollama-sentinel resolve 42          # close Finding 42 as fixed (resolution='fixed')
 ollama-sentinel dismiss 31          # close Finding 31 as false-positive (resolution='dismissed')
+ollama-sentinel fix 42              # localized fix for Finding 42: preview diff, write on confirm, resolve (fixed)
 
 python -m research_agent.main query "question" --context file.py --output result.md
 python -m research_agent.main interactive
@@ -129,7 +130,8 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 | `ollama_sentinel/extractor.py` | LLM JSON extraction + regex fallback for parsing review findings |
 | `ollama_sentinel/watcher.py` | FileSentinel, file watching, ignore logic, pipeline orchestration |
 | `ollama_sentinel/models.py` | Pydantic v2 config models: Ollama/Embedding/Memory/Processing with validators |
-| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss |
+| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss, fix |
+| `ollama_sentinel/remediate.py` | Localized fix generation for `fix <id>`: `splice_lines`/`parse_fix_response`/`build_fix_prompt` (pure) + `propose_fix` (I/O); bounds the model edit to the finding's exact whole-line span |
 | `ollama_sentinel/pytest_plugin.py` | Opt-in pytest plugin: matches test failures to open Findings, records `test_failure` Incidents (`pytest11` entry point) |
 | `ollama_sentinel/hooks.py` | Git post-commit hook installer + `record_commit` (links commits to open Findings) |
 | `ollama_sentinel/dashboard.py` | Live Rich TUI for `ollama-sentinel dashboard` — polls reviews dir + ViolationDB read-only |
@@ -151,6 +153,9 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 ### Security boundaries
 
 - `safe_read()` uses `Path.relative_to()` for containment (not string prefix)
+- `read_strict()` / `safe_write()` back the `fix` write path: same containment as
+  `safe_read` but **raise** instead of degrading — strict UTF-8 (refuse, never
+  corrupt non-text bytes), atomic `os.replace`, original mode preserved
 - `OllamaConfig` validates host URL scheme (http/https only)
 - `OutputConfig` rejects `..` traversal and absolute paths
 - `BrowserTool._validate_url()` blocks private IPs and non-http schemes

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The "I always forget what to run" table.
 | Surface findings in your editor | `ollama-sentinel surface` | Writes `.ollama_reviews/findings.sarif`; open it in VS Code/Cursor (SARIF Viewer → Problems panel) or upload it in CI for GitHub code scanning. Findings are re-anchored to current lines by excerpt; `run` refreshes it automatically |
 | List open findings | `ollama-sentinel findings`<br>or `… --severity high --file foo.py` | Table with ids, ranked by severity then frequency; `-f json` for machine-readable |
 | Close a finding | `ollama-sentinel resolve 42` / `ollama-sentinel dismiss 31` | `resolve` = fixed, `dismiss` = false-positive; records why so the dismiss rate is a usable signal |
+| Apply a localized fix | `ollama-sentinel fix 42` / `… --yes` | Asks the local model for a fix to that finding's exact span, previews a unified diff, and on confirmation writes it into the file and resolves the finding (`fixed`). Never writes without an interactive yes or `--yes`; no commit |
 | Link commits to findings | `ollama-sentinel install-hooks` | Installs a git post-commit hook that records which commit touched each open Finding |
 | Auto-link test failures | add `ollama_sentinel = true` to your pytest config | A failing test on a flagged line becomes a `test_failure` Incident |
 | Create a config file | `ollama-sentinel init` | Writes `ollama-sentinel.yaml` in the current dir |

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -640,8 +640,11 @@ def fix(
                 console.print("[dim](preview only; pass --yes to apply)[/dim]")
                 raise typer.Exit(code=0)
 
-        after = target.stat()
-        if (after.st_mtime_ns, after.st_size) != before_sig:
+        try:
+            after = target.stat()
+        except OSError:
+            after = None
+        if after is None or (after.st_mtime_ns, after.st_size) != before_sig:
             console.print(
                 f"[red]{rel} changed since it was read; re-run fix.[/red]"
             )

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -572,6 +572,15 @@ def fix(
 
         rel = finding["file_path"]
         target = watch_dir / rel
+        # Capture the TOCTOU baseline BEFORE reading, so an edit landing while
+        # the file is being read changes the signature and is caught by the
+        # pre-write re-stat (rather than the edit becoming the accepted baseline).
+        try:
+            before = target.stat()
+        except OSError as e:
+            console.print(f"[red]Cannot read {rel}: {e}[/red]")
+            raise typer.Exit(code=1)
+        before_sig = (before.st_mtime_ns, before.st_size)
         try:
             content = read_strict(target, watch_dir)
         except (ValueError, OSError) as e:
@@ -580,8 +589,6 @@ def fix(
                 f"(would corrupt non-text bytes): {e}[/red]"
             )
             raise typer.Exit(code=1)
-        before = target.stat()
-        before_sig = (before.st_mtime_ns, before.st_size)
 
         reloc = relocate_finding(content, finding)
         if not (reloc.status == "relocated" and reloc.exact):

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -511,6 +511,156 @@ def dismiss(
     )
 
 
+def _print_diff(diff: str) -> None:
+    """Print a unified diff — syntax-highlighted on a terminal, plain otherwise.
+
+    Never routed through Rich markup (diff text can contain ``[...]`` that Rich
+    would mis-parse)."""
+    if console.is_terminal:
+        try:
+            from rich.syntax import Syntax
+            console.print(Syntax(diff, "diff", theme="ansi_dark", word_wrap=False))
+            return
+        except Exception:
+            pass
+    print(diff, end="")
+
+
+@app.command()
+def fix(
+    finding_id: int = typer.Argument(..., help="ID of the Finding to fix"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y",
+        help="Apply the fix without the interactive confirmation prompt",
+    ),
+):
+    """Generate a localized fix for a Finding, preview a diff, and — on
+    confirmation — write it into the watched file and resolve the finding.
+
+    The first code path that writes into watched source: it edits only the
+    finding's excerpt-verified whole-line span, never writes without an
+    interactive yes or --yes, and always shows the diff first.
+    """
+    import difflib
+
+    from .processor import OllamaClient
+    from .remediate import propose_fix
+    from .sarif import relocate_finding
+    from .utils import read_strict, safe_write
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    watch_dir = pathlib.Path(config.watch.directory).resolve()
+    db_path = watch_dir / config.memory.db_path
+    if not db_path.exists():
+        console.print("[red]No violation database found.[/red]")
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        finding = db.get_finding(finding_id)
+        if finding is None:
+            console.print(f"[red]No finding with id {finding_id}.[/red]")
+            raise typer.Exit(code=1)
+        if finding["resolved"]:
+            console.print(f"[red]Finding {finding_id} is already resolved.[/red]")
+            raise typer.Exit(code=1)
+
+        rel = finding["file_path"]
+        target = watch_dir / rel
+        try:
+            content = read_strict(target, watch_dir)
+        except (ValueError, OSError) as e:
+            console.print(
+                f"[red]Cannot read {rel} as UTF-8; refusing to edit "
+                f"(would corrupt non-text bytes): {e}[/red]"
+            )
+            raise typer.Exit(code=1)
+        before = target.stat()
+        before_sig = (before.st_mtime_ns, before.st_size)
+
+        reloc = relocate_finding(content, finding)
+        if not (reloc.status == "relocated" and reloc.exact):
+            if reloc.status == "stale":
+                console.print(
+                    f"[red]Finding {finding_id}: excerpt no longer in {rel}; "
+                    f"cannot locate — nothing to fix.[/red]"
+                )
+            elif reloc.status == "stored":
+                console.print(
+                    f"[red]Finding {finding_id} has no usable excerpt to locate "
+                    f"by; cannot fix safely.[/red]"
+                )
+            else:  # relocated but not exact (fuzzy word-sequence match)
+                console.print(
+                    f"[red]Finding {finding_id}: excerpt only matches across line "
+                    f"boundaries; cannot fix safely (would clobber surrounding "
+                    f"code).[/red]"
+                )
+            raise typer.Exit(code=1)
+
+        async def _generate():
+            client = OllamaClient(config.ollama.model_dump())
+            try:
+                return await propose_fix(
+                    content, finding, reloc, client, model_role="fix"
+                )
+            finally:
+                await client.close()
+
+        try:
+            proposed = asyncio.run(_generate())
+        except Exception as e:
+            console.print(f"[red]Fix generation failed: {e}[/red]")
+            raise typer.Exit(code=1)
+
+        if proposed.status == "no_change":
+            console.print("[yellow]Model proposed no change.[/yellow]")
+            raise typer.Exit(code=0)
+
+        diff = "".join(difflib.unified_diff(
+            content.splitlines(keepends=True),
+            proposed.new_content.splitlines(keepends=True),
+            fromfile=rel, tofile=rel,
+        ))
+        _print_diff(diff)
+
+        if not yes:
+            if _is_stdin_tty():
+                if not typer.confirm(f"Apply this fix to {rel}?"):
+                    console.print(
+                        f"[yellow]Aborted; finding {finding_id} left open.[/yellow]"
+                    )
+                    raise typer.Exit(code=0)
+            else:
+                console.print("[dim](preview only; pass --yes to apply)[/dim]")
+                raise typer.Exit(code=0)
+
+        after = target.stat()
+        if (after.st_mtime_ns, after.st_size) != before_sig:
+            console.print(
+                f"[red]{rel} changed since it was read; re-run fix.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        try:
+            safe_write(target, proposed.new_content, watch_dir)
+        except (ValueError, OSError) as e:
+            console.print(f"[red]Failed to write {rel}: {e}[/red]")
+            raise typer.Exit(code=1)
+        db.mark_resolved(finding_id, resolution="fixed")
+    finally:
+        db.close()
+
+    console.print(
+        f"[green]Applied fix to {rel}; finding {finding_id} resolved (fixed).[/green]"
+    )
+
+
 @app.command()
 def incidents(
     config_path: str = typer.Option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -827,6 +827,10 @@ class TestFixCommand:
         result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
         assert result.exit_code == 0, result.output
         assert src.read_text() == "def f():\n    x = safe(data)\n    return x\n"
+        # The diff is always printed before any write, including under --yes (it
+        # is the record of what landed).
+        assert "x = eval(data)" in result.output
+        assert "x = safe(data)" in result.output
         db = ViolationDB(str(db_path))
         try:
             row = db.get_finding(fid)
@@ -1027,3 +1031,76 @@ class TestFixCommand:
         result = runner.invoke(app, ["fix", "1", "--config", str(cfg), "--yes"])
         assert result.exit_code == 1
         assert "No violation database" in result.output
+
+    def test_file_deleted_between_read_and_write_aborts_cleanly(self, tmp_path, monkeypatch):
+        # A delete (not just an edit) during the generation window must abort
+        # with the clean 'changed since it was read' message, not an uncaught
+        # traceback from the pre-write re-stat.
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+
+        def _delete():
+            src.unlink()
+        _mock_model(monkeypatch, "    x = safe(data)", side_effect=_delete)
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert "changed since it was read" in result.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_interactive_tty_decline_then_accept(self, tmp_path, monkeypatch):
+        # The primary human-driven gate: with a real TTY and no --yes, 'n'
+        # aborts without writing; 'y' applies. This pins the "never writes
+        # unprompted" property's interactive branch.
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        original = src.read_text()
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "    x = safe(data)")
+        monkeypatch.setattr("ollama_sentinel.cli._is_stdin_tty", lambda: True)
+
+        declined = runner.invoke(app, ["fix", str(fid), "--config", str(cfg)], input="n\n")
+        assert declined.exit_code == 0, declined.output
+        assert "Aborted" in declined.output
+        assert src.read_text() == original
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+        accepted = runner.invoke(app, ["fix", str(fid), "--config", str(cfg)], input="y\n")
+        assert accepted.exit_code == 0, accepted.output
+        assert src.read_text() == "def f():\n    x = safe(data)\n    return x\n"
+        db = ViolationDB(str(db_path))
+        try:
+            row = db.get_finding(fid)
+            assert row["resolved"] == 1 and row["resolution"] == "fixed"
+        finally:
+            db.close()
+
+    def test_preserves_crlf_endings_end_to_end(self, tmp_path, monkeypatch):
+        # A fix on a CRLF file must leave every line ending intact (read → splice
+        # → write), not silently flip the whole file to LF.
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_bytes(b"def f():\r\n    x = eval(data)\r\n    return x\r\n")
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "    x = safe(data)")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 0, result.output
+        assert src.read_bytes() == b"def f():\r\n    x = safe(data)\r\n    return x\r\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1032,6 +1032,38 @@ class TestFixCommand:
         assert result.exit_code == 1
         assert "No violation database" in result.output
 
+    def test_concurrent_edit_during_read_is_detected(self, tmp_path, monkeypatch):
+        # The TOCTOU baseline is captured BEFORE the read, so an edit that lands
+        # while the file is being read changes the signature and the pre-write
+        # re-stat aborts (rather than the edit becoming the accepted baseline and
+        # a write proceeding on stale content).
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "    x = safe(data)")
+
+        import ollama_sentinel.utils as utils_mod
+        real_read = utils_mod.read_strict
+
+        def mutating_read(path, watch_dir):
+            data = real_read(path, watch_dir)
+            # a concurrent writer changes the file during our read
+            src.write_text("def f():\n    x = eval(data)\n    return x\n# edited\n")
+            return data
+        monkeypatch.setattr(utils_mod, "read_strict", mutating_read)
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert "changed since it was read" in result.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
     def test_file_deleted_between_read_and_write_aborts_cleanly(self, tmp_path, monkeypatch):
         # A delete (not just an edit) during the generation window must abort
         # with the clean 'changed since it was read' message, not an uncaught

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -776,3 +776,254 @@ class TestDismissCommand:
         result = runner.invoke(app, ["dismiss", "99999", "--config", str(cfg)])
         assert result.exit_code == 1
         assert "No finding with id" in result.output
+
+
+# ---------------------------------------------------------------------------
+# fix (remediate)
+# ---------------------------------------------------------------------------
+
+
+def _seed_fix_finding(db_path, *, file_path, excerpt, line_start=2, line_end=2):
+    """Seed one finding (security/high) with a verbatim excerpt; return its id."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = ViolationDB(str(db_path))
+    try:
+        db.persist_findings(file_path, [
+            Finding(file_path, line_start, line_end, "security", "high",
+                    "eval on untrusted input", verbatim_excerpt=excerpt),
+        ])
+        fid = db._conn.execute(
+            "SELECT id FROM findings ORDER BY id DESC LIMIT 1"
+        ).fetchone()[0]
+    finally:
+        db.close()
+    return fid
+
+
+def _mock_model(monkeypatch, response, *, side_effect=None):
+    """Patch OllamaClient.generate_review to return `response` (no network)."""
+    import ollama_sentinel.processor as proc
+
+    async def fake_gen(self, role, prompt, **kwargs):
+        if side_effect is not None:
+            side_effect()
+        return response
+
+    monkeypatch.setattr(proc.OllamaClient, "generate_review", fake_gen)
+
+
+class TestFixCommand:
+    """Tests for 'ollama-sentinel fix' — the first write-to-source path."""
+
+    def test_happy_path_applies_and_resolves(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "    x = safe(data)")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 0, result.output
+        assert src.read_text() == "def f():\n    x = safe(data)\n    return x\n"
+        db = ViolationDB(str(db_path))
+        try:
+            row = db.get_finding(fid)
+            assert row["resolved"] == 1
+            assert row["resolution"] == "fixed"
+            assert db.get_incidents_for_finding(fid) == []  # no commit → no Incident
+        finally:
+            db.close()
+
+    def test_stale_excerpt_refused(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    return safe(data)\n")
+        original = src.read_text()
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "whatever")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert src.read_text() == original
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_empty_excerpt_stored_refused(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n")
+        original = src.read_text()
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="")
+        _mock_model(monkeypatch, "x = safe(data)")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert src.read_text() == original
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_fuzzy_only_relocation_refused(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        # Excerpt only matches via the flattened word-sequence fallback (spans
+        # lines), so relocation is non-exact and must be refused.
+        src.write_text("import os\n\ndef f():\n    a = 1\n    return secret(a)\n")
+        original = src.read_text()
+        fid = _seed_fix_finding(
+            db_path, file_path="app.py",
+            excerpt="def f(): a = 1 return secret(a)",
+            line_start=3, line_end=5,
+        )
+        _mock_model(monkeypatch, "fixed")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert src.read_text() == original
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_non_utf8_target_refused(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_bytes(b"def f():\n    x = eval(data)  # \x80\xff\n")
+        original = src.read_bytes()
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "x = safe(data)")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert src.read_bytes() == original  # not corrupted
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_mode_preserved_after_fix(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("#!/usr/bin/env python\nx = eval(data)\n")
+        src.chmod(0o755)
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "x = safe(data)")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 0, result.output
+        assert (src.stat().st_mode & 0o777) == 0o755
+
+    def test_file_changed_between_read_and_write_aborts(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+
+        # The model "generation" mutates the file underneath us (simulating a
+        # concurrent editor save / watcher rewrite) so the pre-write re-stat
+        # detects the change and aborts.
+        def _mutate():
+            src.write_text("def f():\n    x = eval(data)\n    return x\n# edited\n")
+        _mock_model(monkeypatch, "    x = safe(data)", side_effect=_mutate)
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert "changed since it was read" in result.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_no_change_leaves_finding_open(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        original = src.read_text()
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        # Model returns the original span unchanged.
+        _mock_model(monkeypatch, "    x = eval(data)")
+
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 0, result.output
+        assert src.read_text() == original
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_missing_id_refused(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        result = runner.invoke(app, ["fix", "99999", "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+
+    def test_already_resolved_refused(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n")
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        db = ViolationDB(str(db_path))
+        db.mark_resolved(fid, resolution="fixed")
+        db.close()
+        _mock_model(monkeypatch, "x = safe(data)")
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert "already resolved" in result.output.lower()
+
+    def test_non_tty_without_yes_previews_only(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        original = src.read_text()
+        fid = _seed_fix_finding(db_path, file_path="app.py", excerpt="x = eval(data)")
+        _mock_model(monkeypatch, "    x = safe(data)")
+        # CliRunner's stdin is non-tty, so without --yes the command must
+        # preview and write nothing.
+        result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        assert src.read_text() == original
+        assert "safe(data)" in result.output  # the diff was printed
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_finding(fid)["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_no_db_refused(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["fix", "1", "--config", str(cfg), "--yes"])
+        assert result.exit_code == 1
+        assert "No violation database" in result.output


### PR DESCRIPTION
**Remediate stack, Piece 3** (tip). The first code path that writes into watched source.

`fix <id>`: get_finding guards → `read_strict` (non-UTF-8 refused) + capture mtime/size → relocate, proceed **only on an exact whole-line match** (stale/stored/fuzzy refused) → `propose_fix` via OllamaClient (`model_role="fix"`, default fallback) → **always print the diff** → apply gate (`--yes` applies; TTY prompts; non-TTY previews) → **TOCTOU re-stat** before write → `safe_write` (atomic, UTF-8, mode-preserving) + `mark_resolved("fixed")`, no commit, no Incident.

**Adversarially verified** (4-lens cloud review, 13 raw → 6 confirmed). This branch folds in every confirmed finding:
- CRLF files were silently rewritten LF across the whole file (read_strict/splice/safe_write) — fixed end-to-end (Pieces 1-2 + an integration test here).
- A file deleted mid-generation crashed the pre-write re-stat with a traceback — now a clean "changed since it was read" abort.
- The interactive TTY-confirm decline path and the "diff shown under --yes" property were untested (both mutation-proven) — now pinned.

15 CLI tests cover the safety properties. Full suite: 673 passed, 15 skipped.