### PR TITLE
feat(guardrails): U3 — relevance-scoped injection into review context

### DIFF
--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -962,6 +962,262 @@ def prune(
     )
 
 
+# ---------------------------------------------------------------------------
+# guardrail — author + curate project guardrails (U2)
+# ---------------------------------------------------------------------------
+
+guardrail_app = typer.Typer(
+    help="Author and curate project guardrails — named, LLM-checked review rules.",
+    no_args_is_help=True,
+)
+app.add_typer(guardrail_app, name="guardrail")
+
+
+def _guardrail_db_path(config_path: str) -> pathlib.Path:
+    """Resolve the ViolationDB path from the config (or exit on a bad config)."""
+    config = _load_config_or_exit(config_path)
+    return pathlib.Path(config.watch.directory).resolve() / config.memory.db_path
+
+
+def _transition_guardrail(
+    guardrail_id: int, config_path: str, *, status: str, action: str, past: str,
+) -> None:
+    """Shared body for disable/enable/dismiss: validate id, set status, report."""
+    from .violation_db import ViolationDB
+
+    db_path = _guardrail_db_path(config_path)
+    if not db_path.exists():
+        console.print(
+            f"[red]No guardrail with id {guardrail_id}; nothing to {action}.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        if db.get_guardrail(guardrail_id) is None:
+            console.print(
+                f"[red]No guardrail with id {guardrail_id}; nothing to {action}.[/red]"
+            )
+            raise typer.Exit(code=1)
+        db.set_guardrail_status(guardrail_id, status)
+    finally:
+        db.close()
+
+    console.print(f"[green]{past} guardrail {guardrail_id}.[/green]")
+
+
+@guardrail_app.command("add")
+def guardrail_add(
+    name: str = typer.Argument(..., help="Short rule name, e.g. no-bare-except"),
+    assertion: str = typer.Option(
+        ..., "--assertion", "-a",
+        help="Natural-language rule the review model checks against code",
+    ),
+    category: Optional[str] = typer.Option(
+        None, "--category",
+        help="Scope to one finding category (e.g. security); omit to apply broadly",
+    ),
+    path_glob: Optional[str] = typer.Option(
+        None, "--path",
+        help="Scope to files matching a glob (e.g. src/*.py); omit to apply broadly",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Author a new guardrail. It is active immediately (no incident history needed)."""
+    from .violation_db import Guardrail, ViolationDB
+
+    db_path = _guardrail_db_path(config_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)  # author before any review
+
+    db = ViolationDB(str(db_path))
+    try:
+        gid = db.create_guardrail(
+            Guardrail(
+                name=name,
+                assertion=assertion,
+                scope_category=category,
+                scope_path_glob=path_glob,
+            )
+        )
+    finally:
+        db.close()
+
+    console.print(f"[green]Added guardrail {gid}: {name} (active).[/green]")
+
+
+@guardrail_app.command("list")
+def guardrail_list(
+    show_all: bool = typer.Option(
+        False, "--all",
+        help="Include disabled/dismissed guardrails (default: active only)",
+    ),
+    status: Optional[str] = typer.Option(
+        None, "--status",
+        help="Filter by exact status: active | disabled | dismissed",
+    ),
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="Output format: table or json",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """List guardrails. Defaults to active; --all or --status widens the view."""
+    import json as json_mod
+
+    from rich.table import Table
+
+    from .violation_db import ViolationDB
+
+    # Precedence: explicit --status wins, then --all (no filter), else active.
+    status_filter = status if status is not None else (None if show_all else "active")
+
+    db_path = _guardrail_db_path(config_path)
+    rows: list = []
+    if db_path.exists():
+        db = ViolationDB(str(db_path))
+        try:
+            rows = db.list_guardrails(status=status_filter)
+        finally:
+            db.close()
+
+    # JSON output is always valid JSON, even when empty (`[]`) — it may be piped.
+    if output_format == "json":
+        console.print(json_mod.dumps(rows, indent=2))
+        return
+
+    if not rows:
+        console.print("[green]No guardrails found.[/green]")
+        raise typer.Exit()
+
+    table = Table(title=f"Guardrails ({len(rows)})")
+    table.add_column("ID", style="bold", width=5)
+    table.add_column("Name", style="cyan")
+    table.add_column("Status", width=10)
+    table.add_column("Src", width=9)
+    table.add_column("Scope", width=22)
+    table.add_column("Assertion")
+
+    for r in rows:
+        scope_bits = []
+        if r["scope_category"]:
+            scope_bits.append(r["scope_category"])
+        if r["scope_path_glob"]:
+            scope_bits.append(r["scope_path_glob"])
+        scope = " · ".join(scope_bits) if scope_bits else "—"
+        table.add_row(
+            str(r["id"]),
+            r["name"],
+            r["status"],
+            r["source"],
+            scope,
+            (r["assertion"] or "")[:70],
+        )
+    console.print(table)
+
+
+@guardrail_app.command("edit")
+def guardrail_edit(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to edit"),
+    name: Optional[str] = typer.Option(None, "--name", help="New name"),
+    assertion: Optional[str] = typer.Option(
+        None, "--assertion", "-a", help="New assertion text",
+    ),
+    category: Optional[str] = typer.Option(
+        None, "--category", help="New scope category",
+    ),
+    path_glob: Optional[str] = typer.Option(
+        None, "--path", help="New scope path glob",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Edit a guardrail's name, assertion, or scope. Only the flags you pass change."""
+    from .violation_db import ViolationDB
+
+    if name is None and assertion is None and category is None and path_glob is None:
+        console.print(
+            "[yellow]Nothing to change; pass --name/--assertion/--category/--path.[/yellow]"
+        )
+        raise typer.Exit()
+
+    db_path = _guardrail_db_path(config_path)
+    if not db_path.exists():
+        console.print(f"[red]No guardrail with id {guardrail_id}.[/red]")
+        raise typer.Exit(code=1)
+
+    db = ViolationDB(str(db_path))
+    try:
+        if db.get_guardrail(guardrail_id) is None:
+            console.print(f"[red]No guardrail with id {guardrail_id}.[/red]")
+            raise typer.Exit(code=1)
+        kwargs: dict = {}
+        if name is not None:
+            kwargs["name"] = name
+        if assertion is not None:
+            kwargs["assertion"] = assertion
+        if category is not None:
+            kwargs["scope_category"] = category
+        if path_glob is not None:
+            kwargs["scope_path_glob"] = path_glob
+        db.update_guardrail(guardrail_id, **kwargs)
+    finally:
+        db.close()
+
+    console.print(f"[green]Updated guardrail {guardrail_id}.[/green]")
+
+
+@guardrail_app.command("disable")
+def guardrail_disable(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to disable"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Disable a guardrail. Disabled guardrails are not injected into reviews."""
+    _transition_guardrail(
+        guardrail_id, config_path, status="disabled",
+        action="disable", past="Disabled",
+    )
+
+
+@guardrail_app.command("enable")
+def guardrail_enable(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to re-enable"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Re-enable a disabled guardrail, restoring it to the active set."""
+    _transition_guardrail(
+        guardrail_id, config_path, status="active",
+        action="enable", past="Enabled",
+    )
+
+
+@guardrail_app.command("dismiss")
+def guardrail_dismiss(
+    guardrail_id: int = typer.Argument(..., help="ID of the guardrail to dismiss"),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Dismiss a guardrail (terminal). Dismissed guardrails are never injected."""
+    _transition_guardrail(
+        guardrail_id, config_path, status="dismissed",
+        action="dismiss", past="Dismissed",
+    )
+
+
 @app.command()
 def triage(
     input_path: Optional[str] = typer.Argument(

--- a/ollama_sentinel/context/recipes.py
+++ b/ollama_sentinel/context/recipes.py
@@ -45,6 +45,38 @@ def _hash_violation(v: dict) -> str:
     return hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
 
 
+def _hash_guardrail(g: dict) -> str:
+    """Stable fallback key for guardrails that lack an `id` field."""
+    key = f"{g.get('name')}:{g.get('assertion')}"
+    return hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
+
+
+def _render_guardrail(g: dict) -> str:
+    name = g.get("name", "guardrail")
+    assertion = g.get("assertion", "")
+    category = g.get("scope_category")
+    scope = f" [{category}]" if category else ""
+    return f"- {name}{scope}: {assertion}"
+
+
+def _guardrail_applies_to_file(g: dict, file_rel_path: str) -> bool:
+    """Whether a guardrail's declared scope admits *file_rel_path*.
+
+    Only the path-glob dimension filters by file: a guardrail scoped to a
+    ``scope_path_glob`` is injected only for files matching that glob (matched
+    against the POSIX-normalized relative path, so ``src/*.py`` admits
+    ``src/app.py`` but not ``lib/app.py`` or ``src/sub/app.py``). An absent
+    glob means "applies broadly". ``scope_category`` does NOT exclude by file —
+    a file has no category until it is reviewed; the category dimension is
+    carried for downstream finding attribution and clustering, not injection.
+    """
+    glob = g.get("scope_path_glob")
+    if not glob:
+        return True
+    normalized = file_rel_path.replace("\\", "/")
+    return pathlib.PurePosixPath(normalized).match(glob)
+
+
 async def build_review_context(
     *,
     file_rel_path: str,
@@ -57,6 +89,7 @@ async def build_review_context(
     total_budget: int,
     retriever: Retriever,
     grounding: bool = True,
+    guardrails: Sequence[dict] = (),
 ) -> str:
     """Sentinel recipe — replaces the body of FileProcessor.format_prompt.
 
@@ -64,6 +97,12 @@ async def build_review_context(
     requires verbatim quoting and references the JSON schema's rejection
     behaviour. When False, omits that section because no schema is enforced —
     the instruction would be a lie and waste context.
+
+    ``guardrails`` are active project rules (already lifecycle-filtered by the
+    caller). They are scope-filtered to this file, then injected as a higher-
+    priority OPTIONAL section than ``PRIOR UNRESOLVED ISSUES`` — the retriever
+    ranks them by relevance and ``soft_budget`` caps the section so a growing
+    rulebook never floods the prompt.
     """
     sections: List[Section] = []
     if grounding:
@@ -92,6 +131,26 @@ async def build_review_context(
         soft_budget=int(total_budget * 0.70),
         truncate="tail",
     ))
+    # Guardrails are appended BEFORE prior violations so that, among OPTIONAL
+    # sections (which assemble() fills in list order), they win budget contention.
+    scoped_guardrails = [
+        g for g in guardrails if _guardrail_applies_to_file(g, file_rel_path)
+    ]
+    if scoped_guardrails:
+        guardrail_items = [
+            ContextItem(
+                text=_render_guardrail(g),
+                embed_key=f"guardrail:{g.get('id', _hash_guardrail(g))}",
+            )
+            for g in scoped_guardrails
+        ]
+        sections.append(Section(
+            name="PROJECT GUARDRAILS — check explicitly",
+            items=guardrail_items,
+            priority=Priority.OPTIONAL,
+            soft_budget=int(total_budget * 0.20),
+            retriever=retriever,
+        ))
     if prior_violations:
         violation_items = [
             ContextItem(

--- a/ollama_sentinel/processor.py
+++ b/ollama_sentinel/processor.py
@@ -413,6 +413,7 @@ class FileProcessor:
         chunk_index: int = 0,
         total_chunks: int = 1,
         prior_violations: Optional[List[dict]] = None,
+        guardrails: Optional[List[dict]] = None,
     ) -> str:
         """Format the review prompt via the shared context recipe."""
         from ollama_sentinel.context import build_review_context
@@ -431,7 +432,24 @@ class FileProcessor:
             total_budget=self.total_budget,
             retriever=self.retriever,
             grounding=self.config.processing.grounding,
+            guardrails=guardrails or [],
         )
+
+    async def _get_active_guardrails(self) -> List[dict]:
+        """Load active project guardrails for injection, or [] on any failure.
+
+        Best-effort and read-only: a missing DB or a query error degrades to no
+        guardrails so review generation is never blocked (consistent with the
+        prior-violation recall layers). Only ``active`` guardrails are returned,
+        so disabled/dismissed rules are never injected.
+        """
+        if not self.violation_db:
+            return []
+        try:
+            return await asyncio.to_thread(self.violation_db.get_active_guardrails)
+        except Exception as e:
+            log.warning("Guardrail load failed (%s); continuing without guardrails.", e)
+            return []
 
     async def _get_ranked_prior_violations(
         self, file_path: pathlib.Path, *, file_content: Optional[str]
@@ -594,9 +612,12 @@ class FileProcessor:
         prior = await self._get_ranked_prior_violations(
             file_change.path, file_content=file_change.content,
         )
+        guardrails = await self._get_active_guardrails()
 
         if file_change.diff is not None:
-            prompt = await self.format_prompt(file_change, prior_violations=prior)
+            prompt = await self.format_prompt(
+                file_change, prior_violations=prior, guardrails=guardrails,
+            )
             raw = await self.ollama_client.generate_review(
                 model_role, prompt, response_format=_review_format(self.config),
             )
@@ -604,7 +625,9 @@ class FileProcessor:
 
         content = file_change.content
         if not content:
-            prompt = await self.format_prompt(file_change, prior_violations=prior)
+            prompt = await self.format_prompt(
+                file_change, prior_violations=prior, guardrails=guardrails,
+            )
             raw = await self.ollama_client.generate_review(
                 model_role, prompt, response_format=_review_format(self.config),
             )
@@ -617,7 +640,8 @@ class FileProcessor:
 
         if len(chunks) == 1:
             prompt = await self.format_prompt(
-                file_change, chunk_text=chunks[0], prior_violations=prior,
+                file_change, chunk_text=chunks[0],
+                prior_violations=prior, guardrails=guardrails,
             )
             raw = await self.ollama_client.generate_review(
                 model_role, prompt, response_format=_review_format(self.config),
@@ -625,13 +649,18 @@ class FileProcessor:
             return self._parse_review_response(raw, grounding=self.config.processing.grounding)
 
         async def review_chunk(chunk_idx, total_chunks):
+            # Prior violations and guardrails ride chunk 0 only (as prior
+            # violations already do) — they are project-level context, not
+            # per-chunk, and repeating them on every chunk would bloat the budget.
             violations = prior if chunk_idx == 0 else None
+            chunk_guardrails = guardrails if chunk_idx == 0 else None
             prompt = await self.format_prompt(
                 file_change,
                 chunk_text=chunks[chunk_idx],
                 chunk_index=chunk_idx,
                 total_chunks=total_chunks,
                 prior_violations=violations,
+                guardrails=chunk_guardrails,
             )
             raw = await self.ollama_client.generate_review(
                 model_role, prompt, response_format=_review_format(self.config),

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -8,6 +8,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
+# Sentinel distinguishing "argument not provided" from an explicit None
+# (used by update_guardrail so callers can *clear* a scope field with None).
+_UNSET = object()
+
 
 @dataclass
 class Finding:
@@ -19,6 +23,27 @@ class Finding:
     severity: str    # "critical", "high", "medium", "low"
     description: str
     verbatim_excerpt: str = ""
+    guardrail_id: Optional[int] = None  # provenance: guardrail that produced this finding
+
+
+@dataclass
+class Guardrail:
+    """A curated, named rule injected into reviews as an LLM-checked assertion.
+
+    Guardrails are model-agnostic prose checks: a ``name``, a natural-language
+    ``assertion`` the review model evaluates against code, and an optional
+    ``scope`` (a finding ``scope_category`` and/or a ``scope_path_glob``) that
+    bounds which files the guardrail applies to. ``status`` gates enforcement
+    (only ``active`` guardrails are injected); ``source`` records whether the
+    developer authored it (``manual``) or confirmed an auto-promoted candidate
+    (``promoted``).
+    """
+    name: str
+    assertion: str
+    scope_category: Optional[str] = None
+    scope_path_glob: Optional[str] = None
+    status: str = "active"    # "active" | "disabled" | "dismissed"
+    source: str = "manual"    # "manual" | "promoted"
 
 
 @dataclass
@@ -81,6 +106,20 @@ class ViolationDB:
         )
     """
 
+    _CREATE_GUARDRAILS_TABLE = """
+        CREATE TABLE IF NOT EXISTS guardrails (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            name            TEXT    NOT NULL,
+            assertion       TEXT    NOT NULL,
+            scope_category  TEXT,
+            scope_path_glob TEXT,
+            status          TEXT    NOT NULL DEFAULT 'active',
+            source          TEXT    NOT NULL DEFAULT 'manual',
+            created_at      TEXT    NOT NULL,
+            updated_at      TEXT    NOT NULL
+        )
+    """
+
     def __init__(self, db_path: str) -> None:
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
@@ -90,11 +129,12 @@ class ViolationDB:
             self._conn.execute("PRAGMA foreign_keys=ON")
             self._conn.execute(self._CREATE_TABLE)
             self._conn.execute(self._CREATE_INCIDENTS_TABLE)
+            self._conn.execute(self._CREATE_GUARDRAILS_TABLE)
             self._conn.commit()
         self._migrate()
 
     def _migrate(self) -> None:
-        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt, resolution)."""
+        """Idempotent migration: add columns introduced after the initial schema (embed_text backfill, triggering_commit_sha, fix_commit_sha, verbatim_excerpt, resolution, guardrail_id)."""
         try:
             with self._lock:
                 cur = self._conn.execute("PRAGMA table_info(findings)")
@@ -126,6 +166,10 @@ class ViolationDB:
                 if "resolution" not in cols:
                     self._conn.execute(
                         "ALTER TABLE findings ADD COLUMN resolution TEXT"
+                    )
+                if "guardrail_id" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE findings ADD COLUMN guardrail_id INTEGER"
                     )
                 self._conn.commit()
         except sqlite3.DatabaseError as e:
@@ -182,8 +226,8 @@ class ViolationDB:
                             INSERT INTO findings
                                 (file_path, line_start, line_end, category,
                                  severity, description, first_seen, last_seen,
-                                 embed_text, verbatim_excerpt)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                 embed_text, verbatim_excerpt, guardrail_id)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                             """,
                             (
                                 f.file_path,
@@ -196,6 +240,7 @@ class ViolationDB:
                                 now,
                                 embed_text,
                                 f.verbatim_excerpt,
+                                f.guardrail_id,
                             ),
                         )
                 self._conn.commit()
@@ -551,6 +596,142 @@ class ViolationDB:
 
         scored.sort(key=lambda p: p[0], reverse=True)
         return [row for _score, row in scored[:k]]
+
+    # ------------------------------------------------------------------
+    # Guardrails (U1)
+    # ------------------------------------------------------------------
+
+    def create_guardrail(self, guardrail: Guardrail) -> int:
+        """Insert a Guardrail and return its new id.
+
+        ``status`` and ``source`` fall back to the dataclass defaults
+        (``active`` / ``manual``). ``created_at`` and ``updated_at`` are stamped
+        to the same instant at creation.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            cur = self._conn.cursor()
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO guardrails
+                        (name, assertion, scope_category, scope_path_glob,
+                         status, source, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        guardrail.name,
+                        guardrail.assertion,
+                        guardrail.scope_category,
+                        guardrail.scope_path_glob,
+                        guardrail.status,
+                        guardrail.source,
+                        now,
+                        now,
+                    ),
+                )
+                self._conn.commit()
+                return int(cur.lastrowid) if cur.lastrowid is not None else -1
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def get_guardrail(self, guardrail_id: int) -> Optional[dict]:
+        """Return the guardrails row for *guardrail_id*, or None — any status."""
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM guardrails WHERE id = ?", (guardrail_id,)
+            )
+            rows = self._rows_to_dicts(cur)
+        return rows[0] if rows else None
+
+    def list_guardrails(
+        self,
+        *,
+        status: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> List[dict]:
+        """Return guardrails, optionally filtered by ``status`` / ``source``.
+
+        Ordered by ``id`` ascending so listings are stable across calls.
+        """
+        clauses: list = []
+        params: list = []
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._lock:
+            cur = self._conn.execute(
+                f"SELECT * FROM guardrails {where} ORDER BY id ASC",
+                tuple(params),
+            )
+            return self._rows_to_dicts(cur)
+
+    def get_active_guardrails(self) -> List[dict]:
+        """Return all ``active`` guardrails (the set eligible for injection)."""
+        return self.list_guardrails(status="active")
+
+    def update_guardrail(
+        self,
+        guardrail_id: int,
+        *,
+        name: Optional[str] = None,
+        assertion: Optional[str] = None,
+        scope_category=_UNSET,
+        scope_path_glob=_UNSET,
+    ) -> int:
+        """Edit a guardrail's name/assertion/scope; return rows updated.
+
+        Only the fields you pass change. ``name`` / ``assertion`` are left
+        untouched when ``None``. ``scope_category`` / ``scope_path_glob`` use the
+        ``_UNSET`` sentinel so passing ``None`` explicitly *clears* the scope
+        (broadens the guardrail) while omitting it leaves it intact. Touches
+        ``updated_at`` whenever any field changes. Returns 0 if no guardrail has
+        that id.
+        """
+        sets = ["updated_at = ?"]
+        params: list = [datetime.now(timezone.utc).isoformat()]
+        if name is not None:
+            sets.append("name = ?")
+            params.append(name)
+        if assertion is not None:
+            sets.append("assertion = ?")
+            params.append(assertion)
+        if scope_category is not _UNSET:
+            sets.append("scope_category = ?")
+            params.append(scope_category)
+        if scope_path_glob is not _UNSET:
+            sets.append("scope_path_glob = ?")
+            params.append(scope_path_glob)
+        params.append(guardrail_id)
+
+        with self._lock:
+            cur = self._conn.execute(
+                f"UPDATE guardrails SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
+            )
+            self._conn.commit()
+            return cur.rowcount
+
+    def set_guardrail_status(self, guardrail_id: int, status: str) -> int:
+        """Set a guardrail's lifecycle ``status`` and return rows updated.
+
+        ``status`` is one of ``active`` / ``disabled`` / ``dismissed``. Setting
+        the same status again is a no-op transition (idempotent) that still
+        reports rowcount 1 — the row exists. Returns 0 if no guardrail has that
+        id. Touches ``updated_at``.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE guardrails SET status = ?, updated_at = ? WHERE id = ?",
+                (status, datetime.now(timezone.utc).isoformat(), guardrail_id),
+            )
+            self._conn.commit()
+            return cur.rowcount
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tests/context/test_recipes.py
+++ b/tests/context/test_recipes.py
@@ -128,6 +128,168 @@ class TestBuildReviewContext:
         assert pos_1 < pos_2
 
 
+def _guardrail(**overrides) -> dict:
+    """A guardrail row dict (as returned by ViolationDB.get_active_guardrails)."""
+    g = dict(
+        id=1, name="g", assertion="do the thing",
+        scope_category=None, scope_path_glob=None,
+        status="active", source="manual",
+    )
+    g.update(overrides)
+    return g
+
+
+class TestGuardrailInjection:
+    """U3 — relevance-scoped guardrail injection into the review prompt."""
+
+    async def test_in_scope_guardrail_appears_with_assertion(self):
+        counter = TokenCounter()
+        out = await build_review_context(
+            file_rel_path="src/app.py", file_type="py",
+            content="x = 1\n", diff=None, chunk_info="",
+            prior_violations=[],
+            guardrails=[_guardrail(name="no-eval",
+                                   assertion="Never call eval on user input.")],
+            counter=counter, total_budget=600, retriever=NullRetriever(),
+        )
+        assert "PROJECT GUARDRAILS" in out
+        assert "no-eval" in out
+        assert "Never call eval on user input." in out
+
+    async def test_path_glob_match_includes(self):
+        counter = TokenCounter()
+        out = await build_review_context(
+            file_rel_path="src/app.py", file_type="py",
+            content="x = 1\n", diff=None, chunk_info="",
+            prior_violations=[],
+            guardrails=[_guardrail(scope_path_glob="src/*.py",
+                                   assertion="scoped rule text")],
+            counter=counter, total_budget=600, retriever=NullRetriever(),
+        )
+        assert "scoped rule text" in out
+
+    async def test_path_glob_mismatch_excludes(self):
+        counter = TokenCounter()
+        out = await build_review_context(
+            file_rel_path="src/app.py", file_type="py",
+            content="x = 1\n", diff=None, chunk_info="",
+            prior_violations=[],
+            guardrails=[_guardrail(scope_path_glob="lib/*.py",
+                                   assertion="lib only rule")],
+            counter=counter, total_budget=600, retriever=NullRetriever(),
+        )
+        assert "PROJECT GUARDRAILS" not in out
+        assert "lib only rule" not in out
+
+    async def test_nested_path_not_matched_by_single_star(self):
+        """src/*.py admits src/app.py but NOT src/sub/app.py (segment-precise)."""
+        counter = TokenCounter()
+        out = await build_review_context(
+            file_rel_path="src/sub/app.py", file_type="py",
+            content="x = 1\n", diff=None, chunk_info="",
+            prior_violations=[],
+            guardrails=[_guardrail(scope_path_glob="src/*.py",
+                                   assertion="single star rule")],
+            counter=counter, total_budget=600, retriever=NullRetriever(),
+        )
+        assert "single star rule" not in out
+
+    async def test_category_only_scope_applies_to_any_file(self):
+        """A category-only scope does not exclude by file (a file has no category)."""
+        counter = TokenCounter()
+        out = await build_review_context(
+            file_rel_path="anywhere/here.py", file_type="py",
+            content="x = 1\n", diff=None, chunk_info="",
+            prior_violations=[],
+            guardrails=[_guardrail(scope_category="security", scope_path_glob=None,
+                                   assertion="security matters everywhere")],
+            counter=counter, total_budget=600, retriever=NullRetriever(),
+        )
+        assert "security matters everywhere" in out
+
+    async def test_zero_guardrails_emits_no_section(self):
+        counter = TokenCounter()
+        out = await build_review_context(
+            file_rel_path="src/app.py", file_type="py",
+            content="x = 1\n", diff=None, chunk_info="",
+            prior_violations=[], guardrails=[],
+            counter=counter, total_budget=600, retriever=NullRetriever(),
+        )
+        assert "PROJECT GUARDRAILS" not in out
+
+    async def test_guardrails_section_above_prior_unresolved(self):
+        counter = TokenCounter()
+        violation = {
+            "id": 1, "severity": "high", "category": "security",
+            "line_start": 10, "line_end": 10, "description": "hardcoded password",
+            "file_path": "src/a.py", "occurrence_count": 1,
+            "first_seen": "2026-01-01T00:00:00",
+        }
+        out = await build_review_context(
+            file_rel_path="src/a.py", file_type="py",
+            content="x = 1\n", diff=None, chunk_info="",
+            prior_violations=[violation],
+            guardrails=[_guardrail(name="rule", assertion="a guardrail assertion")],
+            counter=counter, total_budget=1500, retriever=NullRetriever(),
+        )
+        assert "PROJECT GUARDRAILS" in out and "PRIOR UNRESOLVED" in out
+        assert out.index("PROJECT GUARDRAILS") < out.index("PRIOR UNRESOLVED")
+
+    async def test_retriever_ranks_guardrails_by_similarity(self):
+        content = "x = 1\n"
+        query_key = f"query:{hashlib.sha256(content.encode()).hexdigest()}"
+        embedder = _FakeEmbedder({
+            query_key: [1.0, 0.0],
+            "guardrail:1": [1.0, 0.0],   # cosine 1.0 (most similar)
+            "guardrail:2": [0.0, 1.0],   # cosine 0.0 (least similar)
+        })
+        retriever = SemanticRetriever(embedder=embedder)
+        # Listed bravo-first so NullRetriever would keep bravo on top; the
+        # semantic retriever must reorder alpha (id 1) above bravo (id 2).
+        guardrails = [
+            _guardrail(id=2, name="bravo", assertion="bravo rule text"),
+            _guardrail(id=1, name="alpha", assertion="alpha rule text"),
+        ]
+        out = await build_review_context(
+            file_rel_path="src/a.py", file_type="py",
+            content=content, diff=None, chunk_info="",
+            prior_violations=[], guardrails=guardrails,
+            counter=TokenCounter(), total_budget=1000, retriever=retriever,
+        )
+        assert "PROJECT GUARDRAILS" in out
+        assert out.index("alpha rule text") < out.index("bravo rule text")
+
+    async def test_budget_cap_drops_lowest_ranked_guardrail(self):
+        """When the section budget is tight, the retriever's top pick survives
+        and the lowest-ranked guardrail is dropped (soft_budget cap holds)."""
+        content = "x = 1\n"
+        query_key = f"query:{hashlib.sha256(content.encode()).hexdigest()}"
+        embedder = _FakeEmbedder({
+            query_key: [1.0, 0.0],
+            "guardrail:1": [1.0, 0.0],   # most similar → kept
+            "guardrail:2": [0.0, 1.0],   # least similar → dropped under cap
+        })
+        retriever = SemanticRetriever(embedder=embedder)
+        guardrails = [
+            _guardrail(id=2, name="bravo",
+                       assertion="BRAVO " + "padding " * 30),
+            _guardrail(id=1, name="alpha",
+                       assertion="ALPHA " + "padding " * 30),
+        ]
+        # grounding=False drops the MUST_FIT INSTRUCTIONS section so the budget
+        # math is just FILE (0.70) + guardrails (0.20). A tight total leaves room
+        # for ~one padded guardrail item.
+        out = await build_review_context(
+            file_rel_path="src/a.py", file_type="py",
+            content=content, diff=None, chunk_info="",
+            prior_violations=[], guardrails=guardrails,
+            counter=TokenCounter(), total_budget=140, retriever=retriever,
+            grounding=False,
+        )
+        assert "ALPHA" in out       # top-ranked kept
+        assert "BRAVO" not in out   # lowest-ranked capped out
+
+
 from dataclasses import dataclass, field
 from typing import List
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import yaml
 from typer.testing import CliRunner
 
 from ollama_sentinel.cli import app
-from ollama_sentinel.violation_db import Finding, Incident, ViolationDB
+from ollama_sentinel.violation_db import Finding, Guardrail, Incident, ViolationDB
 
 
 runner = CliRunner()
@@ -1253,3 +1253,182 @@ class TestPruneCommand:
         result = runner.invoke(app, ["prune", "--config", str(cfg)])
         assert result.exit_code == 0
         assert "No violation database" in result.output
+
+
+# ---------------------------------------------------------------------------
+# U2 — `ollama-sentinel guardrail` authoring + lifecycle sub-commands
+# ---------------------------------------------------------------------------
+
+
+def _list_json(cfg, *extra):
+    """Run `guardrail list -f json [extra]` and return the parsed rows."""
+    r = runner.invoke(
+        app, ["guardrail", "list", "--config", str(cfg), "-f", "json", *extra]
+    )
+    assert r.exit_code == 0, r.output
+    return json.loads(r.output)
+
+
+class TestGuardrailCLI:
+    """Tests for the `guardrail` authoring + lifecycle sub-app (U2)."""
+
+    def test_add_creates_active_guardrail_with_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        r = runner.invoke(app, [
+            "guardrail", "add", "no-bare-except",
+            "--assertion", "Do not catch bare Exception without re-raising.",
+            "--category", "bug", "--path", "src/*.py",
+            "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+
+        rows = _list_json(cfg)
+        assert len(rows) == 1
+        g = rows[0]
+        assert g["name"] == "no-bare-except"
+        assert g["assertion"] == "Do not catch bare Exception without re-raising."
+        assert g["scope_category"] == "bug"
+        assert g["scope_path_glob"] == "src/*.py"
+        assert g["status"] == "active"
+        assert g["source"] == "manual"
+
+    def test_add_creates_db_when_absent(self, tmp_path, monkeypatch):
+        """Authoring must work on a fresh setup with no prior reviews/DB."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        assert not db_path.exists()
+        r = runner.invoke(app, [
+            "guardrail", "add", "g1", "--assertion", "a", "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+        assert db_path.exists()
+
+    def test_add_without_scope_is_broad(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        r = runner.invoke(app, [
+            "guardrail", "add", "broad", "--assertion", "Applies everywhere.",
+            "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+        g = _list_json(cfg)[0]
+        assert g["scope_category"] is None
+        assert g["scope_path_glob"] is None
+
+    def test_edit_changes_assertion_and_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, [
+            "guardrail", "add", "g", "--assertion", "old", "--category", "bug",
+            "--config", str(cfg),
+        ])
+        gid = _list_json(cfg)[0]["id"]
+        r = runner.invoke(app, [
+            "guardrail", "edit", str(gid),
+            "--assertion", "new assertion", "--category", "security",
+            "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+        g = _list_json(cfg)[0]
+        assert g["assertion"] == "new assertion"
+        assert g["scope_category"] == "security"
+
+    def test_disable_removes_from_active_and_enable_restores(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, [
+            "guardrail", "add", "g", "--assertion", "a", "--config", str(cfg),
+        ])
+        gid = _list_json(cfg)[0]["id"]
+
+        r = runner.invoke(app, ["guardrail", "disable", str(gid), "--config", str(cfg)])
+        assert r.exit_code == 0, r.output
+        assert _list_json(cfg) == []  # default list is active-only
+
+        r = runner.invoke(app, ["guardrail", "enable", str(gid), "--config", str(cfg)])
+        assert r.exit_code == 0, r.output
+        assert [g["id"] for g in _list_json(cfg)] == [gid]
+
+    def test_list_all_includes_non_active(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        gid = _list_json(cfg)[0]["id"]
+        runner.invoke(app, ["guardrail", "disable", str(gid), "--config", str(cfg)])
+        assert _list_json(cfg) == []
+        all_rows = _list_json(cfg, "--all")
+        assert [g["status"] for g in all_rows] == ["disabled"]
+
+    def test_dismiss_is_terminal_and_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        gid = _list_json(cfg)[0]["id"]
+
+        r1 = runner.invoke(app, ["guardrail", "dismiss", str(gid), "--config", str(cfg)])
+        assert r1.exit_code == 0, r1.output
+        # Dismiss again — no error, stays dismissed.
+        r2 = runner.invoke(app, ["guardrail", "dismiss", str(gid), "--config", str(cfg)])
+        assert r2.exit_code == 0, r2.output
+        all_rows = _list_json(cfg, "--all")
+        assert [g["status"] for g in all_rows] == ["dismissed"]
+
+    def test_list_table_renders_name_and_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("COLUMNS", "200")
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, [
+            "guardrail", "add", "no-eval", "--assertion", "Never call eval.",
+            "--category", "security", "--config", str(cfg),
+        ])
+        r = runner.invoke(app, ["guardrail", "list", "--config", str(cfg)])
+        assert r.exit_code == 0, r.output
+        assert "no-eval" in r.output
+        assert "security" in r.output
+
+    def test_list_empty_message(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()  # empty DB
+        r = runner.invoke(app, ["guardrail", "list", "--config", str(cfg)])
+        assert r.exit_code == 0
+        assert "No guardrails" in r.output
+
+    def test_list_no_db_message(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        r = runner.invoke(app, ["guardrail", "list", "--config", str(cfg)])
+        assert r.exit_code == 0
+        assert "No guardrails" in r.output
+
+    def test_edit_missing_id_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        r = runner.invoke(app, [
+            "guardrail", "edit", "9999", "--assertion", "x", "--config", str(cfg),
+        ])
+        assert r.exit_code == 1
+        assert "No guardrail with id" in r.output
+
+    def test_disable_missing_id_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        runner.invoke(app, ["guardrail", "add", "g", "--assertion", "a", "--config", str(cfg)])
+        r = runner.invoke(app, ["guardrail", "disable", "9999", "--config", str(cfg)])
+        assert r.exit_code == 1
+        assert "No guardrail with id" in r.output
+
+    def test_dismiss_missing_id_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        r = runner.invoke(app, ["guardrail", "dismiss", "9999", "--config", str(cfg)])
+        assert r.exit_code == 1
+        assert "No guardrail with id" in r.output

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -504,6 +504,99 @@ class TestFileProcessorGenerateReview:
         assert "## Part 2/" in summary
 
 
+class TestGuardrailWiring:
+    """U3 — FileProcessor loads active guardrails and injects them into reviews."""
+
+    @staticmethod
+    def _config(tmp_path):
+        """Config with semantic + structural recall off so generate_review makes
+        exactly one (chat) call and no embedder network traffic."""
+        return SentinelConfig(
+            watch=WatchConfig(directory=str(tmp_path)),
+            ollama=OllamaConfig(
+                host="http://localhost:11434",
+                models={
+                    "default": OllamaModelConfig(
+                        name="test-model", system_prompt="Review code."
+                    ),
+                },
+            ),
+            memory=MemoryConfig(
+                enabled=True, db_path=".ollama_reviews/memory.db",
+                semantic_recall=False, structural_recall=False,
+            ),
+        )
+
+    @staticmethod
+    def _db(tmp_path):
+        from ollama_sentinel.violation_db import ViolationDB
+        p = tmp_path / ".ollama_reviews" / "memory.db"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return ViolationDB(str(p))
+
+    async def test_get_active_guardrails_excludes_non_active(self, tmp_path):
+        from ollama_sentinel.violation_db import Guardrail
+
+        db = self._db(tmp_path)
+        try:
+            keep = db.create_guardrail(Guardrail(name="keep", assertion="active rule"))
+            off = db.create_guardrail(Guardrail(name="off", assertion="disabled rule"))
+            gone = db.create_guardrail(Guardrail(name="gone", assertion="dismissed rule"))
+            db.set_guardrail_status(off, "disabled")
+            db.set_guardrail_status(gone, "dismissed")
+
+            fp = FileProcessor(self._config(tmp_path), violation_db=db)
+            try:
+                rows = await fp._get_active_guardrails()
+            finally:
+                await fp.ollama_client.close()
+            assert [r["id"] for r in rows] == [keep]
+        finally:
+            db.close()
+
+    async def test_get_active_guardrails_no_db_returns_empty(self, sentinel_config):
+        fp = FileProcessor(sentinel_config)  # no violation_db wired
+        try:
+            assert await fp._get_active_guardrails() == []
+        finally:
+            await fp.ollama_client.close()
+
+    async def test_generate_review_injects_active_excludes_disabled(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        from ollama_sentinel.violation_db import Guardrail
+
+        source = tmp_path / "small.py"
+        source.write_text("print('hello')")
+
+        db = self._db(tmp_path)
+        db.create_guardrail(Guardrail(
+            name="no-print", assertion="GUARDRAIL_ACTIVE_TOKEN avoid print",
+        ))
+        off = db.create_guardrail(Guardrail(
+            name="off", assertion="GUARDRAIL_DISABLED_TOKEN",
+        ))
+        db.set_guardrail_status(off, "disabled")
+
+        httpx_mock.add_response(
+            url=OLLAMA_CHAT_URL,
+            json={"message": {"content": json.dumps({"summary": "ok", "findings": []})}},
+        )
+
+        fp = FileProcessor(self._config(tmp_path), violation_db=db)
+        fc = FileChange(path=source, change_type=Change.modified)
+        try:
+            await fp.generate_review(fc)
+        finally:
+            await fp.ollama_client.close()
+            db.close()
+
+        body = httpx_mock.get_requests()[0].read().decode()
+        assert "PROJECT GUARDRAILS" in body
+        assert "GUARDRAIL_ACTIVE_TOKEN" in body
+        assert "GUARDRAIL_DISABLED_TOKEN" not in body
+
+
 # ---------------------------------------------------------------------------
 # FileProcessor.save_review tests
 # ---------------------------------------------------------------------------

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from ollama_sentinel.violation_db import Finding, ViolationDB
+from ollama_sentinel.violation_db import Finding, Guardrail, ViolationDB
 
 
 # ---------------------------------------------------------------------------
@@ -1038,3 +1038,260 @@ class TestGetOpenFindings:
             db.close()
         assert all_ids == sorted(all_ids)
         assert limited == sorted(all_ids)[:3]
+
+
+# ---------------------------------------------------------------------------
+# U1: Guardrail storage model + finding provenance
+# ---------------------------------------------------------------------------
+
+
+def _make_guardrail(**overrides) -> Guardrail:
+    """Build a Guardrail with sensible defaults, allowing field overrides."""
+    defaults = dict(
+        name="no-bare-except",
+        assertion="Do not catch bare Exception without re-raising or logging.",
+        scope_category="bug",
+        scope_path_glob="src/*.py",
+    )
+    defaults.update(overrides)
+    return Guardrail(**defaults)
+
+
+class TestGuardrailCRUD:
+    def test_create_returns_id_and_roundtrips(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            assert isinstance(gid, int) and gid > 0
+
+            row = db.get_guardrail(gid)
+            assert row is not None
+            assert row["id"] == gid
+            assert row["name"] == "no-bare-except"
+            assert row["assertion"].startswith("Do not catch bare Exception")
+            assert row["scope_category"] == "bug"
+            assert row["scope_path_glob"] == "src/*.py"
+            # Defaults applied on creation.
+            assert row["status"] == "active"
+            assert row["source"] == "manual"
+            assert row["created_at"]
+            assert row["updated_at"]
+        finally:
+            db.close()
+
+    def test_create_without_scope_defaults_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(
+                Guardrail(name="broad", assertion="Applies everywhere.")
+            )
+            row = db.get_guardrail(gid)
+            assert row["scope_category"] is None
+            assert row["scope_path_glob"] is None
+        finally:
+            db.close()
+
+    def test_create_promoted_source_persists(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail(source="promoted"))
+            assert db.get_guardrail(gid)["source"] == "promoted"
+        finally:
+            db.close()
+
+    def test_get_guardrail_missing_returns_none(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.get_guardrail(424242) is None
+        finally:
+            db.close()
+
+    def test_list_guardrails_all_and_filtered(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            a = db.create_guardrail(_make_guardrail(name="a"))
+            b = db.create_guardrail(_make_guardrail(name="b", source="promoted"))
+            db.set_guardrail_status(b, "disabled")
+
+            all_rows = db.list_guardrails()
+            assert {r["id"] for r in all_rows} == {a, b}
+
+            active = db.list_guardrails(status="active")
+            assert [r["id"] for r in active] == [a]
+
+            promoted = db.list_guardrails(source="promoted")
+            assert [r["id"] for r in promoted] == [b]
+        finally:
+            db.close()
+
+    def test_get_active_guardrails_excludes_non_active(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            keep = db.create_guardrail(_make_guardrail(name="keep"))
+            off = db.create_guardrail(_make_guardrail(name="off"))
+            gone = db.create_guardrail(_make_guardrail(name="gone"))
+            db.set_guardrail_status(off, "disabled")
+            db.set_guardrail_status(gone, "dismissed")
+
+            active = db.get_active_guardrails()
+            assert [r["id"] for r in active] == [keep]
+        finally:
+            db.close()
+
+    def test_status_transitions_persist(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            assert db.get_guardrail(gid)["status"] == "active"
+
+            assert db.set_guardrail_status(gid, "disabled") == 1
+            assert db.get_guardrail(gid)["status"] == "disabled"
+
+            assert db.set_guardrail_status(gid, "active") == 1
+            assert db.get_guardrail(gid)["status"] == "active"
+
+            assert db.set_guardrail_status(gid, "dismissed") == 1
+            assert db.get_guardrail(gid)["status"] == "dismissed"
+        finally:
+            db.close()
+
+    def test_dismiss_is_idempotent(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.set_guardrail_status(gid, "dismissed")
+            # Dismiss again — no error, stays dismissed.
+            db.set_guardrail_status(gid, "dismissed")
+            assert db.get_guardrail(gid)["status"] == "dismissed"
+        finally:
+            db.close()
+
+    def test_set_status_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.set_guardrail_status(424242, "disabled") == 0
+        finally:
+            db.close()
+
+    def test_update_guardrail_edits_name_assertion_scope(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            n = db.update_guardrail(
+                gid,
+                name="renamed",
+                assertion="New assertion text.",
+                scope_category="security",
+                scope_path_glob="lib/**.py",
+            )
+            assert n == 1
+            row = db.get_guardrail(gid)
+            assert row["name"] == "renamed"
+            assert row["assertion"] == "New assertion text."
+            assert row["scope_category"] == "security"
+            assert row["scope_path_glob"] == "lib/**.py"
+        finally:
+            db.close()
+
+    def test_update_guardrail_can_clear_scope(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.update_guardrail(gid, scope_category=None, scope_path_glob=None)
+            row = db.get_guardrail(gid)
+            assert row["scope_category"] is None
+            assert row["scope_path_glob"] is None
+        finally:
+            db.close()
+
+    def test_update_guardrail_unspecified_fields_unchanged(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            # Only change the name — scope must be left intact.
+            db.update_guardrail(gid, name="only-name")
+            row = db.get_guardrail(gid)
+            assert row["name"] == "only-name"
+            assert row["scope_category"] == "bug"
+            assert row["scope_path_glob"] == "src/*.py"
+            assert row["assertion"].startswith("Do not catch bare Exception")
+        finally:
+            db.close()
+
+    def test_update_guardrail_missing_id_returns_zero(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.update_guardrail(424242, name="x") == 0
+        finally:
+            db.close()
+
+
+class TestGuardrailTableMigration:
+    def test_guardrails_table_created_on_init(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            tbl = db._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='guardrails'"
+            ).fetchone()
+            assert tbl is not None
+        finally:
+            db.close()
+
+
+class TestGuardrailProvenance:
+    def test_finding_written_with_guardrail_id(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.persist_findings(
+                "src/app.py",
+                [_make_finding(file_path="src/app.py", guardrail_id=gid)],
+            )
+            row = db.get_unresolved("src/app.py")[0]
+            assert row["guardrail_id"] == gid
+        finally:
+            db.close()
+
+    def test_finding_without_guardrail_id_is_null(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.persist_findings("src/app.py", [_make_finding(file_path="src/app.py")])
+            row = db.get_unresolved("src/app.py")[0]
+            assert row["guardrail_id"] is None
+        finally:
+            db.close()
+
+    def test_migration_adds_guardrail_id_to_legacy_db(self, tmp_path):
+        """Additive migration adds guardrail_id to a pre-existing DB, no data loss."""
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute(
+            """
+            CREATE TABLE findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL, line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL, category TEXT NOT NULL,
+                severity TEXT NOT NULL, description TEXT NOT NULL,
+                first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL DEFAULT 1,
+                resolved INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO findings (file_path, line_start, line_end, category, "
+            "severity, description, first_seen, last_seen) "
+            "VALUES ('a.py', 1, 2, 'bug', 'low', 'd', 't', 't')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = ViolationDB(str(p))  # __init__ runs _migrate
+        try:
+            rows = db.get_unresolved("a.py")
+            assert len(rows) == 1  # existing row intact
+            assert "guardrail_id" in rows[0]
+            assert rows[0]["guardrail_id"] is None  # legacy row: no provenance
+        finally:
+            db.close()


### PR DESCRIPTION
Third unit of the **Pattern promotion → project guardrails** plan, Phase 1. **Stacked on #38 (U2)** → #37 (U1) → master. This PR's base is the U2 branch so the diff shows only U3's delta.

Implements plan requirements **R5** (enforcement via injection into the review prompt), **R6** (relevance-scoped injection — rank + token budget), **R10** (disabled/dismissed never injected).

## What it does
Active guardrails now flow into the review prompt as a dedicated section the model is told to check explicitly — ranked by relevance, scoped by file, and capped by token budget.

### `recipes.py` — `build_review_context` gains a `guardrails` param
- **Scope filter** (`_guardrail_applies_to_file`, pure): a `scope_path_glob` injects only for files whose POSIX-normalized relative path matches the glob — **segment-precise** via `PurePosixPath.match` (`src/*.py` admits `src/app.py`, not `src/sub/app.py`); absent glob = applies broadly. **`scope_category` does not exclude by file** (a file has no category until reviewed) — it's carried for downstream attribution (U4) and clustering (U6).
- **Section placement:** a new `PROJECT GUARDRAILS — check explicitly` OPTIONAL section placed **before** `PRIOR UNRESOLVED ISSUES`. `assemble()` fills OPTIONAL sections in list order, so guardrails win budget contention — i.e. higher priority than prior-unresolved (KTD2/KTD6). Same `Section`/`Priority`/`retriever`/`soft_budget` mechanism; the retriever ranks by relevance and `soft_budget` caps the section so a growing rulebook never floods the prompt. Empty / all-out-of-scope → no section header.

### `processor.py` — wiring
- `FileProcessor._get_active_guardrails()` — best-effort, read-only loader; `[]` on missing DB or error; returns **only `active`** rows, so disabled/dismissed are structurally never injected.
- `generate_review` loads guardrails once and threads them through `format_prompt` (chunk-0 only, exactly like prior violations — project-level context, not per-chunk).

## Tests (12)
**9 recipe** (`test_recipes.py`): in-scope appears with assertion; path-glob match/mismatch; nested-path exclusion; category-only applies broadly; zero→no section; ordered above PRIOR UNRESOLVED; retriever ranks by similarity; **budget-cap drops the lowest-ranked guardrail**.
**3 processor** (`test_processor.py`): `_get_active_guardrails` excludes non-active; `[]` with no DB; and an **end-to-end** `generate_review` asserting the active guardrail reaches the Ollama request body while the disabled one does not.

Full suite: **741 passed / 16 skipped**.