### PR TITLE
docs: refresh VISION.md to current state + 2026-06-07 session handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,33 +192,28 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
   679 passed / 15 skipped, ~10s). Do **not** hardcode the number here again — it
   drifts every time tests land. Quote the command, not the count.
 - **The "make findings actionable" arc** (surface → triage → remediate →
-  stale-prune): **slices 1-3 are MERGED to master.** surface (#14), triage
-  (#15), and **remediate `fix <id>` (PRs #22-26, rebase-merged 2026-06-04)**
-  all ship. Slice 4 (stale-prune `prune`) has a **merged spec but no
-  implementation yet** — that is the next pickup.
+  stale-prune): **the full arc (slices 1-4) is MERGED to master.** surface
+  (#14), triage (#15), remediate `fix <id>` (PRs #22-26, rebase-merged
+  2026-06-04), and **stale-prune `prune` (PR #29, rebase-merged 2026-06-05)**
+  all ship. The arc is complete.
 - **Working tree should be clean.** If it isn't, `git status` first.
 - **The visual guide (`docs/index.html`) is the canonical pitch surface.**
   Linked from README, GUIDE.md, and the v0.1.0 release notes.
 
 ### Resume here next time
 
-1. **Sanity check.** `pytest tests/ -q` should be green (679 / 15 skip last seen).
-2. **Implement stale-prune (`prune`).** Spec (merged, unimplemented):
-   `docs/superpowers/specs/2026-06-04-stale-prune-design.md`. Two pieces:
-   `collect_stale_findings` in `sarif.py` (read-only — reuse `relocate_finding`
-   + the `generate_sarif_file` content rule) → `prune` CLI command (preview +
-   confirm gate like `fix`, closes stale findings with `resolution='stale'`, no
-   Incident, read-only on source). Mirror the `fix` / `findings` command shape.
-3. **Then the deferred tail** (none blocking): OP-1 SIGHUP hot-reload, CB-1
+1. **Sanity check.** `pytest tests/ -q` should be green (689 / 15 skip last seen).
+2. **The "make findings actionable" arc is complete** (stale-prune `prune`
+   merged via PR #29, 2026-06-05). No arc work left.
+3. **The deferred tail** (none blocking): OP-1 SIGHUP hot-reload, CB-1
    formatter dedupe — see `docs/superpowers/followups.md`.
 
 ### Pickable next moves (ordered by leverage)
 
 | # | Item | Effort | Risk | Notes |
 |---|---|---|---|---|
-| 1 | Build stale-prune `prune` (per merged spec) | S-M | low | Only stage that closes the stranded-stale-finding leak; read-only on source. |
-| 2 | OP-1 — SIGHUP hot-reload of `ollama-sentinel.yaml` (`docs/superpowers/followups.md`) | M | med | Real DX pain on long-running watchers. |
-| 3 | CB-1 — dedupe impact-report formatter (`recipes.py` vs `synthesis.py`) | ~30-45 min | low | Dormant; only triggers if `build_research_context` gets impact data. |
+| 1 | OP-1 — SIGHUP hot-reload of `ollama-sentinel.yaml` (`docs/superpowers/followups.md`) | M | med | Real DX pain on long-running watchers. |
+| 2 | CB-1 — dedupe impact-report formatter (`recipes.py` vs `synthesis.py`) | ~30-45 min | low | Dormant; only triggers if `build_research_context` gets impact data. |
 
 Skip TR-3 — deliberate spec deviation, documented in followups.md. Qwen3
 Phases B/C stay parked (no demand; the Phase-A plan forbids pulling the models
@@ -248,6 +243,18 @@ speculatively).
 
 ### Recent landings
 
+- 2026-06-05: **"Make findings actionable" arc COMPLETE — stale-prune `prune`
+  SHIPPED + MERGED (PR #29, rebase-merged to master).** Two pieces, single PR
+  (advisor-approved): `collect_stale_findings(db, watch_dir)` in `sarif.py`
+  (read-only selector — returns open findings whose file is gone or whose
+  verbatim excerpt no longer relocates via `relocate_finding`; reuses the
+  `generate_sarif_file` content rule so `surface`/`prune` agree on "stale";
+  omits `relocated` and `stored` findings) → `cli.prune` (Rich preview table,
+  apply gate like `fix`: `--yes` applies, TTY prompts `[y/N]`, non-TTY previews
+  only; closes with `resolution='stale'`, **no Incident** — `mark_resolved`
+  only inserts an Incident when `fix_commit` is passed; read-only on source).
+  10 new tests (5 sarif + 5 CLI). Full suite 689 passed / 15 skipped.
+  Spec marked Implemented: `docs/superpowers/specs/2026-06-04-stale-prune-design.md`.
 - 2026-06-04/05: **"Make findings actionable" arc — remediate `fix <id>` SHIPPED
   + MERGED; full arc slices 1-3 on master.** REMEDIATE built as a 4-piece stack,
   adversarially verified (Workflow, 4 lenses, 13 raw → 6 confirmed findings
@@ -262,7 +269,7 @@ speculatively).
   already in; plus four polish PRs — `get_open_findings` id-tiebreak (#18),
   idempotent resolve/dismiss (#19), best-effort `findings` corroboration (#27,
   re-opened from auto-closed #20), dashboard unawaited-coroutine warning (#21);
-  CLAUDE.md doc-drift refresh (#17); stale-prune spec (#16, slice 4, unimplemented).
+  CLAUDE.md doc-drift refresh (#17); stale-prune spec (#16, slice 4).
 - 2026-05-30: **v0.2 Incident schema complete (Pieces 1-5).** Pieces 1-3
   (schema + migration + CRUD, post-commit hook + `install-hooks`/
   `record-commit`, `confirm` verb) merged to master as stacked PRs #8/#9/#10.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,13 @@ speculatively).
 
 ### Recent landings
 
+- 2026-06-07: **`docs/VISION.md` refreshed (structural rewrite) + session
+  handoff.** Replaced the stale v0.1.0+ snapshot, added a "making findings
+  actionable (shipped)" section, preserved the v0.3 substrate / north-star
+  narrative; new handoff at
+  `docs/session-notes/2026-06-07-vision-refresh-and-arc-complete-handoff.md`.
+  Docs-only; suite unchanged (689/15). Plan:
+  `docs/plans/2026-06-07-001-docs-refresh-vision-and-handoff-plan.md`.
 - 2026-06-05: **"Make findings actionable" arc COMPLETE — stale-prune `prune`
   SHIPPED + MERGED (PR #29, rebase-merged to master).** Two pieces, single PR
   (advisor-approved): `collect_stale_findings(db, watch_dir)` in `sarif.py`

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -20,46 +20,49 @@ reports, not generic essays. Uses OpenAI; opt-in via `pip install -e ".[research
 Both run on the user's machine. Code never leaves it (with the standard caveat
 that the research agent does call OpenAI when invoked).
 
-## State as of this session — v0.1.0+
+## Where it is now
 
-Shipped, public on GitHub, 353 tests passing, ~2.4s suite. Recent work in this
-session:
+Shipped, public on GitHub. The suite is healthy — run `pytest tests/ -q` for
+the live number (as of 2026-06-07: 689 passed / 15 skipped in ~9s; quote the
+command, not a frozen count). The product has moved well past the v0.1 "model
+that comments on your code" stage. Three things are true today that were
+aspirational a few months ago:
 
-- **Structural recall wired into the sentinel's hot path.** The
-  `ImportResolver` AST scanner — previously dead-coded behind a research-agent
-  import — now augments prior-violation lookup with 1-hop import-graph
-  neighbors. A finding on `utils.py` surfaces when reviewing `app.py`. A
-  finding on `app.py` surfaces when reviewing `utils.py`. Layered after
-  semantic recall, before single-file recall. Python-only. Five tests. Five
-  green.
-- **Truth-in-advertising gap closed.** The README's "knows your blind spots"
-  claim is now load-bearing. Before this session, structural awareness was
-  promised by docs and not delivered by code.
+- **The memory is layered and grounded.** Prior-violation recall is semantic
+  (embedding neighbors via `qwen3-embedding:4b` on the hot path — see Phase A
+  below), structural (1-hop import-graph neighbors via the `ImportResolver` AST
+  scanner, so a finding on `utils.py` surfaces when reviewing `app.py`), and
+  single-file. The README's "knows your blind spots" claim is load-bearing,
+  not marketing.
+- **Findings are no longer just opinions.** The v0.2 Finding/Incident split
+  gives the memory a way to record what *objectively happened* — a failing
+  test, a fix-shaped commit, a manual confirmation — not just what the model
+  said. (Detailed below.)
+- **Findings are actionable.** A finding is no longer a dead row in a table.
+  It can surface in your editor and CI, be auto-fixed, be triaged from tool
+  output, and be pruned when the code it flagged is gone. (The "make findings
+  actionable" arc, below.)
 
-## What's still aspirational
+**Phase A — hot-path embedding swap (shipped 2026-05-01).** The semantic
+recall embedder moved from `nomic-embed-text` to `qwen3-embedding:4b`.
+`EmbeddingConfig` is now a named-role dict; the `consolidation` and `rerank`
+roles are pre-registered in the schema but intentionally unwired (Phases B/C
+are parked — no demand yet, and the plan forbids pulling those models
+speculatively). Legacy `embedding.model: foo` YAML auto-migrates with a
+one-shot deprecation warning.
 
-The vision document gestures at a "software immune system" and a "guardrail
-compiler." Neither exists yet. The substrate they would need does not exist
-either. Specifically: the sentinel's memory currently contains only **model
-opinions** — the LLM said something is concerning, and the LLM keeps saying it
-on every re-read of the same span. Recurrence count over LLM opinion is the
-model agreeing with itself N times. That's not knowledge. That's an echo.
+## From opinion to event — the Finding/Incident model (v0.2, shipped)
 
-The v0.1 schema could not represent (all resolved in v0.2 — see below):
+The v0.1 memory contained only **model opinions**: the LLM said something was
+concerning, and kept saying it on every re-read of the same span. Recurrence
+count over LLM opinion is the model agreeing with itself N times. That's not
+knowledge — that's an echo. The v0.1 schema could not represent the commit that
+introduced a finding, the commit that resolved it, the objective failure that
+confirmed (or refuted) the suspicion, the blast radius (where the failure
+surfaced vs. where the model flagged), or the test gap. When `Finding.resolved`
+flipped, all knowledge of the fix vaporized.
 
-- The commit that introduced a finding.
-- The commit that resolved it.
-- The objective failure that confirmed the model's suspicion (or didn't).
-- The blast radius — where the failure actually surfaced, vs. where the model
-  flagged.
-- The test gap — what ran and passed despite the failure.
-
-In v0.1, `Finding.resolved` was a single bit: when it flipped, all knowledge of
-the fix vaporized. v0.2's Incident schema is what closes these gaps.
-
-## v0.2 — the Finding/Incident split (shipped)
-
-v0.2 splits the schema into two nouns:
+v0.2 closes those gaps by splitting the schema into two nouns:
 
 **Finding** — what the model says. LLM hypothesis. Cheap to produce, plentiful,
 unverified. The v0.1 schema, kept as-is.
@@ -103,15 +106,47 @@ What shipped in v0.2:
 
 The watcher is no longer the only signal source — git and test events now feed
 memory too. The file watcher remains for streaming commentary as you type.
+`gitpython` was already a core dependency, so the infrastructure cost of this
+pivot was near zero.
 
 Deferred past v0.2: `pre-commit` surfacing of incidents on staged files
 (v0.2.1), reverse import-graph blame traversal beyond the simple
 `suspect_commits` heuristic (v0.2.1), and ≥3-incident Pattern promotion (v0.3).
 
-`gitpython` was already a core dependency, so the infrastructure cost of this
-pivot was near zero.
+## Making findings actionable (shipped)
 
-## Next state — v0.3: shared substrate between modules
+v0.2 made findings *corroborable*. The actionability arc (shipped and merged
+2026-06-04/05) makes them *operable* — a finding becomes something you can see,
+diagnose, fix, and retire, from the command line and from inside your editor.
+Four verbs, plus their supporting cast:
+
+- **`surface`** — emit open Findings to `.ollama_reviews/findings.sarif`
+  (SARIF 2.1.0). They light up in the editor Problems panel and in CI, with
+  excerpt-based relocation so a finding tracks its code even as surrounding
+  lines shift. The watcher also auto-refreshes the SARIF file.
+- **`triage`** — pipe tool output (pytest, mypy, ruff, a traceback, anything)
+  into a local-model diagnosis. File+line references are auto-extracted from
+  the output and the relevant source is pulled in as context, so the model
+  reasons about *your* failure, not a generic one.
+- **`fix <id>`** — a localized, excerpt-verified fix for one Finding. It
+  previews a diff, writes only on confirm (`[y/N]` or `--yes`), and resolves
+  the Finding as fixed. The write is bounded to the finding's exact whole-line
+  span, atomic, UTF-8/CRLF-preserving, and mode-preserving. It never commits.
+- **`prune`** — close Findings whose flagged code is gone: the file no longer
+  exists, or the verbatim excerpt no longer relocates. Preview + confirm, then
+  close with `resolution='stale'` (no Incident — a vanished finding isn't a
+  corroborated event). Read-only on source.
+
+Supporting verbs round out the lifecycle: `findings` (list open Findings with
+ids), `resolve` / `dismiss` (close as fixed / false-positive, idempotent), and
+`dashboard` (a live Rich TUI of recent reviews and recurring violations,
+polling the DB read-only).
+
+The throughline: a Finding now has a full lifecycle — proposed by the model,
+corroborated by events, surfaced where you work, acted on, and retired — rather
+than accumulating as inert rows.
+
+## What's still aspirational — v0.3: shared substrate between modules
 
 Today the two modules are architecturally independent. That was the right v0.1
 call. It's now the ceiling.

--- a/docs/plans/2026-06-07-001-docs-refresh-vision-and-handoff-plan.md
+++ b/docs/plans/2026-06-07-001-docs-refresh-vision-and-handoff-plan.md
@@ -1,0 +1,297 @@
+---
+title: "docs: Refresh VISION.md (structural rewrite) + new session handoff"
+type: docs
+status: completed
+date: 2026-06-07
+depth: standard
+---
+
+# docs: Refresh VISION.md (structural rewrite) + new session handoff
+
+## Summary
+
+`docs/VISION.md` is the project's strategic narrative, and it has drifted. Its
+"State as of this session" snapshot still reports **v0.1.0+ / 353 tests / ~2.4s
+suite** (reality is ~689 passed / 15 skipped, ~10s), and it contains **no
+mention of the "make findings actionable" arc** (surface → triage → remediate →
+prune) that fully shipped and merged on 2026-06-04/05 — the single largest body
+of work since the snapshot was written. This plan delivers a **full structural
+rewrite** of `docs/VISION.md` re-sequenced around current reality, plus a new
+dated **session handoff** in `docs/session-notes/`, landed via a `docs/` branch
+and PR.
+
+The rewrite re-sequences; it does **not** discard. The v0.3 shared-substrate
+narrative, the north star, the explicit non-goals, and the doc's distinctive
+voice are load-bearing and must survive intact.
+
+---
+
+## Problem Frame
+
+`docs/VISION.md` (169 lines) is linked from the project as the canonical
+"why this exists / where it's going" document. Three classes of drift:
+
+1. **Stale snapshot.** The "## State as of this session — v0.1.0+" block
+   describes a moment three-plus sessions in the past (structural recall just
+   wired, 353 tests). Everything in it is true-but-ancient.
+2. **A missing milestone.** The findings-actionability arc (surface, triage,
+   remediate `fix <id>`, stale-prune `prune`) is the project's headline
+   capability now — it turns model opinions into closeable, editor-visible,
+   auto-fixable, auto-prunable Findings. The vision doc never mentions it.
+   Phase A (Qwen3 hot-path embedding swap), the dashboard, and the `incidents`
+   CLI are also absent or under-stated.
+3. **Sequencing rot.** Because new milestones were never folded in, the doc's
+   "next state" (v0.3) sits directly after a v0.1-era snapshot, skipping the
+   reality that v0.2 *and* a whole actionability arc shipped in between.
+
+The fix is not a patch — the user has chosen a structural rewrite so the doc
+reads as a coherent current-state narrative again. The companion deliverable is
+a session handoff capturing this session's state and the next pickable moves,
+following the `docs/session-notes/` convention.
+
+---
+
+## Scope Boundaries
+
+**In scope**
+- Full structural rewrite of `docs/VISION.md` around current state.
+- A new dated handoff doc in `docs/session-notes/`.
+- A consistency pass on inbound references to VISION.md (README, `docs/index.html`,
+  `docs/GUIDE.md`, CLAUDE.md) — verify links/claims still resolve after the rewrite.
+- Landing on a `docs/<date>-...` branch with a PR.
+
+### Deferred to Follow-Up Work
+- Rewriting `docs/index.html` (the canonical visual guide). It is pinned as
+  do-not-move and is a separate, larger surface; only verify it doesn't
+  contradict the refreshed VISION.md, don't rewrite it here.
+- Refreshing `README.md` prose beyond reference-integrity checks.
+- Editing the CLAUDE.md "Known Issues / Next Session Breadcrumbs" section as the
+  primary handoff (the user chose a standalone `docs/session-notes/` doc; a
+  one-line CLAUDE.md pointer is optional and lives in U4, not a rewrite).
+
+### Non-goals
+- **No code changes.** Zero edits under `ollama_sentinel/`, `research_agent/`,
+  or `tests/`. The test suite must remain green and unchanged.
+- **No discarding of forward narrative.** The v0.3 substrate plan, north star,
+  non-goals, and "what this is not" content are preserved (re-sequenced/tightened
+  at most, not deleted).
+- **No new product claims.** The rewrite reports what shipped; it does not
+  promise capability that does not exist (the doc itself warns against
+  "truth-in-advertising" gaps — honor that).
+
+---
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Full structural rewrite** of VISION.md (not a patch) | User choice. The doc reads incoherently as a stale snapshot + future-only tail; re-sequencing around current state restores the narrative. |
+| D2 | **Preserve the forward narrative** (v0.3 substrate, north star, non-goals, "what this is not", voice) | These are the doc's durable strategic core and the reason the user values it. A rewrite re-sequences; it must not gut. Explicit guard against the known failure mode of "rewrite" = "start over." |
+| D3 | Handoff = **new standalone doc in `docs/session-notes/`** | User choice. Matches the existing `docs/session-notes/2026-05-05-...` convention; durable and narrative, separate from CLAUDE.md. |
+| D4 | Land via **`docs/<date>-...` branch + PR** | User choice. Matches the repo's recent doc-change convention (`docs/handoff-2026-06-05`, `docs/2026-05-16-session-handoff` branches). |
+| D5 | **Never hardcode the test count** | CLAUDE.md is explicit: "Do not hardcode the number here again — it drifts. Quote the command, not the count." The rewrite reports the suite via the command (`pytest tests/ -q`) and uses the live count captured at write time, framed as "as of <date>". |
+| D6 | CLAUDE.md breadcrumbs are **already current** — don't duplicate | The breadcrumbs section already reflects arc-complete / 689-15. The new handoff doc complements it (narrative session record), it doesn't replace or re-state it; an optional one-line pointer is the only CLAUDE.md touch. |
+
+---
+
+## Current-State Fact Base
+
+The source of truth the rewrite must reflect (verify each in U1 before writing):
+
+- **v0.1.0+** — public on GitHub, structural recall (ImportResolver 1-hop
+  import-graph neighbors) wired into the sentinel hot path. *(already in doc)*
+- **v0.2 — Finding/Incident split — SHIPPED.** Incident schema + migration,
+  opt-in pytest plugin, `confirm` verb, post-commit hook (`install-hooks` /
+  `record-commit`), `incidents` verb. *(already in doc, current)*
+- **Phase A — Qwen3 hot-path embedding swap — SHIPPED (2026-05-01).** Hot-path
+  embedder nomic-embed-text → qwen3-embedding:4b; named-role EmbeddingConfig;
+  consolidation/rerank roles pre-registered but unwired (Phases B/C parked).
+- **"Make findings actionable" arc — COMPLETE (merged 2026-06-04/05).** The
+  headline addition:
+  - `surface` — emit open Findings to `.ollama_reviews/findings.sarif` (editor
+    Problems panel + CI). (PR #14)
+  - `triage` — pipe tool output (pytest/mypy/ruff/traceback) → local-model
+    diagnosis with auto-extracted source context. (PR #15)
+  - `fix <id>` — localized, excerpt-verified, whole-line-span fix: preview diff,
+    write on confirm, resolve as fixed; atomic UTF-8/CRLF-preserving write,
+    never commits. (PRs #22–26)
+  - `prune` — close findings whose flagged code is gone (preview + confirm,
+    `resolution='stale'`, no Incident). (PR #29)
+  - Supporting verbs: `findings`, `resolve`, `dismiss`, `dashboard` (live Rich TUI).
+- **v0.3 — shared substrate — STILL ASPIRATIONAL.** Lift `ImportResolver` to
+  shared infra, unify `Finding`/`ImpactItem`, bidirectional sentinel↔research
+  flow. *(preserve verbatim in intent)*
+- **Test reality** — run `pytest tests/ -q`; quote the command and the
+  date-stamped live count (last documented: 689 passed / 15 skipped, ~10s — do
+  not trust this number, re-measure).
+
+---
+
+## High-Level Design — Target VISION.md Structure
+
+The rewrite maps the existing material onto a current-state-first sequence.
+This is directional guidance for the section order, not prescriptive prose.
+
+```
+BEFORE (current)                          AFTER (target)
+─────────────────────────                 ─────────────────────────────
+# Vision (intro)                          # Vision (intro)            ← keep, tighten
+## What it actually is                     ## What it actually is      ← keep, current
+## State as of this session — v0.1.0+      ## Where it is now (v0.2 +  ← REPLACE stale snapshot
+   (353 tests, structural recall)             actionability arc)         with a current milestone-
+## What's still aspirational                                              accurate state section
+## v0.2 — Finding/Incident split (shipped) ## How memory accrues       ← v0.2 split, kept current
+## Next state — v0.3: shared substrate     ## Making findings          ← NEW: surface→triage→
+## Explicit non-goals                         actionable (shipped)        remediate→prune arc
+## North star                              ## What's still aspirational ← v0.3 substrate (PRESERVE)
+## What this is not                        ## Explicit non-goals       ← PRESERVE
+                                           ## North star               ← PRESERVE
+                                           ## What this is not          ← PRESERVE
+```
+
+Net change: the v0.1-era snapshot is replaced by a current-state section; a new
+"making findings actionable" milestone section is inserted; the forward/strategic
+tail (aspirational, non-goals, north star, what-this-is-not) is preserved.
+Section titles above are directional — the implementer may adjust naming to fit
+the doc's voice.
+
+---
+
+## Implementation Units
+
+### U1. Establish and verify the current-state fact base
+
+**Goal:** Pin every factual claim the rewrite will make, so the new doc kills
+staleness instead of introducing it.
+**Dependencies:** none.
+**Files:** none created (read-only verification pass). Inputs: `docs/VISION.md`,
+`CLAUDE.md` (Recent landings + breadcrumbs), `ollama_sentinel/cli.py` (verb
+surface), `README.md`.
+**Approach:**
+- Run `pytest tests/ -q`; capture the live pass/skip count and date-stamp it.
+- Confirm the shipped verb surface against `ollama_sentinel/cli.py` (surface,
+  triage, fix, prune, findings, resolve, dismiss, incidents, confirm, dashboard,
+  install-hooks, record-commit) — the rewrite must not name a verb that isn't wired.
+- Confirm PR-merge facts for the actionability arc and Phase A against CLAUDE.md
+  "Recent landings".
+- Produce a short internal checklist (the Current-State Fact Base section above,
+  each item ✓-verified).
+**Execution note:** This is a guard against the rewrite re-introducing drift.
+Do it before writing prose.
+**Test scenarios:** Test expectation: none — read-only verification, no artifact
+and no behavioral change. Verification is the completed fact checklist.
+**Verification:** Every bullet in "Current-State Fact Base" is confirmed against
+a primary source (code or merged-PR record), and the live test count is captured
+with its command.
+
+### U2. Structurally rewrite `docs/VISION.md`
+
+**Goal:** Re-sequence the vision doc around current state per the target
+structure, preserving the forward narrative and voice.
+**Dependencies:** U1.
+**Files:** `docs/VISION.md` (rewrite).
+**Approach:**
+- Follow the BEFORE→AFTER map in High-Level Design.
+- Replace the "State as of this session — v0.1.0+" block with a current-state
+  section (v0.2 shipped, actionability arc shipped, Phase A shipped), date-stamped.
+- Insert a "making findings actionable (shipped)" section covering
+  surface→triage→remediate→prune, framed as the bridge between *model opinion*
+  (Finding) and *acted-on outcome* (resolved/fixed/pruned/corroborated).
+- Carry the v0.2 Finding/Incident section forward (it's current — tighten only).
+- **Preserve (D2):** the v0.3 substrate section, explicit non-goals, north star,
+  and "what this is not" — re-sequenced after current-state, not deleted or
+  watered down.
+- Keep the doc's voice (declarative, "the memory is the product", anti-hype).
+- Apply D5: report the suite via command + date-stamped live count, never a bare
+  hardcoded number presented as evergreen.
+**Patterns to follow:** the existing VISION.md voice and the v0.2 section's
+"what shipped" bullet style; the truth-in-advertising discipline the doc itself
+preaches (no claim the code doesn't back).
+**Test scenarios:** Test expectation: none — documentation, no behavioral change.
+Content correctness is verified by the U1 fact checklist and the U2 verification
+list below.
+**Verification:**
+- The stale v0.1.0+ snapshot is gone; a current-state section replaces it.
+- The actionability arc has a dedicated section naming all four verbs accurately.
+- The v0.3 substrate narrative, north star, non-goals, and "what this is not"
+  are all still present and substantively intact (diff-confirm none were dropped).
+- No verb or capability is named that isn't wired in `cli.py` (cross-check U1).
+- No hardcoded evergreen test count; suite is reported per D5.
+
+### U3. Author the session handoff doc
+
+**Goal:** A durable, narrative session handoff in `docs/session-notes/`.
+**Dependencies:** U1 (facts), U2 (so the handoff can reference the refreshed doc).
+**Files:** create `docs/session-notes/2026-06-07-vision-refresh-and-arc-complete-handoff.md`.
+**Approach:** Mirror the structure of `docs/session-notes/2026-05-05-ux-centralization-session-summary.md`.
+Capture: what this session did (VISION.md rewrite + this handoff), the
+arc-complete current state (v0.2 + actionability arc + Phase A), the live test
+count with command, and the next pickable moves (OP-1 SIGHUP hot-reload, CB-1
+formatter dedupe — from CLAUDE.md "Pickable next moves"), plus the persistent
+gotchas worth carrying (qwen3-embedding pull requirement, unwired
+consolidation/rerank roles, `_archive/` no-import rule).
+**Patterns to follow:** existing `docs/session-notes/` and `docs/retros/` doc
+shape; CLAUDE.md breadcrumbs tone (concrete, dated, next-move-oriented).
+**Test scenarios:** Test expectation: none — documentation. Verified by the
+checklist below.
+**Verification:** The handoff names the current state accurately, links to the
+refreshed `docs/VISION.md`, lists concrete next moves with effort/risk, and
+follows the session-notes naming convention.
+
+### U4. Reference-integrity + consistency pass
+
+**Goal:** Ensure the rewrite didn't break inbound references or contradict
+sibling docs.
+**Dependencies:** U2, U3.
+**Files:** read `README.md`, `docs/GUIDE.md`, `docs/index.html`, `CLAUDE.md`;
+optionally a one-line pointer edit in `CLAUDE.md` and/or `README.md` if they
+link to VISION.md sections that were renamed.
+**Approach:**
+- Grep for references to VISION.md and to any renamed section anchors; fix
+  broken anchors/links only (no prose rewrites — those are deferred).
+- Confirm `docs/index.html` (pinned, do-not-move) does not now contradict the
+  refreshed VISION.md; if it does, note it as a follow-up rather than editing it
+  here (out of scope).
+- Optionally add a one-line pointer from CLAUDE.md breadcrumbs to the new
+  session-notes handoff (D6) — additive, not a rewrite.
+**Test scenarios:** Test expectation: none — documentation. Plus a guard:
+`pytest tests/ -q` still green and unchanged (proves U1–U4 touched no code).
+**Verification:** No broken links/anchors to VISION.md; `docs/index.html`
+either consistent or its drift logged as a follow-up; test suite green and
+unchanged from pre-plan baseline.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| "Full rewrite" guts the forward strategic narrative (the part the user values) | Med | D2 + U2 verification explicitly diff-confirms v0.3 / north star / non-goals / "what this is not" survive. Treat preservation as a hard acceptance gate. |
+| Rewrite re-introduces stale or false claims (wrong verb names, fabricated capability) | Med | U1 verifies every claim against `cli.py` and merged-PR record before any prose is written. |
+| Hardcoded test count drifts again | High (historically) | D5: report via command + date-stamped live count; never an evergreen bare number. |
+| Renamed section anchors break inbound links | Low | U4 grep + fix pass. |
+| Editing `docs/index.html` by accident (it's pinned do-not-move) | Low | Explicit non-goal + scope boundary; U4 only *reads* it. |
+
+---
+
+## Open Questions / Deferred
+
+- **`docs/index.html` consistency.** If the visual guide materially contradicts
+  the refreshed VISION.md (e.g. still implies the actionability arc is future
+  work), refreshing it is a separate, larger task — log as follow-up, don't
+  pull into this PR.
+- **README prose refresh.** Same treatment — reference-integrity only here; a
+  README narrative refresh is deferred.
+
+---
+
+## Sources & Research
+
+- `docs/VISION.md` (current, 169 lines) — the rewrite target.
+- `CLAUDE.md` — "Recent landings" and "Known Issues / Next Session Breadcrumbs"
+  (the authoritative shipped-state record; already arc-complete-current).
+- `ollama_sentinel/cli.py` — the wired verb surface (ground truth for capability claims).
+- `docs/session-notes/2026-05-05-ux-centralization-session-summary.md` — handoff doc shape.
+- Git: branches `docs/handoff-2026-06-05` (CLAUDE.md-breadcrumbs style) and
+  `docs/2026-05-16-session-handoff` (standalone-retro style) — the two existing
+  handoff conventions; this plan follows the standalone-doc style per D3.

--- a/docs/session-notes/2026-06-07-vision-refresh-and-arc-complete-handoff.md
+++ b/docs/session-notes/2026-06-07-vision-refresh-and-arc-complete-handoff.md
@@ -1,0 +1,97 @@
+# Vision Refresh + Arc-Complete Handoff
+
+Date: 2026-06-07
+Repo: `ollama-sentinel`
+Topic: Refresh `docs/VISION.md` to current state; capture the next-session handoff
+
+---
+
+## 1. What this session did
+
+- **Structurally rewrote `docs/VISION.md`.** The doc had drifted: its "State as
+  of this session" snapshot still reported v0.1.0+ / 353 tests / ~2.4s, and it
+  never mentioned the "make findings actionable" arc — the largest body of work
+  since that snapshot. The rewrite re-sequences the doc around current reality
+  while preserving the forward narrative (v0.3 shared substrate, north star,
+  explicit non-goals, "what this is not").
+- **Wrote this handoff** in `docs/session-notes/` (the standalone-doc handoff
+  convention, alongside the CLAUDE.md breadcrumbs).
+- **No code changed.** Docs-only. Suite is green and unchanged.
+
+Plan of record: `docs/plans/2026-06-07-001-docs-refresh-vision-and-handoff-plan.md`.
+
+---
+
+## 2. Current state (the source of truth the rewrite reflects)
+
+- **Public on GitHub**, <https://github.com/Skidudeaa/ollama-sentinel>.
+- **Test suite:** `pytest tests/ -q` → **689 passed / 15 skipped in ~9s** as of
+  2026-06-07. Quote the command, not the count — it drifts every time tests land.
+- **v0.2 — Finding/Incident split: SHIPPED.** Incident schema + migration,
+  opt-in pytest plugin, `confirm` verb, post-commit hook
+  (`install-hooks` / `record-commit`), `incidents` verb. Findings are model
+  opinions; Incidents are corroborated events.
+- **Phase A — hot-path embedding swap: SHIPPED (2026-05-01).** Embedder
+  `nomic-embed-text` → `qwen3-embedding:4b`; `EmbeddingConfig` is a named-role
+  dict; `consolidation`/`rerank` roles pre-registered but unwired (Phases B/C
+  parked).
+- **"Make findings actionable" arc: COMPLETE (merged 2026-06-04/05).**
+  - `surface` (PR #14) — SARIF 2.1.0 to `.ollama_reviews/findings.sarif`,
+    editor Problems panel + CI, excerpt-based relocation, watcher auto-refresh.
+  - `triage` (PR #15) — pipe tool output → local-model diagnosis with
+    auto-extracted source context.
+  - `fix <id>` (PRs #22–26) — localized, excerpt-verified, whole-line-span fix;
+    preview diff, write on confirm, resolve as fixed; atomic
+    UTF-8/CRLF/mode-preserving write; never commits.
+  - `prune` (PR #29) — close findings whose flagged code is gone
+    (`resolution='stale'`, no Incident); read-only on source.
+  - Supporting verbs: `findings`, `resolve`, `dismiss` (idempotent),
+    `dashboard` (live Rich TUI).
+- **v0.3 — shared substrate: STILL ASPIRATIONAL.** Lift `ImportResolver` to
+  shared infra, unify `Finding`/`ImpactItem`, bidirectional sentinel↔research
+  flow.
+
+---
+
+## 3. Next pickable moves (ordered by leverage)
+
+| # | Item | Effort | Risk | Notes |
+|---|------|--------|------|-------|
+| 1 | **OP-1** — SIGHUP hot-reload of `ollama-sentinel.yaml` (`docs/superpowers/followups.md`) | M | med | Real DX pain on long-running watchers. |
+| 2 | **CB-1** — dedupe impact-report formatter (`recipes.py` vs `synthesis.py`) | ~30–45 min | low | Dormant; only triggers if `build_research_context` gets impact data. |
+
+Skip **TR-3** — deliberate spec deviation, documented in `docs/superpowers/followups.md`.
+Qwen3 Phases B/C stay parked (no demand; the Phase-A plan forbids pulling the
+models speculatively).
+
+The "make findings actionable" arc is complete — no arc work left.
+
+---
+
+## 4. Persistent gotchas (not session-specific)
+
+- Research agent requires `pip install -e ".[research]"` (heavy deps: langchain,
+  playwright, llama-index). Not installed by default.
+- `ollama-sentinel run` requires `ollama pull qwen3-embedding:4b` once on first
+  use (~2.5 GB), or set `memory.semantic_recall: false` to fall back to
+  legacy exact-path recall.
+- `embedding.models.consolidation` and `embedding.models.rerank` are
+  pre-registered in the schema but **unwired**. Do not pull
+  `qwen3-embedding:8b` or any reranker unless picking up Phase B or C.
+- `impact_scan` node is tested with mocked logic only — needs an integration
+  test against a real LangGraph compile with `OPENAI_API_KEY`.
+- `_archive/` holds superseded snapshots. Do not import from it.
+- `docs/index.html` is the canonical visual guide — pinned, do-not-move. It was
+  **not** rewritten this session; if it now lags the refreshed VISION.md
+  (e.g. implies the actionability arc is future work), refreshing it is a
+  separate follow-up.
+
+---
+
+## 5. Where things live
+
+- Vision: `docs/VISION.md` (refreshed this session).
+- Canonical handoff breadcrumbs: the "Known Issues / Next Session Breadcrumbs"
+  section in `CLAUDE.md` (already current — this doc complements it).
+- Follow-ups with hashes: `docs/superpowers/followups.md`.
+- Plans: `docs/plans/`. Specs: `docs/superpowers/specs/`.


### PR DESCRIPTION
## What

Refreshes the strategic narrative, which had drifted, and adds a session handoff. **Docs-only — no code touched; suite unchanged (689 passed / 15 skipped).**

### `docs/VISION.md` — structural rewrite
The doc still reported its v0.1.0+ snapshot (*353 tests, ~2.4s suite*) and never mentioned the **"make findings actionable" arc** — the largest body of work since that snapshot. The rewrite:

- Replaces the stale snapshot with a **"Where it is now"** section (v0.2 shipped, Phase A embedding swap, arc complete, test count via `pytest tests/ -q` + date rather than a frozen number).
- Adds a **"Making findings actionable (shipped)"** section covering `surface` / `triage` / `fix <id>` / `prune` (all verified wired in `cli.py`).
- Folds the "model opinion = echo" critique into the Finding/Incident section as motivation.
- **Preserves** the forward narrative: v0.3 shared substrate, north star, explicit non-goals, "what this is not".
- 1566 words — within the ≤2500 Cairn Constraint (`docs/decisions/ADR-SYSTEM.md`). Committed with the `docs(living):` prefix per ADR convention.

### New session handoff
`docs/session-notes/2026-06-07-vision-refresh-and-arc-complete-handoff.md` — current state, next pickable moves (OP-1, CB-1), persistent gotchas. CLAUDE.md "Recent landings" gets a one-line pointer to it.

## Verification
- `pytest tests/ -q` → 689 passed / 15 skipped, green and unchanged (docs-only).
- No broken inbound anchors to the renamed VISION.md sections.
- Every CLI verb named in the rewrite confirmed wired in `ollama_sentinel/cli.py`.

## Out of scope (logged follow-up)
`docs/index.html` (pinned visual guide) lags the refreshed VISION.md — it predates the arc. Not edited here; refreshing it is a separate, larger task.

Plan: `docs/plans/2026-06-07-001-docs-refresh-vision-and-handoff-plan.md`