### PR TITLE
feat(watcher): SIGHUP hot-reload of ollama-sentinel.yaml (OP-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This is the primary product surface. Everything the sentinel knows is visible he
 
 > **Heads up — directory matters.** `ollama-sentinel run` reads `ollama-sentinel.yaml` from the **current working directory**. If you have stale YAMLs in multiple project folders, the cwd one wins. Run from anywhere with `ollama-sentinel run --config <abs-path-to-ollama-sentinel.yaml>` if that's a problem.
 
+> **Hot-reload (POSIX).** Edit the YAML while the watcher is running and send `kill -HUP <pid>` — the sentinel reloads model and `request_timeout` settings in place without dropping the watch. (Changing `watch.directory` still needs a restart; it's warned-and-skipped on reload.)
+
 ## Documentation
 
 See **[docs/GUIDE.md](docs/GUIDE.md)** for the full user guide covering:

--- a/docs/superpowers/followups.md
+++ b/docs/superpowers/followups.md
@@ -140,7 +140,21 @@ here for traceability.
 
 ## Operational DX (filed 2026-05-02)
 
-### OP-1. `ollama-sentinel run` doesn't hot-reload `ollama-sentinel.yaml`
+### OP-1. `ollama-sentinel run` doesn't hot-reload — RESOLVED 2026-06-07
+
+**Resolution:** `ollama-sentinel run` now installs a SIGHUP handler
+(`FileSentinel.install_reload_handler`, POSIX-only, registered in
+`FileSentinel.run`). On `kill -HUP <pid>` it calls `FileSentinel.reload_config`,
+which reloads the YAML and applies model/timeout changes in place via
+`FileProcessor.apply_ollama_config` (closes the old `OllamaClient`, builds a
+new one, recomputes the token budget) — the `awatch` loop keeps running. A
+changed `watch.directory` is warned-and-skipped (restart required); a broken
+YAML is logged and the running config is left intact. Six tests in
+`tests/test_hot_reload.py`. Original surface below for context.
+
+---
+
+### OP-1 (original). `ollama-sentinel run` doesn't hot-reload `ollama-sentinel.yaml`
 
 **Files:** `ollama_sentinel/watcher.py:103-126` (FileSentinel.__init__),
 `ollama_sentinel/processor.py:36-58` (OllamaClient.__init__ — bakes

--- a/ollama_sentinel/processor.py
+++ b/ollama_sentinel/processor.py
@@ -345,6 +345,23 @@ class FileProcessor:
         if self._cache is not None and hasattr(self._cache, "close"):
             self._cache.close()
 
+    async def apply_ollama_config(self, ollama_config) -> None:
+        """Rebuild the Ollama client in place from a new OllamaConfig.
+
+        Closes the existing client, swaps in one built from ``ollama_config``,
+        and recomputes the token budget from the (possibly changed) default
+        model. Backs the hot-reload path so the watcher loop keeps running
+        while model/timeout settings change.
+        """
+        await self.ollama_client.close()
+        self.ollama_client = OllamaClient(ollama_config.model_dump())
+        self.config.ollama = ollama_config
+        default_model = ollama_config.models["default"]
+        self.total_budget = max(
+            1024,
+            default_model.context_window - default_model.output_reserve_tokens,
+        )
+
     def prepare_file_content(self, file_change: FileChange) -> None:
         """
         Prepare file content or git diff for review.

--- a/ollama_sentinel/watcher.py
+++ b/ollama_sentinel/watcher.py
@@ -4,6 +4,7 @@ File watcher for Ollama Sentinel.
 import asyncio
 import logging
 import pathlib
+import signal
 import time
 from typing import Dict, Optional, Set
 
@@ -368,9 +369,64 @@ class FileSentinel:
                 self.pending_changes.update(stable_files)
                 await self.process_pending_changes()
     
+    async def reload_config(self) -> bool:
+        """Reload the YAML config and apply model/timeout changes in place.
+
+        Returns True when a reload was applied, False when the file failed to
+        load (the running config is left untouched in that case). A changed
+        ``watch.directory`` is warned-and-skipped — the running ``awatch`` loop
+        is bound to the original tree, so a restart is required to move it.
+        """
+        try:
+            new_config = load_config(self.config_path)
+        except Exception as e:  # defensive: load_config already swallows most
+            log.error("Config reload failed (%s); keeping current config.", e)
+            return False
+        if not new_config:
+            log.error("Config reload failed; keeping current config.")
+            return False
+
+        new_dir = pathlib.Path(new_config.watch.directory).resolve()
+        cur_dir = pathlib.Path(self.config.watch.directory).resolve()
+        if new_dir != cur_dir:
+            log.warning(
+                "watch.directory change ignored on hot-reload (%s -> %s); "
+                "restart the watcher to change the watched tree.",
+                cur_dir, new_dir,
+            )
+
+        # Only model/timeout settings are honored. apply_ollama_config mutates
+        # the shared config object's `ollama`, so self.config stays current
+        # without reassigning it (which would desync from the processor).
+        await self.processor.apply_ollama_config(new_config.ollama)
+        log.info("Config hot-reloaded: model/timeout settings updated.")
+        return True
+
+    def install_reload_handler(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Register a SIGHUP handler that hot-reloads config (POSIX only)."""
+        if not hasattr(signal, "SIGHUP"):
+            return
+
+        def _on_sighup() -> None:
+            log.info("SIGHUP received — reloading configuration.")
+            loop.create_task(self.reload_config())
+
+        try:
+            loop.add_signal_handler(signal.SIGHUP, _on_sighup)
+            log.info("SIGHUP hot-reload handler installed.")
+        except (NotImplementedError, RuntimeError) as e:
+            log.warning("Could not install SIGHUP reload handler: %s", e)
+
     async def run(self) -> None:
         """Run the sentinel."""
+        loop = asyncio.get_running_loop()
+        self.install_reload_handler(loop)
         try:
             await self.watch_directory()
         finally:
+            if hasattr(signal, "SIGHUP"):
+                try:
+                    loop.remove_signal_handler(signal.SIGHUP)
+                except (NotImplementedError, RuntimeError):
+                    pass
             await self.processor.close()

--- a/tests/test_hot_reload.py
+++ b/tests/test_hot_reload.py
@@ -1,0 +1,116 @@
+"""SIGHUP hot-reload of ollama-sentinel.yaml (OP-1).
+
+A long-running `ollama-sentinel run` loads its YAML once at start. These
+tests pin the in-place reload behavior: model/timeout updates are applied by
+rebuilding the OllamaClient without restarting the watcher; watch.directory
+changes are warned-and-skipped; a broken YAML leaves the running config intact.
+"""
+import asyncio
+import logging
+import os
+import signal
+
+import pytest
+import yaml
+
+from ollama_sentinel.watcher import FileSentinel
+
+
+def _rewrite_yaml(path, mutate):
+    """Load the YAML, apply mutate(dict) in place, write it back."""
+    data = yaml.safe_load(path.read_text())
+    mutate(data)
+    path.write_text(yaml.dump(data, sort_keys=False))
+
+
+class TestReloadConfig:
+    async def test_reload_updates_request_timeout(self, config_yaml_path):
+        sentinel = FileSentinel(config_yaml_path)
+        try:
+            assert sentinel.processor.ollama_client.client.timeout.read == 120.0
+            _rewrite_yaml(
+                config_yaml_path,
+                lambda d: d["ollama"].__setitem__("request_timeout", 600),
+            )
+            result = await sentinel.reload_config()
+            assert result is True
+            assert sentinel.config.ollama.request_timeout == 600
+            assert sentinel.processor.ollama_client.client.timeout.read == 600.0
+        finally:
+            await sentinel.processor.close()
+
+    async def test_reload_updates_default_model(self, config_yaml_path):
+        sentinel = FileSentinel(config_yaml_path)
+        try:
+            _rewrite_yaml(
+                config_yaml_path,
+                lambda d: d["ollama"]["models"]["default"].__setitem__("name", "new-model"),
+            )
+            await sentinel.reload_config()
+            assert sentinel.config.ollama.models["default"].name == "new-model"
+            assert (
+                sentinel.processor.ollama_client.config["models"]["default"]["name"]
+                == "new-model"
+            )
+        finally:
+            await sentinel.processor.close()
+
+    async def test_reload_closes_old_client(self, config_yaml_path):
+        sentinel = FileSentinel(config_yaml_path)
+        old_client = sentinel.processor.ollama_client
+        try:
+            await sentinel.reload_config()
+            assert sentinel.processor.ollama_client is not old_client
+            assert old_client.client.is_closed
+        finally:
+            await sentinel.processor.close()
+
+    async def test_reload_ignores_directory_change(self, config_yaml_path, tmp_path, caplog):
+        sentinel = FileSentinel(config_yaml_path)
+        original_dir = sentinel.config.watch.directory
+        try:
+            other = tmp_path / "elsewhere"
+            other.mkdir()
+            _rewrite_yaml(
+                config_yaml_path,
+                lambda d: d["watch"].__setitem__("directory", str(other)),
+            )
+            with caplog.at_level(logging.WARNING):
+                await sentinel.reload_config()
+            assert sentinel.config.watch.directory == original_dir
+            assert any("directory" in r.message.lower() for r in caplog.records)
+        finally:
+            await sentinel.processor.close()
+
+    async def test_reload_keeps_config_on_load_failure(self, config_yaml_path):
+        sentinel = FileSentinel(config_yaml_path)
+        try:
+            config_yaml_path.write_text("not: valid: yaml: {[}")
+            result = await sentinel.reload_config()
+            assert result is False
+            assert sentinel.config.ollama.request_timeout == 120
+        finally:
+            await sentinel.processor.close()
+
+
+class TestSighupHandler:
+    async def test_sighup_triggers_reload(self, config_yaml_path):
+        if not hasattr(signal, "SIGHUP"):
+            pytest.skip("SIGHUP not available on this platform")
+        sentinel = FileSentinel(config_yaml_path)
+        loop = asyncio.get_running_loop()
+        try:
+            sentinel.install_reload_handler(loop)
+            _rewrite_yaml(
+                config_yaml_path,
+                lambda d: d["ollama"].__setitem__("request_timeout", 600),
+            )
+            os.kill(os.getpid(), signal.SIGHUP)
+            for _ in range(100):
+                await asyncio.sleep(0.02)
+                if sentinel.config.ollama.request_timeout == 600:
+                    break
+            assert sentinel.config.ollama.request_timeout == 600
+        finally:
+            loop.remove_signal_handler(signal.SIGHUP)
+            await sentinel.processor.close()


### PR DESCRIPTION
Resolves **OP-1** (`docs/superpowers/followups.md`).

## Problem
`ollama-sentinel run` loads `ollama-sentinel.yaml` once at startup. Editing model or `request_timeout` settings on a running watcher has no effect — you have to Ctrl-C and restart. This bit the user during a `request_timeout: 180 → 600` bump for cloud-model round-trips: the running watcher kept timing out at 180s.

## Change
- **`FileSentinel.install_reload_handler`** — registers a SIGHUP handler (POSIX-only, guarded) in `run()`. `kill -HUP <pid>` triggers a reload.
- **`FileSentinel.reload_config`** — reloads the YAML and applies changes **in place**; the `awatch` loop keeps running. A changed `watch.directory` is **warned-and-skipped** (restart required); a broken YAML is logged and the running config is left intact.
- **`FileProcessor.apply_ollama_config`** — rebuilds the `OllamaClient` (closing the old one) and recomputes the token budget from the new default model.

## Scope
Only model/timeout (the `ollama` config block) is hot-reloaded — matching OP-1's stated scope. `watch.directory` reload is explicitly out of scope (would require restarting the `awatch` loop).

## Tests
`tests/test_hot_reload.py` — 6 tests, TDD (written failing first):
- reload applies `request_timeout` and default-model changes
- old `OllamaClient` is closed on rebuild
- `watch.directory` change is ignored + warned
- broken YAML leaves the running config intact (returns False)
- **integration:** a real `os.kill(pid, SIGHUP)` triggers the reload

Full suite: **699 passed / 15 skipped** (was 693; +6 here).

## Docs
followups.md OP-1 marked resolved; README documents the hot-reload under the `run` section.