### PR TITLE
feat(guardrails): U5 — dashboard guardrails panel

### DIFF
--- a/ollama_sentinel/dashboard.py
+++ b/ollama_sentinel/dashboard.py
@@ -95,6 +95,14 @@ class ViolationRow:
 
 
 @dataclass
+class GuardrailRow:
+    """An active project guardrail for the dashboard panel."""
+    name: str
+    scope: str   # human-readable scope label ("security · src/*.py", "all files")
+    source: str  # "manual" | "promoted"
+
+
+@dataclass
 class OverviewStats:
     """Aggregate system state for the Control Center overview card."""
     total_reviews: int
@@ -150,6 +158,28 @@ def top_violations(db: ViolationDB, min_count: int, limit: int) -> List[Violatio
             description=r["description"],
         )
         for r in raw
+    ]
+
+
+def _format_guardrail_scope(category: Optional[str], path_glob: Optional[str]) -> str:
+    """Human-readable scope label for a guardrail row."""
+    bits = [b for b in (category, path_glob) if b]
+    return " · ".join(bits) if bits else "all files"
+
+
+def active_guardrails(db: ViolationDB) -> List[GuardrailRow]:
+    """Return active guardrails from the DB as ``GuardrailRow`` objects.
+
+    Read-only; mirrors ``top_violations``. The caller's per-source try/except
+    isolates a failure here from the rest of the dashboard.
+    """
+    return [
+        GuardrailRow(
+            name=g["name"],
+            scope=_format_guardrail_scope(g.get("scope_category"), g.get("scope_path_glob")),
+            source=g.get("source", "manual"),
+        )
+        for g in db.get_active_guardrails()
     ]
 
 
@@ -402,6 +432,27 @@ def _patterns_panel(rows: List[ViolationRow]) -> Panel:
     return Panel(table, title=f"Patterns ({len(rows)})", border_style="magenta")
 
 
+def _guardrails_panel(rows: List[GuardrailRow]) -> Panel:
+    """Active-guardrails panel: name + scope + source, one row each.
+
+    Read-only and non-focusable (curation happens via the CLI). Empty state
+    degrades to a muted hint; never raises on bad input.
+    """
+    if not rows:
+        return Panel(
+            Text("no guardrails — author one with `guardrail add`", style="dim"),
+            title="Guardrails", border_style="green",
+        )
+    table = Table.grid(padding=(0, 1), expand=True)
+    table.add_column(no_wrap=True, overflow="ellipsis")   # name
+    table.add_column(no_wrap=True, overflow="ellipsis", style="dim")  # scope
+    table.add_column(no_wrap=True, justify="right", style="dim")      # source
+    for r in rows:
+        src = "auto" if r.source == "promoted" else "✎"
+        table.add_row(r.name, r.scope, src)
+    return Panel(table, title=f"Guardrails ({len(rows)})", border_style="green")
+
+
 def _footer_panel_v2() -> Panel:
     """Footer with keyboard hints."""
     body = "[dim]Ctrl-C[/] quit   [dim]│[/]   Refreshes every 1s   [dim]│[/]   Read-only control center"
@@ -447,6 +498,7 @@ def render_layout(
     hottest: Optional[tuple] = None,
     new_this_week: int = 0,
     research_latest: Optional[Dict] = None,
+    guardrails: Optional[List[GuardrailRow]] = None,
 ) -> Layout:
     """Build the full Rich layout for one frame.
 
@@ -499,7 +551,10 @@ def render_layout(
         Layout(name="right", ratio=1),
     )
     layout["body"]["left"].update(_patterns_panel(ranked))
-    layout["body"]["right"].update(_reviews_rail(reviews, now, -1, 0))
+    layout["body"]["right"].split_column(
+        Layout(_reviews_rail(reviews, now, -1, 0), name="reviews", ratio=2),
+        Layout(_guardrails_panel(guardrails or []), name="guardrails", ratio=1),
+    )
     layout["footer"].update(_footer_panel_v2())
     return layout
 
@@ -589,6 +644,7 @@ async def run_dashboard(
         severity_counts: Dict[str, int] = {}
         hottest: Optional[tuple] = None
         new_this_week: int = 0
+        guardrails: list = []
 
         if db is None and db_path.exists():
             try:
@@ -625,6 +681,11 @@ async def run_dashboard(
                 except Exception:
                     log.exception("count_new_since failed")
 
+                try:
+                    guardrails = active_guardrails(db)
+                except Exception:
+                    log.exception("active_guardrails failed")
+
         research_latest = None
         if config_path:
             try:
@@ -640,6 +701,7 @@ async def run_dashboard(
             "hottest": hottest,
             "new_this_week": new_this_week,
             "research_latest": research_latest,
+            "guardrails": guardrails,
             "now": now,
         }
 
@@ -715,7 +777,11 @@ async def run_dashboard(
             Layout(name="right", ratio=1),
         )
         layout["body"]["left"].update(patterns_p)
-        layout["body"]["right"].update(reviews_p)
+        layout["body"]["right"].split_column(
+            Layout(reviews_p, name="reviews", ratio=2),
+            Layout(_guardrails_panel(data.get("guardrails") or []),
+                   name="guardrails", ratio=1),
+        )
 
         if interactive:
             layout["footer"].update(_footer_interactive(state))

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -7,9 +7,11 @@ import time
 from unittest.mock import MagicMock, patch
 
 from ollama_sentinel.dashboard import (
+    GuardrailRow,
     OverviewStats,
     ReviewRow,
     ViolationRow,
+    active_guardrails,
     compute_overview,
     recent_reviews,
     render_layout,
@@ -18,10 +20,11 @@ from ollama_sentinel.dashboard import (
     top_violations,
     watcher_status,
     watcher_status_from_age,
+    _guardrails_panel,
     _patterns_panel,
     _footer_panel_v2,
 )
-from ollama_sentinel.violation_db import Finding, ViolationDB
+from ollama_sentinel.violation_db import Finding, Guardrail, ViolationDB
 
 
 def _touch(path: pathlib.Path, mtime: float) -> None:
@@ -219,6 +222,36 @@ class TestRunDashboard:
             )
         assert call_count >= 2
 
+    async def test_active_guardrails_exception_does_not_crash_loop(self, tmp_path, monkeypatch):
+        """A guardrail-fetch failure degrades the panel independently — the
+        loop keeps running (Control Center layout, config_path set)."""
+        db_path = tmp_path / "memory.db"
+        ViolationDB(str(db_path)).close()
+        (tmp_path / "ollama-sentinel.yaml").write_text("watch:\n  directory: .\n")
+
+        shutdown = asyncio.Event()
+        call_count = 0
+
+        def _bad_guardrails(db):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise sqlite3.OperationalError("db locked")
+            shutdown.set()
+            return []
+
+        monkeypatch.setattr("ollama_sentinel.dashboard.active_guardrails", _bad_guardrails)
+        with patch("ollama_sentinel.dashboard.Live", return_value=_mock_live()):
+            await run_dashboard(
+                watch_dir=tmp_path,
+                reviews_dir=tmp_path / "reviews",
+                db_path=db_path,
+                shutdown=shutdown,
+                refresh_s=0.01,
+                config_path=str(tmp_path / "ollama-sentinel.yaml"),
+            )
+        assert call_count >= 2
+
 
 # ---------------------------------------------------------------------------
 # Control Center v2 tests
@@ -338,6 +371,60 @@ class TestSuggestedAction:
             severity_counts={},
         )
         assert "all clear" in suggested_action(stats).lower()
+
+
+class TestActiveGuardrails:
+    """U5 — pure DB selector for the dashboard guardrails panel."""
+
+    def test_empty_db(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert active_guardrails(db) == []
+        finally:
+            db.close()
+
+    def test_returns_only_active_as_rows(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.create_guardrail(Guardrail(
+                name="no-eval", assertion="never eval",
+                scope_category="security", scope_path_glob="src/*.py",
+            ))
+            off = db.create_guardrail(Guardrail(name="off", assertion="x"))
+            db.set_guardrail_status(off, "disabled")
+
+            rows = active_guardrails(db)
+            assert all(isinstance(r, GuardrailRow) for r in rows)
+            assert [r.name for r in rows] == ["no-eval"]
+            assert rows[0].source == "manual"
+            assert "security" in rows[0].scope and "src/*.py" in rows[0].scope
+        finally:
+            db.close()
+
+    def test_broad_scope_label(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            db.create_guardrail(Guardrail(name="broad", assertion="x"))
+            assert active_guardrails(db)[0].scope == "all files"
+        finally:
+            db.close()
+
+
+class TestGuardrailsPanel:
+    """U5 — guardrails panel renderer (read-only, degrades safely)."""
+
+    def test_empty_renders_without_error(self):
+        panel = _guardrails_panel([])
+        assert panel.title == "Guardrails"
+        assert "no guardrails" in _render(panel)
+
+    def test_with_data_shows_name_and_scope(self):
+        rows = [GuardrailRow(name="no-eval", scope="security · src/*.py", source="manual")]
+        panel = _guardrails_panel(rows)
+        assert "Guardrails (1)" in panel.title
+        text = _render(panel)
+        assert "no-eval" in text
+        assert "security" in text
 
 
 class TestControlCenterPanels:
@@ -496,6 +583,34 @@ class TestTriageRenderIntegration:
         i_high = out.index("HighFile.py")
         i_crit = out.index("CritFile.py")
         assert i_low < i_high < i_crit, out
+
+
+class TestRenderLayoutGuardrails:
+    """U5 — the guardrails panel lands in the Control Center right column."""
+
+    def test_guardrails_panel_in_right_column(self, tmp_path):
+        now = time.time()
+        layout = render_layout(
+            str(tmp_path), tmp_path, tmp_path / "memory.db",
+            [], [], now,
+            config_path="test.yaml", model_name="gemma3",
+            guardrails=[GuardrailRow(name="no-eval", scope="security", source="manual")],
+        )
+        panel = layout["body"]["right"]["guardrails"].renderable
+        out = _render(panel, width=120)
+        assert "no-eval" in out
+
+    def test_right_column_still_present_without_guardrails(self, tmp_path):
+        now = time.time()
+        layout = render_layout(
+            str(tmp_path), tmp_path, tmp_path / "memory.db",
+            [], [], now,
+            config_path="test.yaml", model_name="gemma3",
+        )
+        # Backwards-compat: right column exists; guardrails sub-panel degrades empty.
+        assert layout["body"]["right"] is not None
+        out = _render(layout["body"]["right"]["guardrails"].renderable, width=120)
+        assert "no guardrails" in out
 
 
 class TestViolationDBNewHelpers:


### PR DESCRIPTION
Fifth and final unit of **Phase 1** of the **Pattern promotion → project guardrails** plan. **Stacked on #40 (U4)** → #39 → #38 → #37 → master. Base is the U4 branch so the diff shows only U5's delta.

Implements plan requirement **R9** (surfacing via the dashboard). With this, **Phase 1 (U1–U5) delivers the full manual-authoring value loop**: author → curate → inject → attribute → see.

## What it does
The live Control Center TUI now shows a read-only panel of active project guardrails.

- **`GuardrailRow` + pure `active_guardrails(db)`** (mirrors `top_violations`): maps active guardrails to rows with a human-readable scope label (`security · src/*.py`, `all files`).
- **`_guardrails_panel(rows)`** (mirrors `_patterns_panel`): read-only, non-focusable (curation is via the CLI from U2), green-bordered, with a muted empty state pointing at `guardrail add`. Source rendered as ✎ (manual) / auto (promoted) — the latter lands in U7.
- **`_fetch_data`** loads guardrails inside its own `try/except`, so a failure degrades this panel independently without crashing the loop (same convention as the other DB-backed panels).
- **Layout:** the Control Center right column splits into the reviews rail (top) + guardrails panel (bottom), in both `render_layout` and the live `_build_layout`. `render_layout` gains a defaulted `guardrails` param; the legacy two-panel layout is untouched.

## Tests (8)
`active_guardrails` (empty, active-only-as-rows, broad-scope label); panel (empty renders, name+scope shown); a **loop-resilience** test (a guardrail-fetch failure keeps the loop alive); and two `render_layout` integration checks (panel in the right column; right column still present and degrades empty without guardrails).

Full suite: **760 passed / 16 skipped**.

---
### Phase 1 complete
This closes the Phase-1 stack (#37 → #38 → #39 → #40 → #41). Phase 2 (U6 shape clustering, U7 candidate surfacing, U8 evidence-integrity gate) layers auto-promotion on top of this artifact and is out of scope here.