### PR TITLE
feat(guardrails): U4 — provenance capture on guardrail-flagged findings

### DIFF
--- a/ollama_sentinel/processor.py
+++ b/ollama_sentinel/processor.py
@@ -95,6 +95,58 @@ def _number_lines(content: str) -> str:
     )
 
 
+def attribute_guardrail_provenance(
+    findings: "List[Any]", guardrails: "List[dict]", file_rel_path: str,
+) -> None:
+    """Best-effort: stamp each finding with the guardrail that produced it.
+
+    Mutates ``finding.guardrail_id`` in place. The guardrail set is scope-filtered
+    to ``file_rel_path`` using the *same* canonical filter the injection path uses
+    (``recipes._guardrail_applies_to_file``), so a finding is only ever attributed
+    to a guardrail that was actually injected for this file. Attribution is
+    intentionally conservative — it fails safe to ``None`` (U8's integrity gate
+    only *adds* trust when provenance is present, so a missed link just counts the
+    finding as independently discovered):
+
+      1. If exactly one in-scope guardrail is scoped to the finding's category,
+         attribute to it.
+      2. Else, if the only in-scope guardrail is a single *broad* rule (no
+         category scope), attribute to it.
+      3. Otherwise (ambiguous, or the only rule is scoped to a different
+         category) leave the provenance null.
+
+    Never raises — a malformed guardrail entry is skipped, and a per-finding
+    failure degrades that finding to null without affecting the others. Provenance
+    must never block finding persistence.
+    """
+    from ollama_sentinel.context.recipes import _guardrail_applies_to_file
+
+    def _applies(g) -> bool:
+        try:
+            return _guardrail_applies_to_file(g, file_rel_path)
+        except Exception:
+            return False
+
+    in_scope = [g for g in guardrails if _applies(g)]
+    if not in_scope:
+        return
+
+    for f in findings:
+        try:
+            category = getattr(f, "category", None)
+            cat_matches = [g for g in in_scope if g.get("scope_category") == category]
+            if len(cat_matches) == 1:
+                f.guardrail_id = cat_matches[0]["id"]
+            elif (
+                not cat_matches
+                and len(in_scope) == 1
+                and in_scope[0].get("scope_category") is None
+            ):
+                f.guardrail_id = in_scope[0]["id"]
+        except Exception:
+            continue
+
+
 @dataclass
 class FileChange:
     """Represents a changed file to be processed."""

--- a/ollama_sentinel/watcher.py
+++ b/ollama_sentinel/watcher.py
@@ -14,7 +14,7 @@ from watchfiles import awatch, Change
 from .config import load_config
 from .extractor import extract_findings_legacy, validate_findings
 from .models import SentinelConfig
-from .processor import FileChange, FileProcessor
+from .processor import FileChange, FileProcessor, attribute_guardrail_provenance
 from .violation_db import ViolationDB
 
 log = logging.getLogger("ollama-sentinel")
@@ -262,6 +262,21 @@ class FileSentinel:
                         summary_text = review.get("summary", "")
                         valid_findings = extract_findings_legacy(summary_text, str(rel_path))
                     if valid_findings:
+                        # Best-effort guardrail provenance: attribute each finding
+                        # to the in-scope guardrail it corresponds to. Never blocks
+                        # persistence — a failure leaves provenance null.
+                        try:
+                            guardrails = await asyncio.to_thread(
+                                self.violation_db.get_active_guardrails,
+                            )
+                            if guardrails:
+                                attribute_guardrail_provenance(
+                                    valid_findings, guardrails, str(rel_path),
+                                )
+                        except Exception as e:
+                            log.warning(
+                                "Guardrail attribution failed for %s: %s", rel_path, e,
+                            )
                         await asyncio.to_thread(
                             self.violation_db.persist_findings, str(rel_path), valid_findings,
                         )

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -504,6 +504,115 @@ class TestFileProcessorGenerateReview:
         assert "## Part 2/" in summary
 
 
+def _gr(**overrides) -> dict:
+    """A guardrail row dict (as returned by ViolationDB.get_active_guardrails)."""
+    g = dict(
+        id=1, name="g", assertion="a",
+        scope_category=None, scope_path_glob=None,
+        status="active", source="manual",
+    )
+    g.update(overrides)
+    return g
+
+
+class TestGuardrailAttribution:
+    """U4 — best-effort guardrail provenance on flagged findings."""
+
+    def test_single_category_scoped_guardrail_attributed(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "security", "high", "uses eval")
+        attribute_guardrail_provenance(
+            [f], [_gr(id=7, scope_category="security")], "src/app.py",
+        )
+        assert f.guardrail_id == 7
+
+    def test_single_broad_guardrail_attributed(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "bug", "high", "x")
+        attribute_guardrail_provenance([f], [_gr(id=3)], "src/app.py")  # broad
+        assert f.guardrail_id == 3
+
+    def test_category_match_chosen_among_many(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "security", "high", "x")
+        guardrails = [
+            _gr(id=1, scope_category="security"),
+            _gr(id=2, scope_category="perf"),
+        ]
+        attribute_guardrail_provenance([f], guardrails, "src/app.py")
+        assert f.guardrail_id == 1
+
+    def test_unrelated_finding_stays_null(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "style", "low", "x")
+        guardrails = [
+            _gr(id=1, scope_category="security"),
+            _gr(id=2, scope_category="perf"),
+        ]
+        attribute_guardrail_provenance([f], guardrails, "src/app.py")
+        assert f.guardrail_id is None
+
+    def test_ambiguous_category_stays_null(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "bug", "high", "x")
+        guardrails = [
+            _gr(id=1, scope_category="bug"),
+            _gr(id=2, scope_category="bug"),
+        ]
+        attribute_guardrail_provenance([f], guardrails, "src/app.py")
+        assert f.guardrail_id is None
+
+    def test_out_of_path_scope_not_attributed(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "security", "high", "x")
+        guardrails = [_gr(id=1, scope_category="security", scope_path_glob="lib/*.py")]
+        attribute_guardrail_provenance([f], guardrails, "src/app.py")
+        assert f.guardrail_id is None
+
+    def test_no_guardrails_is_noop(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "security", "high", "x")
+        attribute_guardrail_provenance([f], [], "src/app.py")
+        assert f.guardrail_id is None
+
+    def test_single_mismatched_category_guardrail_stays_null(self):
+        """A lone in-scope guardrail scoped to a *different* category must not
+        capture an unrelated finding (only broad lone rules attribute)."""
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "security", "high", "x")
+        attribute_guardrail_provenance(
+            [f], [_gr(id=1, scope_category="perf")], "src/app.py",
+        )
+        assert f.guardrail_id is None
+
+    def test_malformed_guardrail_degrades_without_raising(self):
+        from ollama_sentinel.processor import attribute_guardrail_provenance
+        from ollama_sentinel.violation_db import Finding
+
+        f = Finding("src/app.py", 1, 1, "security", "high", "x")
+        # A non-dict entry must be skipped, not crash; the valid one still attributes.
+        attribute_guardrail_provenance(
+            [f], [None, _gr(id=5, scope_category="security")], "src/app.py",
+        )
+        assert f.guardrail_id == 5
+
+
 class TestGuardrailWiring:
     """U3 — FileProcessor loads active guardrails and injects them into reviews."""
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -485,3 +485,62 @@ class TestSarifAutoRefresh:
 
         # The review itself still saved.
         assert (tmp_path / ".ollama_reviews" / "app.md").exists()
+
+
+class TestGuardrailProvenanceWiring:
+    """U4 — process_change attributes guardrail provenance to flagged findings."""
+
+    async def test_flagged_finding_records_guardrail_provenance(
+        self, tmp_path, monkeypatch
+    ):
+        from ollama_sentinel.violation_db import Guardrail
+
+        cfg = _watcher_cfg(tmp_path)
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+
+        sentinel = FileSentinel(cfg)
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review)
+        # Author a guardrail scoped to the finding's category before review.
+        gid = sentinel.violation_db.create_guardrail(
+            Guardrail(name="no-eval", assertion="Never eval untrusted input.",
+                      scope_category="security")
+        )
+        try:
+            await sentinel.process_change(
+                FileChange(path=src, change_type=Change.modified)
+            )
+        finally:
+            await sentinel.processor.close()
+
+        rows = sentinel.violation_db.get_unresolved("app.py")
+        assert len(rows) == 1
+        assert rows[0]["guardrail_id"] == gid
+
+    async def test_provenance_failure_does_not_block_persistence(
+        self, tmp_path, monkeypatch
+    ):
+        """If guardrail attribution raises, findings still persist (null provenance)."""
+        cfg = _watcher_cfg(tmp_path)
+        src = tmp_path / "app.py"
+        src.write_text("def f():\n    x = eval(data)\n    return x\n")
+
+        sentinel = FileSentinel(cfg)
+        monkeypatch.setattr(sentinel.processor, "generate_review", _fake_review)
+
+        def _boom(self):
+            raise RuntimeError("guardrail load blew up")
+
+        # get_active_guardrails raising inside process_change must not abort persist.
+        from ollama_sentinel.violation_db import ViolationDB
+        monkeypatch.setattr(ViolationDB, "get_active_guardrails", _boom)
+        try:
+            await sentinel.process_change(
+                FileChange(path=src, change_type=Change.modified)
+            )
+        finally:
+            await sentinel.processor.close()
+
+        rows = sentinel.violation_db.get_unresolved("app.py")
+        assert len(rows) == 1
+        assert rows[0]["guardrail_id"] is None


### PR DESCRIPTION
Fourth unit of the **Pattern promotion → project guardrails** plan, Phase 1. **Stacked on #39 (U3)** → #38 → #37 → master. Base is the U3 branch so the diff shows only U4's delta.

Implements plan requirement **R7** (a finding records the originating guardrail). This is what makes U8's evidence-integrity gate enforceable later.

## What it does
When a review flags findings under injected guardrails, each finding is best-effort attributed to the guardrail that produced it, and the `guardrail_id` provenance column (U1) is populated.

### `processor.py` — pure `attribute_guardrail_provenance(findings, guardrails, file_rel_path)`
- Stamps `finding.guardrail_id` in place.
- **Scope-filters with the same canonical filter the injection path uses** (`recipes._guardrail_applies_to_file`), so a finding is only ever attributed to a guardrail that was actually injected for this file — attribution scope == injection scope.
- **Conservative, fail-safe-to-null** heuristic (U8 only *adds* trust when provenance is present, so a missed link just counts the finding as independently discovered):
  1. exactly one in-scope guardrail scoped to the finding's category → attribute;
  2. else a single in-scope **broad** (no-category) rule → attribute;
  3. else (ambiguous, or the lone rule is scoped to a different category) → **null**.
- **Never raises** — malformed/non-dict entries are skipped; a per-finding failure degrades that finding only.

### `watcher.py` — wiring
`process_change` loads active guardrails and runs attribution immediately before `persist_findings`, wrapped best-effort: a load/attribution failure logs and leaves provenance null, **never blocking persistence** (consistent with the existing best-effort extraction convention). No change to `generate_review`'s return contract.

## Tests (11)
**9 helper** (`test_processor.py`): category match, single broad, match-among-many, unrelated→null, ambiguous→null, out-of-path-scope→null, no-guardrails noop, malformed-entry degrades, single-mismatched-category→null.
**2 watcher integration** (`test_watcher.py`): a security-scoped guardrail's id lands on a flagged security finding end-to-end; and an attribution failure still persists the finding with null provenance.

Full suite: **752 passed / 16 skipped**.