### PR TITLE
fix(grounding): salvage truncated structured reviews instead of discarding findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,8 +289,8 @@ speculatively).
 
 ### Recent landings
 
-- 2026-06-13: **v0.3 Pattern promotion → project guardrails BUILT (8-PR stack,
-  pending merge).** Executed the `docs/plans/2026-06-08-001-...-plan.md` plan
+- 2026-06-13: **v0.3 Pattern promotion → project guardrails BUILT + MERGED
+  (8-PR stack).** Executed the `docs/plans/2026-06-08-001-...-plan.md` plan
   end-to-end via `/ce-work`, TDD per unit, one stacked PR each off master:
   **Phase 1** — U1 storage+provenance (#37: `guardrails` table + CRUD + finding
   `guardrail_id` via additive migration), U2 CLI authoring/lifecycle (#38:
@@ -302,11 +302,22 @@ speculatively).
   surfacing+curation (#43: `guardrail candidates/promote/reject` w/ LLM-drafted
   assertions + signature suppression), U8 evidence-integrity gate (#44:
   `counts_toward_strength` — self-caused findings reinforce only via
-  test_failure/fix_commit, no echo). Suite 699→803 passed / 16 skip. Two
-  transparent deferrals: live dashboard *pending*-candidate view (KTD4: clustering
-  on-demand only) and U8 scoped-vs-global gate — both flagged in the PR bodies.
-  Also salvaged-truncated-grounded-review fix as independent **PR #36**. Merge
-  bottom-up #37→#44 (+ #36).
+  test_failure/fix_commit, no echo). Plus full doc sweep (#45: README, GUIDE,
+  VISION, index.html, CLAUDE.md). Suite 699→803 passed / 16 skip. All
+  rebase-merged bottom-up #37→#45 to master 2026-06-13. Two transparent
+  deferrals (open): live dashboard *pending*-candidate view (KTD4: clustering
+  on-demand only) and U8 scoped-vs-global gate — both noted in the U7/U8 PRs.
+- 2026-06-12: **Truncated grounded-review salvage (PR #36, merged 2026-06-13).**
+  A grounded review that hits the output-token cap (`num_predict`) is cut
+  mid-JSON by Ollama; the parse failure was misdiagnosed as "model ignored
+  format" and every complete finding was discarded, degrading to the regex
+  extractor. Now `OllamaClient.generate_with_model` reads `done_reason` and warns
+  with the `num_predict` value on truncation, and `_parse_review_response` runs a
+  string/escape-aware bracket scan (`_salvage_truncated_review`) to trim to the
+  last complete finding object, close the document, and re-parse — summary + all
+  complete findings survive; only the finding cut mid-generation is lost.
+  `:cloud` schema-ignoring prose still degrades to the legacy extractor. 10 new
+  tests. Reproduced live against `qwen3-coder:30b`.
 - 2026-06-08: **Small-DX backlog drained + v0.3 Pattern-promotion planned.**
   Shipped OP-1 SIGHUP hot-reload (PR #32), the impact_scan integration test
   (PR #34), and salvaged grounding P1–P4 positives (PR #31); closed CB-1 as

--- a/ollama_sentinel/processor.py
+++ b/ollama_sentinel/processor.py
@@ -54,6 +54,57 @@ def _review_format(config) -> Optional[Union[str, Dict[str, Any]]]:
     return _REVIEW_SCHEMA if config.processing.grounding else None
 
 
+def _salvage_truncated_review(raw: Any) -> Optional[Dict[str, Any]]:
+    """Recover the complete findings from a truncated grounded review.
+
+    When generation hits the output-token cap (Ollama ``done_reason:
+    "length"``), the schema-constrained JSON is cut mid-stream — the document
+    never closes, but every finding emitted before the cut is still
+    well-formed. Trim to the last complete object in the ``findings`` array,
+    close the document, and re-parse. Returns the salvaged dict only when the
+    result is schema-conformant; anything else (true prose from a
+    schema-ignoring model, a cut inside ``summary``) returns None so the
+    caller degrades to the legacy extractor as before.
+    """
+    if not isinstance(raw, str):
+        return None
+    depth = 0
+    in_string = False
+    escaped = False
+    last_finding_close = -1
+    for i, ch in enumerate(raw):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch in "{[":
+            depth += 1
+        elif ch in "}]":
+            depth -= 1
+            # A '}' landing back on depth 2 closes one item of the top-level
+            # findings array: {root(1) -> findings [(2) -> finding {(3).
+            if ch == "}" and depth == 2:
+                last_finding_close = i + 1
+    if last_finding_close < 0:
+        return None
+    try:
+        parsed = json.loads(raw[:last_finding_close] + "]}")
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if (
+        isinstance(parsed, dict)
+        and "summary" in parsed
+        and isinstance(parsed.get("findings"), list)
+    ):
+        return parsed
+    return None
+
+
 def _is_retryable_ollama_error(exc: BaseException) -> bool:
     """Return True for transient Ollama HTTP errors worth retrying.
 
@@ -248,7 +299,16 @@ class OllamaClient:
         try:
             response = await self.client.post(url, headers=headers, json=payload)
             response.raise_for_status()
-            return response.json()["message"]["content"]
+            data = response.json()
+            if data.get("done_reason") == "length":
+                log.warning(
+                    "Model %s hit the output-token cap (num_predict=%s); the "
+                    "response is truncated. Raise the model's max_tokens / "
+                    "output_reserve_tokens if this recurs.",
+                    name,
+                    options.get("num_predict", "unset"),
+                )
+            return data["message"]["content"]
         except httpx.ReadTimeout:
             log.error(
                 "Ollama API read timeout after %ss for model %s "
@@ -635,10 +695,26 @@ class FileProcessor:
                     "grounding_parse_failed": True,
                 }
         except (json.JSONDecodeError, TypeError, ValueError) as e:
-            # The model ignored Ollama's `format` schema (common for :cloud
-            # models and markdown-instructed system prompts) and returned
-            # prose. Recoverable: the watcher degrades to the legacy regex
-            # extractor on the prose. WARNING, not ERROR — handled path.
+            # Two distinct failure shapes land here. (1) Generation hit the
+            # output-token cap (done_reason "length") and the JSON was cut
+            # mid-stream — the findings emitted before the cut are intact, so
+            # salvage them rather than discarding the structured review.
+            salvaged = _salvage_truncated_review(raw)
+            if salvaged is not None:
+                log.warning(
+                    "Grounded review JSON was truncated mid-stream (%s) — "
+                    "output likely hit the token cap; salvaged the summary "
+                    "and %d complete finding(s). Raise the model's "
+                    "output_reserve_tokens / max_tokens to stop losing "
+                    "findings.",
+                    e,
+                    len(salvaged["findings"]),
+                )
+                return salvaged
+            # (2) The model ignored Ollama's `format` schema (common for
+            # :cloud models and markdown-instructed system prompts) and
+            # returned prose. Recoverable: the watcher degrades to the legacy
+            # regex extractor on the prose. WARNING, not ERROR — handled path.
             log.warning(
                 "Grounded review did not parse as JSON (%s); "
                 "degrading to legacy prose extractor", e,

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -575,6 +575,178 @@ class TestParseReviewResponse:
         assert result["findings"] == []
         assert result["grounding_parse_failed"] is True
 
+    async def test_truncated_grounded_json_salvages_complete_findings(
+        self, sentinel_config, tmp_path, httpx_mock, caplog
+    ):
+        """Output cut at num_predict mid-finding recovers the summary and
+        every complete finding instead of degrading to the prose extractor."""
+        from ollama_sentinel.processor import FileProcessor, FileChange
+        from watchfiles import Change
+        import json
+
+        source = tmp_path / "big.py"
+        source.write_text("a = 1\nb = 2\n")
+
+        full = json.dumps(
+            {
+                "summary": "Two issues found.",
+                "findings": [
+                    {
+                        "line_start": 1,
+                        "line_end": 1,
+                        "category": "bug",
+                        "severity": "high",
+                        "verbatim_excerpt": "a = 1",
+                        "description": "First issue",
+                    },
+                    {
+                        "line_start": 2,
+                        "line_end": 2,
+                        "category": "style",
+                        "severity": "low",
+                        "verbatim_excerpt": "b = 2",
+                        "description": "Second issue",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        # Cut mid-way through the second finding's description string —
+        # the shape Ollama produces when generation hits num_predict.
+        truncated = full[: full.rindex("Second iss") + len("Second iss")]
+
+        httpx_mock.add_response(
+            url="http://localhost:11434/api/chat",
+            json={"message": {"content": truncated}, "done_reason": "length"},
+        )
+        fp = FileProcessor(sentinel_config)
+        fc = FileChange(path=source, change_type=Change.modified)
+        try:
+            result = await fp.generate_review(fc)
+        finally:
+            await fp.ollama_client.close()
+
+        assert result["summary"] == "Two issues found."
+        assert len(result["findings"]) == 1
+        assert result["findings"][0]["description"] == "First issue"
+        assert "grounding_parse_failed" not in result
+
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("salvaged" in m for m in warnings)
+
+    async def test_truncated_before_any_complete_finding_degrades(
+        self, sentinel_config, tmp_path, httpx_mock
+    ):
+        """Truncation before the first finding closes leaves nothing to
+        salvage — degrade to the legacy extractor as before."""
+        from ollama_sentinel.processor import FileProcessor, FileChange
+        from watchfiles import Change
+
+        source = tmp_path / "tiny.py"
+        source.write_text("x = 1\n")
+
+        truncated = '{\n  "summary": "Cut off mid-summ'
+        httpx_mock.add_response(
+            url="http://localhost:11434/api/chat",
+            json={"message": {"content": truncated}, "done_reason": "length"},
+        )
+        fp = FileProcessor(sentinel_config)
+        fc = FileChange(path=source, change_type=Change.modified)
+        try:
+            result = await fp.generate_review(fc)
+        finally:
+            await fp.ollama_client.close()
+
+        assert result["summary"] == truncated
+        assert result["findings"] == []
+        assert result["grounding_parse_failed"] is True
+
+
+class TestSalvageTruncatedReview:
+    """Unit tests for the pure _salvage_truncated_review helper."""
+
+    def _make_finding(self, n: int, excerpt: str = "code") -> dict:
+        return {
+            "line_start": n,
+            "line_end": n,
+            "category": "bug",
+            "severity": "low",
+            "verbatim_excerpt": excerpt,
+            "description": f"finding {n}",
+        }
+
+    def test_recovers_findings_before_the_cut(self):
+        import json
+        from ollama_sentinel.processor import _salvage_truncated_review
+
+        full = json.dumps(
+            {
+                "summary": "s",
+                "findings": [self._make_finding(1), self._make_finding(2)],
+            },
+            indent=2,
+        )
+        truncated = full[: full.rindex("finding 2")]
+
+        salvaged = _salvage_truncated_review(truncated)
+        assert salvaged is not None
+        assert salvaged["summary"] == "s"
+        assert len(salvaged["findings"]) == 1
+
+    def test_braces_and_escaped_quotes_inside_strings_do_not_confuse_scan(self):
+        import json
+        from ollama_sentinel.processor import _salvage_truncated_review
+
+        tricky = 'if x { return "}\\"]}" }'
+        full = json.dumps(
+            {
+                "summary": "s",
+                "findings": [
+                    self._make_finding(1, excerpt=tricky),
+                    self._make_finding(2),
+                ],
+            },
+            indent=2,
+        )
+        truncated = full[: full.rindex("finding 2")]
+
+        salvaged = _salvage_truncated_review(truncated)
+        assert salvaged is not None
+        assert len(salvaged["findings"]) == 1
+        assert salvaged["findings"][0]["verbatim_excerpt"] == tricky
+
+    def test_cut_between_findings_after_comma(self):
+        import json
+        from ollama_sentinel.processor import _salvage_truncated_review
+
+        full = json.dumps(
+            {
+                "summary": "s",
+                "findings": [self._make_finding(1), self._make_finding(2)],
+            },
+            indent=2,
+        )
+        # Cut right after the comma that separates the two findings.
+        cut = full.index("},") + 2
+        salvaged = _salvage_truncated_review(full[:cut])
+        assert salvaged is not None
+        assert len(salvaged["findings"]) == 1
+
+    def test_prose_returns_none(self):
+        from ollama_sentinel.processor import _salvage_truncated_review
+
+        assert _salvage_truncated_review("This is a prose review. No JSON.") is None
+
+    def test_truncated_summary_returns_none(self):
+        from ollama_sentinel.processor import _salvage_truncated_review
+
+        assert _salvage_truncated_review('{"summary": "cut mid-str') is None
+
+    def test_non_string_returns_none(self):
+        from ollama_sentinel.processor import _salvage_truncated_review
+
+        assert _salvage_truncated_review(None) is None
+
 
 # ---------------------------------------------------------------------------
 # Recipe instruction ordering test (Step 2)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -311,6 +311,50 @@ class TestOllamaClient:
 
         assert result == expected
 
+    async def test_done_reason_length_logs_truncation_warning(
+        self, ollama_config, httpx_mock: HTTPXMock, caplog
+    ):
+        """done_reason=length means Ollama cut the output at num_predict —
+        warn with the cap value so the user knows which knob to raise."""
+        httpx_mock.add_response(
+            url=OLLAMA_CHAT_URL,
+            json={
+                "message": {"content": '{"summary": "cut off mid'},
+                "done_reason": "length",
+            },
+        )
+
+        client = OllamaClient(ollama_config)
+        try:
+            result = await client.generate_review("default", "prompt")
+        finally:
+            await client.close()
+
+        assert result == '{"summary": "cut off mid'
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("output-token cap" in m and "2000" in m for m in warnings)
+
+    async def test_done_reason_stop_logs_no_warning(
+        self, ollama_config, httpx_mock: HTTPXMock, caplog
+    ):
+        """A normal completion (done_reason=stop) must not warn."""
+        httpx_mock.add_response(
+            url=OLLAMA_CHAT_URL,
+            json={
+                "message": {"content": "complete review"},
+                "done_reason": "stop",
+            },
+        )
+
+        client = OllamaClient(ollama_config)
+        try:
+            result = await client.generate_review("default", "prompt")
+        finally:
+            await client.close()
+
+        assert result == "complete review"
+        assert not [r for r in caplog.records if r.levelname in ("WARNING", "ERROR")]
+
 
 # ---------------------------------------------------------------------------
 # FileProcessor.format_prompt tests


### PR DESCRIPTION
## Summary

A grounded review that hits the output-token cap (`num_predict`, derived from `output_reserve_tokens`) is cut mid-JSON by Ollama. Local models are grammar-constrained by the format schema, so **truncation is the only way their output can be invalid JSON** — yet the parse failure was misdiagnosed as "model ignored format," and every complete finding the model emitted was thrown away, degrading to the regex extractor over truncated JSON text.

Reproduced live against `qwen3-coder:30b` (`done_reason: "length"`, same unterminated-string signature).

## Changes

- **`OllamaClient.generate_with_model`** now reads `done_reason` and warns with the `num_predict` value when output is truncated, instead of silently discarding the signal. Benefits review, triage, and remediate callers.
- **`_parse_review_response`** tries `_salvage_truncated_review` before degrading: a string/escape-aware bracket scan trims to the last complete finding object, closes the document, and re-parses. The summary and all complete findings survive; only the finding cut mid-generation is lost. Genuine schema-ignoring prose (`:cloud` models) still degrades to the legacy extractor exactly as before.

## Tests

10 new tests: `done_reason` warning on/off, salvage + degrade paths through `generate_review`, and unit coverage of the scanner (escaped quotes, braces inside excerpt strings, cut-after-comma).

Full suite: **709 passed / 16 skipped**.