### PR TITLE
test(grounding): add P1-P4 real-source positive cases

### DIFF
--- a/tests/test_grounding_regression.py
+++ b/tests/test_grounding_regression.py
@@ -166,3 +166,185 @@ def test_mixed_batch_preserves_valid_finding(caplog):
     assert any("MAGIC = 42" in m for m in warnings), (
         "WARNING must include the rejected excerpt"
     )
+
+
+# ---------------------------------------------------------------------------
+# P1-P4 — real-code positive cases (plan Validation item 2).
+#
+# Validation item 2 of docs/superpowers/plans/2026-05-09-reviewer-grounding.md:
+# "Run the pipeline against reviews known to be correct ... The findings must
+#  round-trip without being rejected by the validator. If they're rejected,
+#  the validator is too strict (whitespace normalization wrong, line-range
+#  off-by-one, etc.)."
+#
+# The May-3 retro never snapshotted raw model responses, and the pre-grounding
+# .ollama_reviews/ captures predate the verbatim_excerpt field, so there is no
+# replayable real-history corpus. Instead these fixtures use VERBATIM real
+# source frozen from ollama_sentinel/processor.py @ 47f1929 — the exact
+# @retry construct the plan's own schema example cites — and assert correct
+# findings on it survive the full validate_findings path. Each case targets
+# a strictness failure mode item 2 names that R3 (zero-indent, 2-line) does
+# not cover: multi-line spans, line-range boundaries, deep indentation, and
+# regex-metachar excerpts (a guard against any future substring->regex swap).
+#
+# To regenerate after a real refactor: re-copy the cited line ranges from
+# processor.py and update line_start/line_end. The uniqueness guard below
+# fails loudly if an excerpt stops being unique to its cited range, so a
+# stale fixture cannot pass for the wrong reason.
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+
+def _norm(text: str) -> str:
+    """Mirror extractor._validate_verbatim's private whitespace normaliser."""
+    return _re.sub(r"\s+", " ", text).strip()
+
+
+# processor.py:112-117 — the @retry decorator block (multi-line, 4-space
+# indent, parens). The plan's schema example cites this exact construct.
+_RETRY_BLOCK = (
+    "    @retry(\n"
+    "        retry=retry_if_exception(_is_retryable_ollama_error),\n"
+    "        wait=wait_exponential(multiplier=1, min=2, max=60),\n"
+    "        stop=stop_after_attempt(5),\n"
+    "        reraise=True,\n"
+    "    )\n"
+)
+
+# processor.py:64-66 — contiguous real block used for both line-range
+# boundary cases (first line and last line).
+_STATUS_GUARD = (
+    "    if isinstance(exc, httpx.HTTPStatusError):\n"
+    "        status = exc.response.status_code\n"
+    "        return status == 408 or status == 429 or status >= 500\n"
+)
+
+# processor.py:104-106 — deeply-indented httpx client init; line 2 is rich
+# in regex metacharacters ( ( ) [ ] " . ).
+_CLIENT_INIT = (
+    "        self.client = httpx.AsyncClient(\n"
+    "            timeout=httpx.Timeout(connect=5.0, read=float(config[\"request_timeout\"]), write=5.0, pool=5.0)\n"
+    "        )\n"
+)
+
+
+@pytest.mark.parametrize(
+    "case_id, file_content, finding",
+    [
+        # P1 — multi-line (>2) excerpt, real 4-space indentation, parens.
+        (
+            "P1_multiline_decorator",
+            _RETRY_BLOCK,
+            {
+                "line_start": 1,
+                "line_end": 6,
+                "category": "reliability",
+                "severity": "medium",
+                "verbatim_excerpt": (
+                    "@retry( retry=retry_if_exception(_is_retryable_ollama_error), "
+                    "wait=wait_exponential(multiplier=1, min=2, max=60), "
+                    "stop=stop_after_attempt(5), reraise=True, )"
+                ),
+                "description": "retry predicate spans the whole decorator block.",
+            },
+        ),
+        # P2 — line-range END boundary: excerpt only on the final line.
+        # An end-exclusive off-by-one would slice it away and reject.
+        (
+            "P2_end_boundary",
+            _STATUS_GUARD,
+            {
+                "line_start": 3,
+                "line_end": 3,
+                "category": "maintainability",
+                "severity": "low",
+                "verbatim_excerpt": "return status == 408 or status == 429 or status >= 500",
+                "description": "Status predicate is the last line of the block.",
+            },
+        ),
+        # P3 — line-range START boundary: excerpt only on line 1.
+        # A start-off-by-one (lines[start:end] with start=line_start) empties
+        # the slice and rejects.
+        (
+            "P3_start_boundary",
+            _STATUS_GUARD,
+            {
+                "line_start": 1,
+                "line_end": 1,
+                "category": "design",
+                "severity": "low",
+                "verbatim_excerpt": "if isinstance(exc, httpx.HTTPStatusError):",
+                "description": "Guard clause is the first line of the block.",
+            },
+        ),
+        # P4 — deep (12-space) indentation + regex metacharacters in the
+        # excerpt. Whitespace must normalise; ( ) [ ] " must NOT be treated
+        # as a pattern (guards a future substring->regex regression).
+        (
+            "P4_deep_indent_metachars",
+            _CLIENT_INIT,
+            {
+                "line_start": 2,
+                "line_end": 2,
+                "category": "reliability",
+                "severity": "medium",
+                "verbatim_excerpt": (
+                    'timeout=httpx.Timeout(connect=5.0, '
+                    'read=float(config["request_timeout"]), write=5.0, pool=5.0)'
+                ),
+                "description": "Timeout construction line, deeply indented.",
+            },
+        ),
+    ],
+    ids=[
+        "P1_multiline_decorator",
+        "P2_end_boundary",
+        "P3_start_boundary",
+        "P4_deep_indent_metachars",
+    ],
+)
+def test_correct_finding_on_real_source_is_not_rejected(
+    case_id, file_content, finding, caplog
+):
+    """A correct finding on verbatim real source round-trips un-rejected.
+
+    Empirical seal on plan Validation item 2: the validator must not be too
+    strict against real, correct findings (whitespace, multi-line, line-range
+    boundaries, metachars).
+    """
+    # Uniqueness guard: the normalised excerpt occurs exactly once in the
+    # normalised file, so a True result can ONLY mean the cited range matched
+    # — not an accidental substring elsewhere (green-for-wrong-reason).
+    occurrences = _norm(file_content).count(_norm(finding["verbatim_excerpt"]))
+    assert occurrences == 1, (
+        f"{case_id}: excerpt must be unique to its cited range "
+        f"(found {occurrences}); fixture is ambiguous and proves nothing"
+    )
+
+    # Step 1: the validator helper accepts it.
+    assert _validate_verbatim(finding, file_content) is True, (
+        f"{case_id}: validator rejected a correct excerpt — it is too strict"
+    )
+
+    # Step 2: the full path returns the finding intact, no WARNING.
+    with caplog.at_level("WARNING"):
+        result = asyncio.run(
+            validate_findings([finding], f"{case_id}.py", file_content)
+        )
+
+    assert len(result) == 1, f"{case_id}: correct finding must survive validation"
+    survived = result[0]
+    assert survived.verbatim_excerpt == finding["verbatim_excerpt"]
+    assert survived.category == finding["category"]
+    assert survived.description == finding["description"]
+
+    rejection_warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelname == "WARNING" and "not found in cited range" in r.getMessage()
+    ]
+    assert not rejection_warnings, (
+        f"{case_id}: a correct finding must not emit a rejection WARNING; "
+        f"got {rejection_warnings}"
+    )


### PR DESCRIPTION
Salvages real test coverage from the abandoned `docs/2026-05-15-implementation-audit` branch (commit `e3011cd`) before that branch is deleted.

## What
`tests/test_grounding_regression.py` on master had only the **R1–R4 slop-*rejection*** cases. This adds **P1–P4 real-code *positive*** cases that prove the grounding validator round-trips correct findings without over-rejecting them — **Validation item 2** of `docs/superpowers/plans/2026-05-09-reviewer-grounding.md`.

The fixtures use verbatim real source (the `@retry` construct the plan's schema example cites) and assert correct findings survive the full `validate_findings` path.

## Verification
- `pytest tests/test_grounding_regression.py -q` → 8 passed (4 R + 4 P).
- Full suite → **693 passed / 15 skipped** (was 689; +4 here).

## Note
Test-only salvage. The source branch's CLAUDE.md / followups.md / plan-doc edits were **intentionally left behind** — they predate ~88 commits of master and would revert current state.