### PR TITLE
feat: prune stale findings (arc slice 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ ollama-sentinel findings            # list open Findings with ids (filter: --sev
 ollama-sentinel resolve 42          # close Finding 42 as fixed (resolution='fixed')
 ollama-sentinel dismiss 31          # close Finding 31 as false-positive (resolution='dismissed')
 ollama-sentinel fix 42              # localized fix for Finding 42: preview diff, write on confirm, resolve (fixed)
+ollama-sentinel prune               # close findings whose flagged code is gone (preview + confirm, resolution='stale')
 
 python -m research_agent.main query "question" --context file.py --output result.md
 python -m research_agent.main interactive
@@ -130,12 +131,12 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 | `ollama_sentinel/extractor.py` | LLM JSON extraction + regex fallback for parsing review findings |
 | `ollama_sentinel/watcher.py` | FileSentinel, file watching, ignore logic, pipeline orchestration |
 | `ollama_sentinel/models.py` | Pydantic v2 config models: Ollama/Embedding/Memory/Processing with validators |
-| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss, fix |
+| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss, fix, prune |
 | `ollama_sentinel/remediate.py` | Localized fix generation for `fix <id>`: `splice_lines`/`parse_fix_response`/`build_fix_prompt` (pure) + `propose_fix` (I/O); bounds the model edit to the finding's exact whole-line span |
 | `ollama_sentinel/pytest_plugin.py` | Opt-in pytest plugin: matches test failures to open Findings, records `test_failure` Incidents (`pytest11` entry point) |
 | `ollama_sentinel/hooks.py` | Git post-commit hook installer + `record_commit` (links commits to open Findings) |
 | `ollama_sentinel/dashboard.py` | Live Rich TUI for `ollama-sentinel dashboard` — polls reviews dir + ViolationDB read-only |
-| `ollama_sentinel/sarif.py` | SARIF 2.1.0 surface: excerpt-based `relocate_finding`, `build_sarif` document, `generate_sarif_file` (read-only orchestration) — backs the `surface` command + watcher auto-refresh |
+| `ollama_sentinel/sarif.py` | SARIF 2.1.0 surface: excerpt-based `relocate_finding`, `build_sarif` document, `generate_sarif_file` (read-only orchestration) — backs the `surface` command + watcher auto-refresh; `collect_stale_findings` (read-only) backs `prune` |
 | `ollama_sentinel/context/assembler.py` | `Section` / `Priority` / `ContextItem` dataclasses + `assemble()` + `chunk_by_lines` — pure, token-budgeted |
 | `ollama_sentinel/context/tokens.py` | `TokenCounter` (tiktoken `cl100k_base` with char-based fallback) |
 | `ollama_sentinel/context/embeddings.py` | `OllamaEmbedder` — async `/api/embeddings` client, cache-backed, `EmbeddingUnavailable` on failure |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The "I always forget what to run" table.
 | List open findings | `ollama-sentinel findings`<br>or `… --severity high --file foo.py` | Table with ids, ranked by severity then frequency; `-f json` for machine-readable |
 | Close a finding | `ollama-sentinel resolve 42` / `ollama-sentinel dismiss 31` | `resolve` = fixed, `dismiss` = false-positive; records why so the dismiss rate is a usable signal |
 | Apply a localized fix | `ollama-sentinel fix 42` / `… --yes` | Asks the local model for a fix to that finding's exact span, previews a unified diff, and on confirmation writes it into the file and resolves the finding (`fixed`). Never writes without an interactive yes or `--yes`; no commit |
+| Prune stale findings | `ollama-sentinel prune` / `… --yes` | Previews the open findings whose flagged code is gone (file deleted or excerpt no longer locatable) and, on confirmation, closes them with `resolution='stale'`. Read-only on source; no Incident; still-locatable findings are left open |
 | Link commits to findings | `ollama-sentinel install-hooks` | Installs a git post-commit hook that records which commit touched each open Finding |
 | Auto-link test failures | add `ollama_sentinel = true` to your pytest config | A failing test on a flagged line becomes a `test_failure` Incident |
 | Create a config file | `ollama-sentinel init` | Writes `ollama-sentinel.yaml` in the current dir |

--- a/docs/superpowers/specs/2026-06-04-stale-prune-design.md
+++ b/docs/superpowers/specs/2026-06-04-stale-prune-design.md
@@ -1,7 +1,7 @@
 # Stale-prune (`prune`) — design
 
 **Date:** 2026-06-04
-**Status:** Approved (brainstorm), pending implementation plan
+**Status:** Implemented 2026-06-05 — `prune` command + `collect_stale_findings`
 **Slice:** 4 of N in the "make findings actionable" arc (after surface/SARIF #14, triage #15, remediate #16)
 
 ## Problem

--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -883,6 +883,86 @@ def surface(
 
 
 @app.command()
+def prune(
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y",
+        help="Prune without the interactive confirmation prompt",
+    ),
+):
+    """Close findings whose flagged code is no longer locatable (stale).
+
+    Relocates every open finding by its verbatim excerpt and — on confirmation —
+    closes the ones whose file is gone or whose excerpt no longer matches,
+    recording resolution='stale' (a distinct label, no Incident). Read-only on
+    source: it reads files to relocate but never edits them.
+    """
+    from rich.table import Table
+
+    from .sarif import collect_stale_findings
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    watch_dir = pathlib.Path(config.watch.directory).resolve()
+    db_path = watch_dir / config.memory.db_path
+    if not db_path.exists():
+        console.print(
+            "[yellow]No violation database found. Run some reviews first.[/yellow]"
+        )
+        raise typer.Exit()
+
+    db = ViolationDB(str(db_path))
+    try:
+        stale = collect_stale_findings(db, watch_dir)
+        if not stale:
+            console.print("[green]No stale findings to prune.[/green]")
+            raise typer.Exit()
+
+        table = Table(
+            title=f"{len(stale)} stale finding(s) — flagged code no longer locatable"
+        )
+        table.add_column("ID", style="bold", width=5)
+        table.add_column("Sev", width=9)
+        table.add_column("Cat", width=10)
+        table.add_column("Location", style="cyan")
+        table.add_column("Description")
+        for r in stale:
+            table.add_row(
+                str(r["id"]),
+                r["severity"],
+                r["category"],
+                f"{r['file_path']}:{r['line_start']}",
+                (r["description"] or "")[:60],
+            )
+        console.print(table)
+
+        if not yes:
+            if _is_stdin_tty():
+                if not typer.confirm(f"Prune these {len(stale)} stale finding(s)?"):
+                    console.print(
+                        f"[yellow]Aborted; {len(stale)} finding(s) left open.[/yellow]"
+                    )
+                    raise typer.Exit()
+            else:
+                console.print("[dim](preview only; pass --yes to prune)[/dim]")
+                raise typer.Exit()
+
+        pruned = 0
+        for r in stale:
+            if db.mark_resolved(r["id"], resolution="stale") > 0:
+                pruned += 1
+    finally:
+        db.close()
+
+    console.print(
+        f"[green]Pruned {pruned} stale finding(s) (resolution=stale).[/green]"
+    )
+
+
+@app.command()
 def triage(
     input_path: Optional[str] = typer.Argument(
         None,

--- a/ollama_sentinel/sarif.py
+++ b/ollama_sentinel/sarif.py
@@ -295,3 +295,41 @@ def generate_sarif_file(
         unverified=unverified,
         path=sarif_path,
     )
+
+
+def collect_stale_findings(db, watch_dir: "pathlib.Path | str") -> List[dict]:
+    """Return the open findings whose flagged code is no longer locatable.
+
+    Reuses the exact staleness rule of :func:`generate_sarif_file` so ``surface``
+    and ``prune`` agree on what "stale" means: a finding is stale when its file
+    is gone, or when ``relocate_finding`` reports ``status == "stale"`` (its
+    verbatim excerpt no longer matches the file). Read-only — it queries the DB
+    and reads source files, but writes nothing.
+
+    Findings that still relocate (``"relocated"``) or have no verifiable excerpt
+    (``"stored"``) are NOT stale and are omitted. Returns the full row dicts in
+    ``get_all_unresolved()`` order.
+    """
+    watch_dir = pathlib.Path(watch_dir)
+    content_cache: dict = {}
+
+    def _content(rel: str):
+        # safe_read returns "" (never raises) for missing/unreadable/symlink/
+        # traversal, so check existence explicitly: a gone file is stale, an
+        # empty-but-present file goes through relocation like any other.
+        if rel not in content_cache:
+            abs_path = watch_dir / rel
+            content_cache[rel] = (
+                safe_read(abs_path, watch_dir) if abs_path.is_file() else None
+            )
+        return content_cache[rel]
+
+    stale: List[dict] = []
+    for r in db.get_all_unresolved():
+        content = _content(r["file_path"])
+        if content is None:
+            stale.append(r)
+            continue
+        if relocate_finding(content, r).status == "stale":
+            stale.append(r)
+    return stale

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1136,3 +1136,120 @@ class TestFixCommand:
         result = runner.invoke(app, ["fix", str(fid), "--config", str(cfg), "--yes"])
         assert result.exit_code == 0, result.output
         assert src.read_bytes() == b"def f():\r\n    x = safe(data)\r\n    return x\r\n"
+
+
+# ---------------------------------------------------------------------------
+# prune (stale-prune)
+# ---------------------------------------------------------------------------
+
+
+def _seed_prune(db_path, file_path, findings):
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = ViolationDB(str(db_path))
+    db.persist_findings(file_path, findings)
+    db.close()
+
+
+class TestPruneCommand:
+    """Tests for 'ollama-sentinel prune' — close findings whose code is gone."""
+
+    def test_happy_path_prunes_only_stale(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+        original = src.read_text()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        db.persist_findings("app.py", [
+            Finding("app.py", 2, 2, "security", "high", "live",
+                    verbatim_excerpt="x = eval(data)"),     # present → kept
+            Finding("app.py", 5, 5, "bug", "low", "gone",
+                    verbatim_excerpt="q = unsafe(z)"),       # absent → stale
+        ])
+        ids = {r["description"]: r["id"] for r in db.get_all_unresolved()}
+        db.close()
+
+        result = runner.invoke(app, ["prune", "--config", str(cfg), "--yes"])
+        assert result.exit_code == 0, result.output
+        assert src.read_text() == original  # read-only on source
+        db = ViolationDB(str(db_path))
+        try:
+            gone = db.get_finding(ids["gone"])
+            live = db.get_finding(ids["live"])
+            assert gone["resolved"] == 1 and gone["resolution"] == "stale"
+            assert live["resolved"] == 0 and live["resolution"] is None
+            assert db.get_incidents_for_finding(ids["gone"]) == []  # no Incident
+        finally:
+            db.close()
+
+    def test_nothing_to_prune(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        (tmp_path / "app.py").write_text("def f():\n    x = eval(data)\n")
+        _seed_prune(db_path, "app.py", [
+            Finding("app.py", 2, 2, "security", "high", "live",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+        result = runner.invoke(app, ["prune", "--config", str(cfg), "--yes"])
+        assert result.exit_code == 0
+        assert "No stale findings" in result.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_all_unresolved()[0]["resolved"] == 0
+        finally:
+            db.close()
+
+    def test_non_tty_without_yes_previews_only(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        # Flagged file never created → finding is stale.
+        _seed_prune(db_path, "missing.py", [
+            Finding("missing.py", 1, 1, "bug", "low", "gone",
+                    verbatim_excerpt="q = bad()"),
+        ])
+        result = runner.invoke(app, ["prune", "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        assert "preview only" in result.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_all_unresolved()[0]["resolved"] == 0  # not pruned
+        finally:
+            db.close()
+
+    def test_tty_decline_then_accept(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_prune(db_path, "missing.py", [
+            Finding("missing.py", 1, 1, "bug", "low", "gone",
+                    verbatim_excerpt="q = bad()"),
+        ])
+        monkeypatch.setattr("ollama_sentinel.cli._is_stdin_tty", lambda: True)
+
+        declined = runner.invoke(app, ["prune", "--config", str(cfg)], input="n\n")
+        assert declined.exit_code == 0, declined.output
+        assert "Aborted" in declined.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_all_unresolved()[0]["resolved"] == 0
+        finally:
+            db.close()
+
+        accepted = runner.invoke(app, ["prune", "--config", str(cfg)], input="y\n")
+        assert accepted.exit_code == 0, accepted.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_all_unresolved() == []  # pruned → no open findings
+        finally:
+            db.close()
+
+    def test_no_db_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        result = runner.invoke(app, ["prune", "--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No violation database" in result.output

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -174,7 +174,7 @@ class TestBuildSarif:
 
 import pathlib
 
-from ollama_sentinel.sarif import generate_sarif_file
+from ollama_sentinel.sarif import collect_stale_findings, generate_sarif_file
 from ollama_sentinel.violation_db import Finding, ViolationDB
 
 
@@ -313,3 +313,96 @@ class TestGenerateSarifFile:
         assert summary.path == custom_out
         assert custom_out.exists()
         assert not (tmp_path / ".ollama_reviews" / "findings.sarif").exists()
+
+
+class TestCollectStaleFindings:
+    """collect_stale_findings: same 'stale' rule as generate_sarif_file, but
+    returns the stale row dicts and writes nothing."""
+
+    def test_excerpt_absent_is_stale(self, tmp_path):
+        (tmp_path / "app.py").write_text("def f():\n    return safe(data)\n")
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "app.py", [
+            Finding("app.py", 2, 2, "security", "high", "gone",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+        db = ViolationDB(str(db_path))
+        try:
+            stale = collect_stale_findings(db, tmp_path)
+        finally:
+            db.close()
+        assert [r["description"] for r in stale] == ["gone"]
+
+    def test_missing_file_is_stale(self, tmp_path):
+        # No app.py on disk at all → the flagged file is gone.
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "app.py", [
+            Finding("app.py", 2, 2, "security", "high", "filegone",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+        db = ViolationDB(str(db_path))
+        try:
+            stale = collect_stale_findings(db, tmp_path)
+        finally:
+            db.close()
+        assert [r["description"] for r in stale] == ["filegone"]
+
+    def test_relocatable_even_drifted_not_stale(self, tmp_path):
+        # Excerpt present but drifted to line 4 → relocated, not stale.
+        (tmp_path / "app.py").write_text(
+            "import os\nimport sys\ndef f():\n    x = eval(data)\n"
+        )
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "app.py", [
+            Finding("app.py", 2, 2, "security", "high", "live",
+                    verbatim_excerpt="x = eval(data)"),
+        ])
+        db = ViolationDB(str(db_path))
+        try:
+            stale = collect_stale_findings(db, tmp_path)
+        finally:
+            db.close()
+        assert stale == []
+
+    def test_empty_excerpt_stored_not_stale(self, tmp_path):
+        (tmp_path / "app.py").write_text("anything\n")
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed(db_path, "app.py", [
+            Finding("app.py", 2, 2, "security", "high", "noexcerpt",
+                    verbatim_excerpt=""),
+        ])
+        db = ViolationDB(str(db_path))
+        try:
+            stale = collect_stale_findings(db, tmp_path)
+        finally:
+            db.close()
+        assert stale == []
+
+    def test_mixed_set_returns_only_stale_and_writes_nothing(self, tmp_path):
+        (tmp_path / "app.py").write_text("def f():\n    x = eval(data)\n")
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = ViolationDB(str(db_path))
+        db.persist_findings("app.py", [
+            Finding("app.py", 2, 2, "security", "high", "live",
+                    verbatim_excerpt="x = eval(data)"),
+            Finding("app.py", 5, 5, "bug", "low", "gone",
+                    verbatim_excerpt="y = unsafe(z)"),
+            Finding("app.py", 9, 9, "style", "low", "noexcerpt",
+                    verbatim_excerpt=""),
+        ])
+        db.persist_findings("missing.py", [
+            Finding("missing.py", 1, 1, "bug", "low", "filegone",
+                    verbatim_excerpt="q = bad()"),
+        ])
+        db.close()
+
+        db = ViolationDB(str(db_path))
+        try:
+            stale = collect_stale_findings(db, tmp_path)
+            still_open = db.get_all_unresolved()
+        finally:
+            db.close()
+        assert {r["description"] for r in stale} == {"gone", "filegone"}
+        assert len(still_open) == 4
+        assert all(r["resolved"] == 0 for r in still_open)


### PR DESCRIPTION
Implements **stale-prune**, slice 4 of the "make findings actionable" arc (after surface #14, triage #15, remediate #16).

## What

- **`collect_stale_findings(db, watch_dir)`** in `sarif.py` — read-only selector. Returns the open findings whose flagged code is no longer locatable: file gone, or `relocate_finding` reports `status == "stale"` (verbatim excerpt no longer matches). Reuses the exact content rule of `generate_sarif_file` so `surface` and `prune` agree on what "stale" means. Findings that still relocate (`relocated`) or have no verifiable excerpt (`stored`) are intentionally left untouched. Writes nothing.
- **`ollama-sentinel prune`** CLI command — previews stale findings in a Rich table, then on confirmation closes them with `resolution='stale'` (a distinct label, **no Incident**). Mirrors the `fix`/`findings` command shape: friendly no-DB exit, apply gate (`--yes` applies; TTY prompts `[y/N]`; non-TTY previews only and writes nothing).

## Safety

- **Read-only on source** — reads files to relocate excerpts, never edits them.
- No Incident created (`mark_resolved` only inserts an Incident when `fix_commit` is supplied).
- Relocatable and empty-excerpt findings are never pruned.

## Tests

- `tests/test_sarif.py` — stale-collection cases (file gone / excerpt drifted / still relocates / stored).
- `tests/test_cli.py::TestPruneCommand` — happy path prunes only stale, nothing-to-prune, non-TTY preview-only, interactive abort leaves findings open, missing-DB clean exit.
- Full suite: **689 passed, 15 skipped**.

Spec: `docs/superpowers/specs/2026-06-04-stale-prune-design.md`.