### PR TITLE
docs: close CB-1 (already deduped) + refresh next-moves breadcrumbs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,18 +202,24 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 
 ### Resume here next time
 
-1. **Sanity check.** `pytest tests/ -q` should be green (689 / 15 skip last seen).
+1. **Sanity check.** `pytest tests/ -q` should be green (run it for the live
+   count; ~699 / 15 skip after OP-1 landed — do not trust this number, it drifts).
 2. **The "make findings actionable" arc is complete** (stale-prune `prune`
    merged via PR #29, 2026-06-05). No arc work left.
-3. **The deferred tail** (none blocking): OP-1 SIGHUP hot-reload, CB-1
-   formatter dedupe — see `docs/superpowers/followups.md`.
+3. **The deferred DX tail is now closed:** OP-1 SIGHUP hot-reload SHIPPED
+   (PR #32, 2026-06-07); CB-1 formatter dedupe verified already-done (drift
+   correction, 2026-06-07). See `docs/superpowers/followups.md`.
 
 ### Pickable next moves (ordered by leverage)
 
+The small-DX backlog is drained. What's left is the v0.3 product leap plus one
+testing gap.
+
 | # | Item | Effort | Risk | Notes |
 |---|---|---|---|---|
-| 1 | OP-1 — SIGHUP hot-reload of `ollama-sentinel.yaml` (`docs/superpowers/followups.md`) | M | med | Real DX pain on long-running watchers. |
-| 2 | CB-1 — dedupe impact-report formatter (`recipes.py` vs `synthesis.py`) | ~30-45 min | low | Dormant; only triggers if `build_research_context` gets impact data. |
+| 1 | **Pattern promotion** — the Finding→Incident→**Pattern** rung (≥3 incidents of the same shape → project-specific guardrail). The north-star payoff. | L | med | Design-heavy — start with `/ce-brainstorm` (shape-detection, storage, feedback into review context). Not yet started. |
+| 2 | **v0.3 shared substrate** — lift `ImportResolver` to shared infra, unify `Finding`/`ImpactItem`, bidirectional impact↔incident flow. | L | med | The moat play (see `docs/VISION.md`). Larger/architectural; can follow Pattern. |
+| 3 | **`impact_scan` integration test** — currently mocked-only; needs a real LangGraph compile w/ `OPENAI_API_KEY`. | S-M | low | Closes a long-standing testing gotcha. |
 
 Skip TR-3 — deliberate spec deviation, documented in followups.md. Qwen3
 Phases B/C stay parked (no demand; the Phase-A plan forbids pulling the models

--- a/docs/superpowers/followups.md
+++ b/docs/superpowers/followups.md
@@ -15,22 +15,22 @@ Not blockers — each entry has enough context to pick up in a fresh session.
 Plan: `docs/superpowers/plans/2026-04-16-context-builder.md`.
 Spec: `docs/superpowers/specs/2026-04-16-context-builder-design.md`.
 
-### CB-1. Dedupe impact-report formatters
+### CB-1. Dedupe impact-report formatters — DONE (verified 2026-06-07)
 
-**Files:** `ollama_sentinel/context/recipes.py:_format_impact_report`,
-`research_agent/tools/synthesis.py:format_impact_report`.
+**Files:** `ollama_sentinel/context/recipes.py:format_impact_report` (canonical),
+`research_agent/tools/synthesis.py:format_impact_report` (thin wrapper).
 
-**Issue:** two formatters diverge — the `SynthesisTool` version emits a
-`SUGGESTED FIRST COMMIT` block for HIGH-severity items; the recipe version
-does not. Currently mutually exclusive (synthesis short-circuits impact
-before reaching the recipe), so harmless today.
+**Was:** two formatters diverged — the `SynthesisTool` version emitted a
+`SUGGESTED FIRST COMMIT` block for HIGH-severity items; the recipe version did
+not.
 
-**Fix:** move the canonical formatter to a neutral location
-(`ollama_sentinel/context/recipes.py` or a shared
-`research_agent/core/impact.py`) and have both callers import it.
-
-**Trigger:** any PR that makes `build_research_context` a reachable path
-for impact data.
+**Resolution:** the canonical formatter now lives in
+`ollama_sentinel/context/recipes.py:format_impact_report` with the
+`SUGGESTED FIRST COMMIT` block reconciled in (line ~156).
+`SynthesisTool.format_impact_report` imports it (`_shared_format_impact_report`)
+and only prepends the standalone `IMPACT ANALYSIS:` header. No duplicate
+formatter body remains; `tests/test_research_agent.py::TestImpactSynthesisFormat`
+exercises the shared formatter directly. No further action required.
 
 ### CB-2. SemanticRetriever integration test — DONE (commit 566eb67)
 


### PR DESCRIPTION
Doc-accuracy fix. **CB-1** (dedupe impact-report formatters) turned out to be **already resolved** — the canonical `format_impact_report` lives in `ollama_sentinel/context/recipes.py` (with the `SUGGESTED FIRST COMMIT` block reconciled in) and `research_agent/tools/synthesis.py` delegates to it via a thin header-prepending wrapper. No duplicate formatter body remains; tests exercise the shared one. The followups.md/CLAUDE.md entries were stale.

This PR:
- Marks **CB-1 DONE** in `followups.md` with the resolution detail.
- Records **OP-1 shipped** (PR #32) in CLAUDE.md and removes both from the deferred tail.
- Repoints **Pickable next moves** at the real remaining work: v0.3 Pattern promotion (north-star rung), v0.3 shared substrate, and the `impact_scan` integration test.

No code changes.