### PR TITLE
feat(guardrails): U2 — guardrail authoring + lifecycle CLI verbs

### DIFF
--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -962,6 +962,262 @@ def prune(
     )
 
 
+# ---------------------------------------------------------------------------
+# guardrail — author + curate project guardrails (U2)
+# ---------------------------------------------------------------------------
+
+guardrail_app = typer.Typer(
+    help="Author and curate project guardrails — named, LLM-checked review rules.",
+    no_args_is_help=True,
+)
+app.add_typer(guardrail_app, name="guardrail")
+
+
+def _guardrail_db_path(config_path: str) -> pathlib.Path:
+    """Resolve the ViolationDB path from the config (or exit on a bad config)."""
+    config = _load_config_or_exit(config_path)
+    return pathlib.Path(config.watch.directory).resolve() / config.memory.db_path
+
+
+def _transition_guardrail(
+    guardrail_id: int, config_path: str, *, status: str, action: str, past: str,
+) -> None:
+    """Shared body for disable/enable/dismiss: validate id, set status, report."""
+    from .violation_db import ViolationDB
+
+    db_path = _guardrail_db_path(config_path)
+    if not db_path.exists():
+        console.print(
+            f"[red]No guardrail with id {guardrail_id}; nothing to {action}.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        if db.get_guardrail(guardrail_id) is None:
+            console.print(
+                f"[red]No guardrail with id {guardrail_id}; nothing to {action}.[/red]"
+            )
+            raise typer.Exit(code=1)
+        db.set_guardrail_status(guardrail_id, status)
+    finally:
+        db.close()
+
+    console.print(f"[green]{past} guardrail {guardrail_id}.[/green]")
+
+
+@guardrail_app.command("add")
+def guardrail_add(
+    name: str = typer.Argument(..., help="Short rule name, e.g. no-bare-except"),
+    assertion: str = typer.Option(
+        ..., "--assertion", "-a",
+        help="Natural-language rule the review model checks against code",
+    ),
+    category: Optional[str] = typer.Option(
+        None, "--category",
+        help="Scope to one finding category (e.g. security); omit to apply broadly",
+    ),
+    path_glob: Optional[str] = typer.Option(
+        None, "--path",
+        help="Scope to files matching a glob (e.g. src/*.py); omit to apply broadly",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Author a new guardrail. It is active immediately (no incident history needed)."""
+    from .violation_db import Guardrail, ViolationDB
+
+    db_path = _guardrail_db_path(config_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)  # author before any review
+
+    db = ViolationDB(str(db_path))
+    try:
+        gid = db.create_guardrail(
+            Guardrail(
+                name=name,
+                assertion=assertion,
+                scope_category=category,
+                scope_path_glob=path_glob,
+            )
+        )
+    finally:
+        db.close()
+
+    console.print(f"[green]Added guardrail {gid}: {name} (active).[/green]")
+
+
+@guardrail_app.command("list")
+def guardrail_list(
+    show_all: bool = typer.Option(
+        False, "--all",
+        help="Include disabled/dismissed guardrails (default: active only)",
+    ),
+    status: Optional[str] = typer.Option(
+        None, "--status",
+        help="Filter by exact status: active | disabled | dismissed",
+    ),
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="Output format: table or json",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """List guardrails. Defaults to active; --all or --status widens the view."""
+    import json as json_mod
+
+    from rich.table import Table
+
+    from .violation_db import ViolationDB
+
+    # Precedence: explicit --status wins, then --all (no filter), else active.
+    status_filter = status if status is not None else (None if show_all else "active")
+
+    db_path = _guardrail_db_path(config_path)
+    rows: list = []
+    if db_path.exists():
+        db = ViolationDB(str(db_path))
+        try:
+            rows = db.list_guardrails(status=status_filter)
+        finally:
+            db.close()
+
+    # JSON output is always valid JSON, even when empty (`[]`) — it may be piped.
+    if output_format == "json":
+        console.print(json_mod.dumps(rows, indent=2))
+        return
+
+    if not rows:
+        console.print("[green]No guardrails found.[/green]")
+        raise typer.Exit()
+
+    table = Table(title=f"Guardrails ({len(rows)})")
+    table.add_column("ID", style="bold", width=5)
+    table.add_column("Name", style="cyan")
+    table.add_column("Status", width=10)
+    table.add_column("Src", width=9)
+    table.add_column("Scope", width=22)
+    table.add_column("Assertion")
+
+    for r in rows:
+        scope_bits = []
+        if r["scope_category"]:
+            scope_bits.append(r["scope_category"])
+        if r["scope_path_glob"]:
+            scope_bits.append(r["scope_path_glob"])
+        scope = " · ".join(scope_bits) if scope_bits else "—"
+        table.add_row(
+            str(r["id"]),
+            r["name"],
+            r["status"],
+            r["source"],
+            scope,
+            (r["assertion"] or "")[:70],
+        )
+    console.print(table)
+
+
+@guardrail_app.command("edit")
+def guardrail_edit(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to edit"),
+    name: Optional[str] = typer.Option(None, "--name", help="New name"),
+    assertion: Optional[str] = typer.Option(
+        None, "--assertion", "-a", help="New assertion text",
+    ),
+    category: Optional[str] = typer.Option(
+        None, "--category", help="New scope category",
+    ),
+    path_glob: Optional[str] = typer.Option(
+        None, "--path", help="New scope path glob",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Edit a guardrail's name, assertion, or scope. Only the flags you pass change."""
+    from .violation_db import ViolationDB
+
+    if name is None and assertion is None and category is None and path_glob is None:
+        console.print(
+            "[yellow]Nothing to change; pass --name/--assertion/--category/--path.[/yellow]"
+        )
+        raise typer.Exit()
+
+    db_path = _guardrail_db_path(config_path)
+    if not db_path.exists():
+        console.print(f"[red]No guardrail with id {guardrail_id}.[/red]")
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        if db.get_guardrail(guardrail_id) is None:
+            console.print(f"[red]No guardrail with id {guardrail_id}.[/red]")
+            raise typer.Exit(code=1)
+        kwargs: dict = {}
+        if name is not None:
+            kwargs["name"] = name
+        if assertion is not None:
+            kwargs["assertion"] = assertion
+        if category is not None:
+            kwargs["scope_category"] = category
+        if path_glob is not None:
+            kwargs["scope_path_glob"] = path_glob
+        db.update_guardrail(guardrail_id, **kwargs)
+    finally:
+        db.close()
+
+    console.print(f"[green]Updated guardrail {guardrail_id}.[/green]")
+
+
+@guardrail_app.command("disable")
+def guardrail_disable(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to disable"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Disable a guardrail. Disabled guardrails are not injected into reviews."""
+    _transition_guardrail(
+        guardrail_id, config_path, status="disabled",
+        action="disable", past="Disabled",
+    )
+
+
+@guardrail_app.command("enable")
+def guardrail_enable(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to re-enable"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Re-enable a disabled guardrail, restoring it to the active set."""
+    _transition_guardrail(
+        guardrail_id, config_path, status="active",
+        action="enable", past="Enabled",
+    )
+
+
+@guardrail_app.command("dismiss")
+def guardrail_dismiss(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to dismiss"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Dismiss a guardrail (terminal). Dismissed guardrails are never injected."""
+    _transition_guardrail(
+        guardrail_id, config_path, status="dismissed",
+        action="dismiss", past="Dismissed",
+    )
+
+
 @app.command()
 def triage(
     input_path: Optional[str] = typer.Argument(

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -8,6 +8,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
+# Sentinel distinguishing "argument not provided" from an explicit None
+# (used by update_guardrail so callers can *clear* a scope field with None).
+_UNSET = object()
+
 
 @dataclass
 class Finding:
@@ -19,6 +23,27 @@ class Finding:
     severity: str    # "critical", "high", "medium", "low"
     description: str
     verbatim_excerpt: str = ""
+    guardrail_id: Optional[int] = None  # provenance: guardrail that produced this finding
+
+
+@dataclass
+class Guardrail:
+    """A curated, named rule injected into reviews as an LLM-checked assertion.
+
+    Guardrails are model-agnostic prose checks: a ``name``, a natural-language
+    ``assertion`` the review model evaluates against code, and an optional
+    ``scope`` (a finding ``scope_category`` and/or a ``scope_path_glob``) that
+    bounds which files the guardrail applies to. ``status`` gates enforcement
+    (only ``active`` guardrails are injected); ``source`` records whether the
+    developer authored it (``manual``) or confirmed an auto-promoted candidate
+    (``promoted``).
+    """
+    name: str
+    assertion: str
+    scope_category: Optional[str] = None
+    scope_path_glob: Optional[str] = None
+    status: str = "active"    # "active" | "disabled" | "dismissed"
+    source: str = "manual"    # "manual" | "promoted"
 
 
 @dataclass
@@ -81,6 +106,20 @@ class ViolationDB:
         )
     """
 
+    _CREATE_GUARDRAILS_TABLE = """
+        CREATE TABLE IF NOT EXISTS guardrails (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            name            TEXT    NOT NULL,
+            assertion       TEXT    NOT NULL,
+            scope_category  TEXT,
+            scope_path_glob TEXT,
+            status          TEXT    NOT NULL DEFAULT 'active',
+            source          TEXT    NOT NULL DEFAULT 'manual',
+            created_at      TEXT    NOT NULL,
+            updated_at      TEXT    NOT NULL
+        )
+    """
+
     def __init__(self, db_path: str) -> None:
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
@@ -90,11 +129,12 @@ class ViolationDB:
             self._conn.execute("PRAGMA foreign_keys=ON")
             self._conn.execute(self._CREATE_TABLE)
             self._conn.execute(self._CREATE_INCIDENTS_TABLE)
+            self._conn.execute(self._CREATE_GUARDRAILS_TABLE)
             self._conn.commit()
         self._migrate()
 
     def _migrate(self) -> None:
-        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt, resolution)."""
+        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt, resolution, guardrail_id)."""
         try:
             with self._lock:
                 cur = self._conn.execute("PRAGMA table_info(findings)")
@@ -126,6 +166,10 @@ class ViolationDB:
                 if "resolution" not in cols:
                     self._conn.execute(
                         "ALTER TABLE findings ADD COLUMN resolution TEXT"
+                    )
+                if "guardrail_id" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN guardrail_id INTEGER"
                     )
                 self._conn.commit()
         except sqlite3.DatabaseError as e:
@@ -182,8 +226,8 @@ class ViolationDB:
                             INSERT INTO findings
                                 (file_path, line_start, line_end, category,
                                  severity, description, first_seen, last_seen,
-                                 embed_text, verbatim_excerpt)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                 embed_text, verbatim_excerpt, guardrail_id)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                             """,
                             (
                                 f.file_path,
@@ -196,6 +240,7 @@ class ViolationDB:
                                 now,
                                 embed_text,
                                 f.verbatim_excerpt,
+                                f.guardrail_id,
                             ),
                         )
                 self._conn.commit()
@@ -551,6 +596,142 @@ class ViolationDB:
 
         scored.sort(key=lambda p: p[0], reverse=True)
         return [row for _score, row in scored[:k]]
+
+    # ------------------------------------------------------------------
+    # Guardrails (U1)
+    # ------------------------------------------------------------------
+
+    def create_guardrail(self, guardrail: Guardrail) -> int:
+        """Insert a Guardrail and return its new id.
+
+        ``status`` and ``source`` fall back to the dataclass defaults
+        (``active`` / ``manual``). ``created_at`` and ``updated_at`` are stamped
+        to the same instant at creation.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            cur = self._conn.cursor()
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO guardrails
+                        (name, assertion, scope_category, scope_path_glob,
+                         status, source, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        guardrail.name,
+                        guardrail.assertion,
+                        guardrail.scope_category,
+                        guardrail.scope_path_glob,
+                        guardrail.status,
+                        guardrail.source,
+                        now,
+                        now,
+                    ),
+                )
+                self._conn.commit()
+                return int(cur.lastrowid) if cur.lastrowid is not None else -1
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def get_guardrail(self, guardrail_id: int) -> Optional[dict]:
+        """Return the guardrails row for *guardrail_id*, or None — any status."""
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM guardrails WHERE id = ?", (guardrail_id,)
+            )
+            rows = self._rows_to_dicts(cur)
+        return rows[0] if rows else None
+
+    def list_guardrails(
+        self,
+        *,
+        status: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> List[dict]:
+        """Return guardrails, optionally filtered by ``status`` / ``source``.
+
+        Ordered by ``id`` ascending so listings are stable across calls.
+        """
+        clauses: list = []
+        params: list = []
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._lock:
+            cur = self._conn.execute(
+                f"SELECT * FROM guardrails {where} ORDER BY id ASC",
+                tuple(params),
+            )
+            return self._rows_to_dicts(cur)
+
+    def get_active_guardrails(self) -> List[dict]:
+        """Return all ``active`` guardrails (the set eligible for injection)."""
+        return self.list_guardrails(status="active")
+
+    def update_guardrail(
+        self,
+        guardrail_id: int,
+        *,
+        name: Optional[str] = None,
+        assertion: Optional[str] = None,
+        scope_category=_UNSET,
+        scope_path_glob=_UNSET,
+    ) -> int:
+        """Edit a guardrail's name/assertion/scope; return rows updated.
+
+        Only the fields you pass change. ``name`` / ``assertion`` are left
+        untouched when ``None``. ``scope_category`` / ``scope_path_glob`` use the
+        ``_UNSET`` sentinel so passing ``None`` explicitly *clears* the scope
+        (broadens the guardrail) while omitting it leaves it intact. Touches
+        ``updated_at`` whenever any field changes. Returns 0 if no guardrail has
+        that id.
+        """
+        sets = ["updated_at = ?"]
+        params: list = [datetime.now(timezone.utc).isoformat()]
+        if name is not None:
+            sets.append("name = ?")
+            params.append(name)
+        if assertion is not None:
+            sets.append("assertion = ?")
+            params.append(assertion)
+        if scope_category is not _UNSET:
+            sets.append("scope_category = ?")
+            params.append(scope_category)
+        if scope_path_glob is not _UNSET:
+            sets.append("scope_path_glob = ?")
+            params.append(scope_path_glob)
+        params.append(guardrail_id)
+
+        with self._lock:
+            cur = self._conn.execute(
+                f"UPDATE guardrails SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
+            )
+            self._conn.commit()
+            return cur.rowcount
+
+    def set_guardrail_status(self, guardrail_id: int, status: str) -> int:
+        """Set a guardrail's lifecycle ``status`` and return rows updated.
+
+        ``status`` is one of ``active`` / ``disabled`` / ``dismissed``. Setting
+        the same status again is a no-op transition (idempotent) that still
+        reports rowcount 1 — the row exists. Returns 0 if no guardrail has that
+        id. Touches ``updated_at``.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE guardrails SET status = ?, updated_at = ? WHERE id = ?",
+                (status, datetime.now(timezone.utc).isoformat(), guardrail_id),
+            )
+            self._conn.commit()
+            return cur.rowcount
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import yaml
 from typer.testing import CliRunner
 
 from ollama_sentinel.cli import app
-from ollama_sentinel.violation_db import Finding, Incident, ViolationDB
+from ollama_sentinel.violation_db import Finding, Guardrail, Incident, ViolationDB
 
 
 runner = CliRunner()
@@ -1253,3 +1253,182 @@ class TestPruneCommand:
         result = runner.invoke(app, ["prune", "--config", str(cfg)])
         assert result.exit_code == 0
         assert "No violation database" in result.output
+
+
+# ---------------------------------------------------------------------------
+# U2 — `ollama-sentinel guardrail` authoring + lifecycle sub-commands
+# ---------------------------------------------------------------------------
+
+
+def _list_json(cfg, *extra):
+    """Run `guardrail list -f json [extra]` and return the parsed rows."""
+    r = runner.invoke(
+        app, ["guardrail", "list", "--config", str(cfg), "-f", "json", *extra]
+    )
+    assert r.exit_code == 0, r.output
+    return json.loads(r.output)
+
+
+class TestGuardrailCLI:
+    """Tests for the `guardrail` authoring + lifecycle sub-app (U2)."""
+
+    def test_add_creates_active_guardrail_with_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        r = runner.invoke(app, [
+            "guardrail", "add", "no-bare-except",
+            "--assertion", "Do not catch bare Exception without re-raising.",
+            "--category", "bug", "--path", "src/*.py",
+            "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+
+        rows = _list_json(cfg)
+        assert len(rows) == 1
+        g = rows[0]
+        assert g["name"] == "no-bare-except"
+        assert g["assertion"] == "Do not catch bare Exception without re-raising."
+        assert g["scope_category"] == "bug"
+        assert g["scope_path_glob"] == "src/*.py"
+        assert g["status"] == "active"
+        assert g["source"] == "manual"
+
+    def test_add_creates_db_when_absent(self, tmp_path, monkeypatch):
+        """Authoring must work on a fresh setup with no prior reviews/DB."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        assert not db_path.exists()
+        r = runner.invoke(app, [
+            "guardrail", "add", "g1", "--assertion", "a", "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+        assert db_path.exists()
+
+    def test_add_without_scope_is_broad(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        r = runner.invoke(app, [
+            "guardrail", "add", "broad", "--assertion", "Applies everywhere.",
+            "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+        g = _list_json(cfg)[0]
+        assert g["scope_category"] is None
+        assert g["scope_path_glob"] is None
+
+    def test_edit_changes_assertion_and_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, [
+            "guardrail", "add", "g", "--assertion", "old", "--category", "bug",
+            "--config", str(cfg),
+        ])
+        gid = _list_json(cfg)[0]["id"]
+        r = runner.invoke(app, [
+            "guardrail", "edit", str(gid),
+            "--assertion", "new assertion", "--category", "security",
+            "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+        g = _list_json(cfg)[0]
+        assert g["assertion"] == "new assertion"
+        assert g["scope_category"] == "security"
+
+    def test_disable_removes_from_active_and_enable_restores(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, [
+            "guardrail", "add", "g", "--assertion", "a", "--config", str(cfg),
+        ])
+        gid = _list_json(cfg)[0]["id"]
+
+        r = runner.invoke(app, ["guardrail", "disable", str(gid), "--config", str(cfg)])
+        assert r.exit_code == 0, r.output
+        assert _list_json(cfg) == []  # default list is active-only
+
+        r = runner.invoke(app, ["guardrail", "enable", str(gid), "--config", str(cfg)])
+        assert r.exit_code == 0, r.output
+        assert [g["id"] for g in _list_json(cfg)] == [gid]
+
+    def test_list_all_includes_non_active(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        gid = _list_json(cfg)[0]["id"]
+        runner.invoke(app, ["guardrail", "disable", str(gid), "--config", str(cfg)])
+        assert _list_json(cfg) == []
+        all_rows = _list_json(cfg, "--all")
+        assert [g["status"] for g in all_rows] == ["disabled"]
+
+    def test_dismiss_is_terminal_and_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        gid = _list_json(cfg)[0]["id"]
+
+        r1 = runner.invoke(app, ["guardrail", "dismiss", str(gid), "--config", str(cfg)])
+        assert r1.exit_code == 0, r1.output
+        # Dismiss again — no error, stays dismissed.
+        r2 = runner.invoke(app, ["guardrail", "dismiss", str(gid), "--config", str(cfg)])
+        assert r2.exit_code == 0, r2.output
+        all_rows = _list_json(cfg, "--all")
+        assert [g["status"] for g in all_rows] == ["dismissed"]
+
+    def test_list_table_renders_name_and_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("COLUMNS", "200")
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, [
+            "guardrail", "add", "no-eval", "--assertion", "Never call eval.",
+            "--category", "security", "--config", str(cfg),
+        ])
+        r = runner.invoke(app, ["guardrail", "list", "--config", str(cfg)])
+        assert r.exit_code == 0, r.output
+        assert "no-eval" in r.output
+        assert "security" in r.output
+
+    def test_list_empty_message(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()  # empty DB
+        r = runner.invoke(app, ["guardrail", "list", "--config", str(cfg)])
+        assert r.exit_code == 0
+        assert "No guardrails" in r.output
+
+    def test_list_no_db_message(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        r = runner.invoke(app, ["guardrail", "list", "--config", str(cfg)])
+        assert r.exit_code == 0
+        assert "No guardrails" in r.output
+
+    def test_edit_missing_id_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        r = runner.invoke(app, [
+            "guardrail", "edit", "9999", "--assertion", "x", "--config", str(cfg),
+        ])
+        assert r.exit_code == 1
+        assert "No guardrail with id" in r.output
+
+    def test_disable_missing_id_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        r = runner.invoke(app, ["guardrail", "disable", "9999", "--config", str(cfg)])
+        assert r.exit_code == 1
+        assert "No guardrail with id" in r.output
+
+    def test_dismiss_missing_id_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        r = runner.invoke(app, ["guardrail", "dismiss", "9999", "--config", str(cfg)])
+        assert r.exit_code == 1
+        assert "No guardrail with id" in r.output

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from ollama_sentinel.violation_db import Finding, ViolationDB
+from ollama_sentinel.violation_db import Finding, Guardrail, ViolationDB
 
 
 # ---------------------------------------------------------------------------
@@ -1038,3 +1038,260 @@ class TestGetOpenFindings:
             db.close()
         assert all_ids == sorted(all_ids)
         assert limited == sorted(all_ids)[:3]
+
+
+# ---------------------------------------------------------------------------
+# U1: Guardrail storage model + finding provenance
+# ---------------------------------------------------------------------------
+
+
+def _make_guardrail(**overrides) -> Guardrail:
+    """Build a Guardrail with sensible defaults, allowing field overrides."""
+    defaults = dict(
+        name="no-bare-except",
+        assertion="Do not catch bare Exception without re-raising or logging.",
+        scope_category="bug",
+        scope_path_glob="src/*.py",
+    )
+    defaults.update(overrides)
+    return Guardrail(**defaults)
+
+
+class TestGuardrailCRUD:
+    def test_create_returns_id_and_roundtrips(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            assert isinstance(gid, int) and gid > 0
+
+            row = db.get_guardrail(gid)
+            assert row is not None
+            assert row["id"] == gid
+            assert row["name"] == "no-bare-except"
+            assert row["assertion"].startswith("Do not catch bare Exception")
+            assert row["scope_category"] == "bug"
+            assert row["scope_path_glob"] == "src/*.py"
+            # Defaults applied on creation.
+            assert row["status"] == "active"
+            assert row["source"] == "manual"
+            assert row["created_at"]
+            assert row["updated_at"]
+        finally:
+            db.close()
+
+    def test_create_without_scope_defaults_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(
+                Guardrail(name="broad", assertion="Applies everywhere.")
+            )
+            row = db.get_guardrail(gid)
+            assert row["scope_category"] is None
+            assert row["scope_path_glob"] is None
+        finally:
+            db.close()
+
+    def test_create_promoted_source_persists(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail(source="promoted"))
+            assert db.get_guardrail(gid)["source"] == "promoted"
+        finally:
+            db.close()
+
+    def test_get_guardrail_missing_returns_none(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.get_guardrail(424242) is None
+        finally:
+            db.close()
+
+    def test_list_guardrails_all_and_filtered(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            a = db.create_guardrail(_make_guardrail(name="a"))
+            b = db.create_guardrail(_make_guardrail(name="b", source="promoted"))
+            db.set_guardrail_status(b, "disabled")
+
+            all_rows = db.list_guardrails()
+            assert {r["id"] for r in all_rows} == {a, b}
+
+            active = db.list_guardrails(status="active")
+            assert [r["id"] for r in active] == [a]
+
+            promoted = db.list_guardrails(source="promoted")
+            assert [r["id"] for r in promoted] == [b]
+        finally:
+            db.close()
+
+    def test_get_active_guardrails_excludes_non_active(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            keep = db.create_guardrail(_make_guardrail(name="keep"))
+            off = db.create_guardrail(_make_guardrail(name="off"))
+            gone = db.create_guardrail(_make_guardrail(name="gone"))
+            db.set_guardrail_status(off, "disabled")
+            db.set_guardrail_status(gone, "dismissed")
+
+            active = db.get_active_guardrails()
+            assert [r["id"] for r in active] == [keep]
+        finally:
+            db.close()
+
+    def test_status_transitions_persist(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            assert db.get_guardrail(gid)["status"] == "active"
+
+            assert db.set_guardrail_status(gid, "disabled") == 1
+            assert db.get_guardrail(gid)["status"] == "disabled"
+
+            assert db.set_guardrail_status(gid, "active") == 1
+            assert db.get_guardrail(gid)["status"] == "active"
+
+            assert db.set_guardrail_status(gid, "dismissed") == 1
+            assert db.get_guardrail(gid)["status"] == "dismissed"
+        finally:
+            db.close()
+
+    def test_dismiss_is_idempotent(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.set_guardrail_status(gid, "dismissed")
+            # Dismiss again — no error, stays dismissed.
+            db.set_guardrail_status(gid, "dismissed")
+            assert db.get_guardrail(gid)["status"] == "dismissed"
+        finally:
+            db.close()
+
+    def test_set_status_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.set_guardrail_status(424242, "disabled") == 0
+        finally:
+            db.close()
+
+    def test_update_guardrail_edits_name_assertion_scope(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            n = db.update_guardrail(
+                gid,
+                name="renamed",
+                assertion="New assertion text.",
+                scope_category="security",
+                scope_path_glob="lib/**.py",
+            )
+            assert n == 1
+            row = db.get_guardrail(gid)
+            assert row["name"] == "renamed"
+            assert row["assertion"] == "New assertion text."
+            assert row["scope_category"] == "security"
+            assert row["scope_path_glob"] == "lib/**.py"
+        finally:
+            db.close()
+
+    def test_update_guardrail_can_clear_scope(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.update_guardrail(gid, scope_category=None, scope_path_glob=None)
+            row = db.get_guardrail(gid)
+            assert row["scope_category"] is None
+            assert row["scope_path_glob"] is None
+        finally:
+            db.close()
+
+    def test_update_guardrail_unspecified_fields_unchanged(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            # Only change the name — scope must be left intact.
+            db.update_guardrail(gid, name="only-name")
+            row = db.get_guardrail(gid)
+            assert row["name"] == "only-name"
+            assert row["scope_category"] == "bug"
+            assert row["scope_path_glob"] == "src/*.py"
+            assert row["assertion"].startswith("Do not catch bare Exception")
+        finally:
+            db.close()
+
+    def test_update_guardrail_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.update_guardrail(424242, name="x") == 0
+        finally:
+            db.close()
+
+
+class TestGuardrailTableMigration:
+    def test_guardrails_table_created_on_init(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            tbl = db._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='guardrails'"
+            ).fetchone()
+            assert tbl is not None
+        finally:
+            db.close()
+
+
+class TestGuardrailProvenance:
+    def test_finding_written_with_guardrail_id(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.persist_findings(
+                "src/app.py",
+                [_make_finding(file_path="src/app.py", guardrail_id=gid)],
+            )
+            row = db.get_unresolved("src/app.py")[0]
+            assert row["guardrail_id"] == gid
+        finally:
+            db.close()
+
+    def test_finding_without_guardrail_id_is_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("src/app.py", [_make_finding(file_path="src/app.py")])
+            row = db.get_unresolved("src/app.py")[0]
+            assert row["guardrail_id"] is None
+        finally:
+            db.close()
+
+    def test_migration_adds_guardrail_id_to_legacy_db(self, tmp_path):
+        """Additive migration adds guardrail_id to a pre-existing DB, no data loss."""
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute(
+            """
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL, line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL, category TEXT NOT NULL,
+                severity TEXT NOT NULL, description TEXT NOT NULL,
+                first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL DEFAULT 1,
+                resolved INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO findings (file_path, line_start, line_end, category, "
+            "severity, description, first_seen, last_seen) "
+            "VALUES ('a.py', 1, 2, 'bug', 'low', 'd', 't', 't')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = ViolationDB(str(p))  # __init__ runs _migrate
+        try:
+            rows = db.get_unresolved("a.py")
+            assert len(rows) == 1  # existing row intact
+            assert "guardrail_id" in rows[0]
+            assert rows[0]["guardrail_id"] is None  # legacy row: no provenance
+        finally:
+            db.close()


### PR DESCRIPTION
Second unit of the **Pattern promotion → project guardrails** plan, Phase 1. **Stacked on #37 (U1)** — review/merge U1 first; this PR's base is the U1 branch so the diff shows only U2's delta.

Implements plan requirements **R2** (manual authoring — primary), **R4** (curation: confirm/edit/disable/dismiss), **R9** (CLI surfacing), **R10** (disable/dismiss lifecycle).

## Design note — sub-group vs flat verbs
The plan permits a sub-group "if it reads better." With **6 guardrail verbs**, a flat namespace forces clunky compounds (`guardrail-add`, `guardrail-disable`, …). A Typer `guardrail` sub-app reads cleaner and is self-documenting via `guardrail --help`.

## Verbs
- `guardrail add NAME -a ASSERTION [--category C] [--path GLOB]` — author; **active immediately** (no incident history needed). Creates the DB if absent, so authoring works before any review has run.
- `guardrail list [--all] [--status S] [-f json]` — defaults to **active-only**; `--all`/`--status` widen. JSON mode always emits valid JSON (`[]` when empty) so it can be piped.
- `guardrail edit ID [--name] [--assertion] [--category] [--path]` — only the flags you pass change.
- `guardrail disable | enable | dismiss ID` — lifecycle transitions via a shared `_transition_guardrail` helper mirroring `_close_finding`'s validate-then-report.

Disabled/dismissed guardrails are excluded from the active listing. Nothing here enforces until U3 wires injection. Reuses `_load_config_or_exit` + the existing `ViolationDB` try/finally + Rich-table conventions.

## Tests
13 new tests: add+list round-trip (scope persistence, broad/no-scope), DB-created-on-author, edit assertion/scope, disable→active-excluded→enable→restored, `--all` shows non-active, dismiss terminal+idempotent, table render, empty/no-db messages, and missing-id errors for edit/disable/dismiss.

Full suite: **729 passed / 16 skipped**.