### PR TITLE
feat(guardrails): U1 — guardrail storage model + finding provenance

### DIFF
--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -8,6 +8,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
+# Sentinel distinguishing "argument not provided" from an explicit None
+# (used by update_guardrail so callers can *clear* a scope field with None).
+_UNSET = object()
+
 
 @dataclass
 class Finding:
@@ -19,6 +23,27 @@ class Finding:
     severity: str    # "critical", "high", "medium", "low"
     description: str
     verbatim_excerpt: str = ""
+    guardrail_id: Optional[int] = None  # provenance: guardrail that produced this finding
+
+
+@dataclass
+class Guardrail:
+    """A curated, named rule injected into reviews as an LLM-checked assertion.
+
+    Guardrails are model-agnostic prose checks: a ``name``, a natural-language
+    ``assertion`` the review model evaluates against code, and an optional
+    ``scope`` (a finding ``scope_category`` and/or a ``scope_path_glob``) that
+    bounds which files the guardrail applies to. ``status`` gates enforcement
+    (only ``active`` guardrails are injected); ``source`` records whether the
+    developer authored it (``manual``) or confirmed an auto-promoted candidate
+    (``promoted``).
+    """
+    name: str
+    assertion: str
+    scope_category: Optional[str] = None
+    scope_path_glob: Optional[str] = None
+    status: str = "active"    # "active" | "disabled" | "dismissed"
+    source: str = "manual"    # "manual" | "promoted"
 
 
 @dataclass
@@ -81,6 +106,20 @@ class ViolationDB:
         )
     """
 
+    _CREATE_GUARDRAILS_TABLE = """
+        CREATE TABLE IF NOT EXISTS guardrails (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            name            TEXT    NOT NULL,
+            assertion       TEXT    NOT NULL,
+            scope_category  TEXT,
+            scope_path_glob TEXT,
+            status          TEXT    NOT NULL DEFAULT 'active',
+            source          TEXT    NOT NULL DEFAULT 'manual',
+            created_at      TEXT    NOT NULL,
+            updated_at      TEXT    NOT NULL
+        )
+    """
+
     def __init__(self, db_path: str) -> None:
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
@@ -90,11 +129,12 @@ class ViolationDB:
             self._conn.execute("PRAGMA foreign_keys=ON")
             self._conn.execute(self._CREATE_TABLE)
             self._conn.execute(self._CREATE_INCIDENTS_TABLE)
+            self._conn.execute(self._CREATE_GUARDRAILS_TABLE)
             self._conn.commit()
         self._migrate()
 
     def _migrate(self) -> None:
-        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt, resolution)."""
+        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt, resolution, guardrail_id)."""
         try:
             with self._lock:
                 cur = self._conn.execute("PRAGMA table_info(findings)")
@@ -126,6 +166,10 @@ class ViolationDB:
                 if "resolution" not in cols:
                     self._conn.execute(
                         "ALTER TABLE findings ADD COLUMN resolution TEXT"
+                    )
+                if "guardrail_id" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN guardrail_id INTEGER"
                     )
                 self._conn.commit()
         except sqlite3.DatabaseError as e:
@@ -182,8 +226,8 @@ class ViolationDB:
                             INSERT INTO findings
                                 (file_path, line_start, line_end, category,
                                  severity, description, first_seen, last_seen,
-                                 embed_text, verbatim_excerpt)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                 embed_text, verbatim_excerpt, guardrail_id)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                             """,
                             (
                                 f.file_path,
@@ -196,6 +240,7 @@ class ViolationDB:
                                 now,
                                 embed_text,
                                 f.verbatim_excerpt,
+                                f.guardrail_id,
                             ),
                         )
                 self._conn.commit()
@@ -551,6 +596,142 @@ class ViolationDB:
 
         scored.sort(key=lambda p: p[0], reverse=True)
         return [row for _score, row in scored[:k]]
+
+    # ------------------------------------------------------------------
+    # Guardrails (U1)
+    # ------------------------------------------------------------------
+
+    def create_guardrail(self, guardrail: Guardrail) -> int:
+        """Insert a Guardrail and return its new id.
+
+        ``status`` and ``source`` fall back to the dataclass defaults
+        (``active`` / ``manual``). ``created_at`` and ``updated_at`` are stamped
+        to the same instant at creation.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            cur = self._conn.cursor()
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO guardrails
+                        (name, assertion, scope_category, scope_path_glob,
+                         status, source, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        guardrail.name,
+                        guardrail.assertion,
+                        guardrail.scope_category,
+                        guardrail.scope_path_glob,
+                        guardrail.status,
+                        guardrail.source,
+                        now,
+                        now,
+                    ),
+                )
+                self._conn.commit()
+                return int(cur.lastrowid) if cur.lastrowid is not None else -1
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def get_guardrail(self, guardrail_id: int) -> Optional[dict]:
+        """Return the guardrails row for *guardrail_id*, or None — any status."""
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM guardrails WHERE id = ?", (guardrail_id,)
+            )
+            rows = self._rows_to_dicts(cur)
+        return rows[0] if rows else None
+
+    def list_guardrails(
+        self,
+        *,
+        status: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> List[dict]:
+        """Return guardrails, optionally filtered by ``status`` / ``source``.
+
+        Ordered by ``id`` ascending so listings are stable across calls.
+        """
+        clauses: list = []
+        params: list = []
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._lock:
+            cur = self._conn.execute(
+                f"SELECT * FROM guardrails {where} ORDER BY id ASC",
+                tuple(params),
+            )
+            return self._rows_to_dicts(cur)
+
+    def get_active_guardrails(self) -> List[dict]:
+        """Return all ``active`` guardrails (the set eligible for injection)."""
+        return self.list_guardrails(status="active")
+
+    def update_guardrail(
+        self,
+        guardrail_id: int,
+        *,
+        name: Optional[str] = None,
+        assertion: Optional[str] = None,
+        scope_category=_UNSET,
+        scope_path_glob=_UNSET,
+    ) -> int:
+        """Edit a guardrail's name/assertion/scope; return rows updated.
+
+        Only the fields you pass change. ``name`` / ``assertion`` are left
+        untouched when ``None``. ``scope_category`` / ``scope_path_glob`` use the
+        ``_UNSET`` sentinel so passing ``None`` explicitly *clears* the scope
+        (broadens the guardrail) while omitting it leaves it intact. Touches
+        ``updated_at`` whenever any field changes. Returns 0 if no guardrail has
+        that id.
+        """
+        sets = ["updated_at = ?"]
+        params: list = [datetime.now(timezone.utc).isoformat()]
+        if name is not None:
+            sets.append("name = ?")
+            params.append(name)
+        if assertion is not None:
+            sets.append("assertion = ?")
+            params.append(assertion)
+        if scope_category is not _UNSET:
+            sets.append("scope_category = ?")
+            params.append(scope_category)
+        if scope_path_glob is not _UNSET:
+            sets.append("scope_path_glob = ?")
+            params.append(scope_path_glob)
+        params.append(guardrail_id)
+
+        with self._lock:
+            cur = self._conn.execute(
+                f"UPDATE guardrails SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
+            )
+            self._conn.commit()
+            return cur.rowcount
+
+    def set_guardrail_status(self, guardrail_id: int, status: str) -> int:
+        """Set a guardrail's lifecycle ``status`` and return rows updated.
+
+        ``status`` is one of ``active`` / ``disabled`` / ``dismissed``. Setting
+        the same status again is a no-op transition (idempotent) that still
+        reports rowcount 1 — the row exists. Returns 0 if no guardrail has that
+        id. Touches ``updated_at``.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE guardrails SET status = ?, updated_at = ? WHERE id = ?",
+                (status, datetime.now(timezone.utc).isoformat(), guardrail_id),
+            )
+            self._conn.commit()
+            return cur.rowcount
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from ollama_sentinel.violation_db import Finding, ViolationDB
+from ollama_sentinel.violation_db import Finding, Guardrail, ViolationDB
 
 
 # ---------------------------------------------------------------------------
@@ -1038,3 +1038,260 @@ class TestGetOpenFindings:
             db.close()
         assert all_ids == sorted(all_ids)
         assert limited == sorted(all_ids)[:3]
+
+
+# ---------------------------------------------------------------------------
+# U1: Guardrail storage model + finding provenance
+# ---------------------------------------------------------------------------
+
+
+def _make_guardrail(**overrides) -> Guardrail:
+    """Build a Guardrail with sensible defaults, allowing field overrides."""
+    defaults = dict(
+        name="no-bare-except",
+        assertion="Do not catch bare Exception without re-raising or logging.",
+        scope_category="bug",
+        scope_path_glob="src/*.py",
+    )
+    defaults.update(overrides)
+    return Guardrail(**defaults)
+
+
+class TestGuardrailCRUD:
+    def test_create_returns_id_and_roundtrips(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            assert isinstance(gid, int) and gid > 0
+
+            row = db.get_guardrail(gid)
+            assert row is not None
+            assert row["id"] == gid
+            assert row["name"] == "no-bare-except"
+            assert row["assertion"].startswith("Do not catch bare Exception")
+            assert row["scope_category"] == "bug"
+            assert row["scope_path_glob"] == "src/*.py"
+            # Defaults applied on creation.
+            assert row["status"] == "active"
+            assert row["source"] == "manual"
+            assert row["created_at"]
+            assert row["updated_at"]
+        finally:
+            db.close()
+
+    def test_create_without_scope_defaults_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(
+                Guardrail(name="broad", assertion="Applies everywhere.")
+            )
+            row = db.get_guardrail(gid)
+            assert row["scope_category"] is None
+            assert row["scope_path_glob"] is None
+        finally:
+            db.close()
+
+    def test_create_promoted_source_persists(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail(source="promoted"))
+            assert db.get_guardrail(gid)["source"] == "promoted"
+        finally:
+            db.close()
+
+    def test_get_guardrail_missing_returns_none(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.get_guardrail(424242) is None
+        finally:
+            db.close()
+
+    def test_list_guardrails_all_and_filtered(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            a = db.create_guardrail(_make_guardrail(name="a"))
+            b = db.create_guardrail(_make_guardrail(name="b", source="promoted"))
+            db.set_guardrail_status(b, "disabled")
+
+            all_rows = db.list_guardrails()
+            assert {r["id"] for r in all_rows} == {a, b}
+
+            active = db.list_guardrails(status="active")
+            assert [r["id"] for r in active] == [a]
+
+            promoted = db.list_guardrails(source="promoted")
+            assert [r["id"] for r in promoted] == [b]
+        finally:
+            db.close()
+
+    def test_get_active_guardrails_excludes_non_active(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            keep = db.create_guardrail(_make_guardrail(name="keep"))
+            off = db.create_guardrail(_make_guardrail(name="off"))
+            gone = db.create_guardrail(_make_guardrail(name="gone"))
+            db.set_guardrail_status(off, "disabled")
+            db.set_guardrail_status(gone, "dismissed")
+
+            active = db.get_active_guardrails()
+            assert [r["id"] for r in active] == [keep]
+        finally:
+            db.close()
+
+    def test_status_transitions_persist(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            assert db.get_guardrail(gid)["status"] == "active"
+
+            assert db.set_guardrail_status(gid, "disabled") == 1
+            assert db.get_guardrail(gid)["status"] == "disabled"
+
+            assert db.set_guardrail_status(gid, "active") == 1
+            assert db.get_guardrail(gid)["status"] == "active"
+
+            assert db.set_guardrail_status(gid, "dismissed") == 1
+            assert db.get_guardrail(gid)["status"] == "dismissed"
+        finally:
+            db.close()
+
+    def test_dismiss_is_idempotent(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.set_guardrail_status(gid, "dismissed")
+            # Dismiss again — no error, stays dismissed.
+            db.set_guardrail_status(gid, "dismissed")
+            assert db.get_guardrail(gid)["status"] == "dismissed"
+        finally:
+            db.close()
+
+    def test_set_status_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.set_guardrail_status(424242, "disabled") == 0
+        finally:
+            db.close()
+
+    def test_update_guardrail_edits_name_assertion_scope(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            n = db.update_guardrail(
+                gid,
+                name="renamed",
+                assertion="New assertion text.",
+                scope_category="security",
+                scope_path_glob="lib/**.py",
+            )
+            assert n == 1
+            row = db.get_guardrail(gid)
+            assert row["name"] == "renamed"
+            assert row["assertion"] == "New assertion text."
+            assert row["scope_category"] == "security"
+            assert row["scope_path_glob"] == "lib/**.py"
+        finally:
+            db.close()
+
+    def test_update_guardrail_can_clear_scope(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.update_guardrail(gid, scope_category=None, scope_path_glob=None)
+            row = db.get_guardrail(gid)
+            assert row["scope_category"] is None
+            assert row["scope_path_glob"] is None
+        finally:
+            db.close()
+
+    def test_update_guardrail_unspecified_fields_unchanged(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            # Only change the name — scope must be left intact.
+            db.update_guardrail(gid, name="only-name")
+            row = db.get_guardrail(gid)
+            assert row["name"] == "only-name"
+            assert row["scope_category"] == "bug"
+            assert row["scope_path_glob"] == "src/*.py"
+            assert row["assertion"].startswith("Do not catch bare Exception")
+        finally:
+            db.close()
+
+    def test_update_guardrail_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.update_guardrail(424242, name="x") == 0
+        finally:
+            db.close()
+
+
+class TestGuardrailTableMigration:
+    def test_guardrails_table_created_on_init(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            tbl = db._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='guardrails'"
+            ).fetchone()
+            assert tbl is not None
+        finally:
+            db.close()
+
+
+class TestGuardrailProvenance:
+    def test_finding_written_with_guardrail_id(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.persist_findings(
+                "src/app.py",
+                [_make_finding(file_path="src/app.py", guardrail_id=gid)],
+            )
+            row = db.get_unresolved("src/app.py")[0]
+            assert row["guardrail_id"] == gid
+        finally:
+            db.close()
+
+    def test_finding_without_guardrail_id_is_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("src/app.py", [_make_finding(file_path="src/app.py")])
+            row = db.get_unresolved("src/app.py")[0]
+            assert row["guardrail_id"] is None
+        finally:
+            db.close()
+
+    def test_migration_adds_guardrail_id_to_legacy_db(self, tmp_path):
+        """Additive migration adds guardrail_id to a pre-existing DB, no data loss."""
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute(
+            """
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL, line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL, category TEXT NOT NULL,
+                severity TEXT NOT NULL, description TEXT NOT NULL,
+                first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL DEFAULT 1,
+                resolved INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO findings (file_path, line_start, line_end, category, "
+            "severity, description, first_seen, last_seen) "
+            "VALUES ('a.py', 1, 2, 'bug', 'low', 'd', 't', 't')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = ViolationDB(str(p))  # __init__ runs _migrate
+        try:
+            rows = db.get_unresolved("a.py")
+            assert len(rows) == 1  # existing row intact
+            assert "guardrail_id" in rows[0]
+            assert rows[0]["guardrail_id"] is None  # legacy row: no provenance
+        finally:
+            db.close()


### PR DESCRIPTION
First unit of the **Pattern promotion → project guardrails** plan (`docs/plans/2026-06-08-001-feat-pattern-promotion-guardrails-plan.md`), Phase 1. Implements the Finding→Incident→**Pattern** rung's persistence foundation. Plan requirements **R1** (guardrail = named rule + NL assertion + optional scope) and **R7** (finding records originating guardrail).

This is the base of the Phase 1 stack — U2 (CLI), U3 (injection), U5 (dashboard) build on it.

## Changes

**`ollama_sentinel/violation_db.py`**
- New `guardrails` table via `CREATE TABLE IF NOT EXISTS` (mirrors `_CREATE_INCIDENTS_TABLE`): `name`, `assertion`, optional scope (`scope_category` + `scope_path_glob`), lifecycle `status` (active/disabled/dismissed), `source` (manual/promoted), `created_at`/`updated_at`.
- `Guardrail` dataclass + CRUD: `create_guardrail`, `get_guardrail`, `list_guardrails` (status/source filters), `get_active_guardrails`, `update_guardrail`, `set_guardrail_status` — same `with self._lock` + `_rows_to_dicts` style as the existing finding/incident CRUD.
  - `update_guardrail` uses an `_UNSET` sentinel so passing `None` **clears** a scope field while omitting it leaves it intact.
  - `set_guardrail_status` lifecycle transitions are idempotent.
- **Provenance:** nullable `guardrail_id` column on `findings`, added via the idempotent additive `_migrate` (same precedent as `triggering_commit_sha`), plus a defaulted `guardrail_id` field on the `Finding` dataclass, written through `persist_findings`. Defaults null; U4 populates it via attribution.

## Tests

17 new tests: CRUD round-trip, scope defaults, status transitions (active→disabled→active, active→dismissed), dismiss idempotency, update clear-vs-unchanged semantics, guardrails-table creation, finding provenance write, and **legacy-DB migration adds `guardrail_id` with no data loss**.

Full suite: **716 passed / 16 skipped**.

## Scope boundaries
Storage + DB CRUD only. CLI verbs (U2), injection (U3), provenance attribution heuristic (U4), and dashboard panel (U5) are separate stacked PRs.