### PR TITLE
feat(guardrails): U6 — shape clustering + candidate detection

### DIFF
--- a/ollama_sentinel/guardrails.py
+++ b/ollama_sentinel/guardrails.py
@@ -1,0 +1,129 @@
+"""Guardrail shape clustering + candidate detection (Phase 2).
+
+Leaf module: the clustering logic is pure enough to test with a fake embedder
+(no Ollama, no DB). Candidate detection runs *on demand* — when the developer
+lists candidates — never on the review hot path (KTD4).
+"""
+from __future__ import annotations
+
+import asyncio
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import List
+
+from ollama_sentinel.context.embeddings import EmbeddingUnavailable
+
+
+@dataclass
+class Candidate:
+    """A detected guardrail candidate: a cluster of same-shape findings.
+
+    A candidate is a proposal, not a guardrail — the developer confirms or
+    dismisses it (U7). ``finding_ids`` are the distinct corroborated findings
+    that formed the shape; ``descriptions``/``file_paths`` carry member context
+    for drafting an assertion and deriving a scope.
+    """
+    category: str
+    finding_ids: List[int] = field(default_factory=list)
+    descriptions: List[str] = field(default_factory=list)
+    file_paths: List[str] = field(default_factory=list)
+
+    @property
+    def size(self) -> int:
+        return len(self.finding_ids)
+
+
+def _cosine(a, b) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def _embed_text_for(f: dict) -> str:
+    """Text to embed for a finding — its stored ``embed_text`` or a fallback."""
+    return f.get("embed_text") or (
+        f"[{f.get('severity', '')}] {f.get('category', '')}: {f.get('description', '')}"
+    )
+
+
+async def _embed_findings(findings: List[dict], embedder):
+    """Embed each finding, dropping any the embedder cannot handle.
+
+    A finding the embedder rejects (``EmbeddingUnavailable``) is silently
+    excluded rather than aborting the whole run — detection degrades, never
+    crashes.
+    """
+    async def _one(f):
+        try:
+            vec = await embedder.embed(
+                _embed_text_for(f), cache_key=f"finding:{f['id']}",
+            )
+        except EmbeddingUnavailable:
+            return None
+        return (f, vec)
+
+    pairs = await asyncio.gather(*(_one(f) for f in findings))
+    return [p for p in pairs if p is not None]
+
+
+def _cluster(pairs, threshold: float):
+    """Greedy seed clustering.
+
+    A finding joins the first existing cluster whose *seed* vector is within
+    ``threshold`` cosine similarity; otherwise it seeds a new cluster. Input
+    order is deterministic (caller sorts by id), so clusters are reproducible.
+    """
+    clusters: list = []  # each: {"seed": vec, "members": [finding, ...]}
+    for f, vec in pairs:
+        for c in clusters:
+            if _cosine(vec, c["seed"]) >= threshold:
+                c["members"].append(f)
+                break
+        else:
+            clusters.append({"seed": vec, "members": [f]})
+    return clusters
+
+
+async def detect_candidates(
+    findings: List[dict],
+    embedder,
+    *,
+    similarity_threshold: float = 0.85,
+    min_distinct: int = 3,
+) -> List[Candidate]:
+    """Detect guardrail candidates from corroborated findings.
+
+    ``findings`` are corroborated findings (each with >=1 incident; see
+    ``ViolationDB.get_corroborated_findings``). They are grouped by category and
+    clustered within category by embedding cosine similarity; a cluster with at
+    least ``min_distinct`` (default 3) *distinct* findings becomes a Candidate.
+    Cross-category findings never merge (grouping precedes clustering), and the
+    threshold counts distinct findings — not incident counts.
+
+    Embedding goes through the injected async ``embedder`` (duck-typed:
+    ``embed(text, *, cache_key=None)``), so a fake embedder drives the tests and
+    the real ``OllamaEmbedder`` drives production. Deterministic: findings are
+    processed in id order.
+    """
+    if not findings:
+        return []
+
+    by_category: "defaultdict[str, list]" = defaultdict(list)
+    for f in sorted(findings, key=lambda r: r.get("id", 0)):
+        by_category[f.get("category", "")].append(f)
+
+    candidates: List[Candidate] = []
+    for category, group in by_category.items():
+        pairs = await _embed_findings(group, embedder)
+        for c in _cluster(pairs, similarity_threshold):
+            members = c["members"]
+            if len(members) >= min_distinct:
+                candidates.append(Candidate(
+                    category=category,
+                    finding_ids=[m["id"] for m in members],
+                    descriptions=[m.get("description", "") for m in members],
+                    file_paths=[m.get("file_path", "") for m in members],
+                ))
+    return candidates

--- a/ollama_sentinel/violation_db.py
+++ b/ollama_sentinel/violation_db.py
@@ -414,6 +414,33 @@ class ViolationDB:
             )
             return self._rows_to_dicts(cur)
 
+    def get_corroborated_findings(self) -> List[dict]:
+        """Return every finding with >=1 Incident, across all files (read-only).
+
+        One row per distinct finding (not per incident). Each row is the full
+        findings row plus a ``confirming_signals`` list — the distinct
+        ``confirming_signal`` values of its incidents. Backs guardrail shape
+        clustering (U6) and the evidence-integrity gate (U8): ``guardrail_id``
+        provenance and the signal set are both carried so the caller can apply
+        the gate without a second query.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                SELECT findings.*,
+                       GROUP_CONCAT(DISTINCT incidents.confirming_signal) AS _signals
+                FROM findings
+                JOIN incidents ON incidents.finding_id = findings.id
+                GROUP BY findings.id
+                ORDER BY findings.id ASC
+                """
+            )
+            rows = self._rows_to_dicts(cur)
+        for r in rows:
+            raw = r.pop("_signals", None)
+            r["confirming_signals"] = raw.split(",") if raw else []
+        return rows
+
     def get_unresolved(self, file_path: str) -> List[dict]:
         """Return all unresolved findings for *file_path*."""
         with self._lock:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,142 @@
+"""Tests for ollama_sentinel.guardrails — shape clustering + candidate detection."""
+
+from ollama_sentinel.context.embeddings import EmbeddingUnavailable
+from ollama_sentinel.guardrails import Candidate, detect_candidates
+
+
+class _FakeEmbedder:
+    """Maps a finding's cache_key (or embed_text) to a fixed vector.
+
+    Raises EmbeddingUnavailable for anything unmapped — mirrors the real
+    embedder's failure mode so degradation paths are exercised.
+    """
+    def __init__(self, vectors: dict):
+        self._vectors = vectors
+
+    async def embed(self, text, *, cache_key=None):
+        if cache_key in self._vectors:
+            return self._vectors[cache_key]
+        if text in self._vectors:
+            return self._vectors[text]
+        raise EmbeddingUnavailable(f"no vector for {cache_key or text!r}")
+
+
+def _finding(fid, category, description, *, file_path="src/a.py", embed_text=None):
+    return {
+        "id": fid,
+        "category": category,
+        "severity": "high",
+        "description": description,
+        "file_path": file_path,
+        "line_start": fid,
+        "line_end": fid,
+        "embed_text": embed_text or f"[{category}] {description}",
+        "guardrail_id": None,
+        "confirming_signals": ["manual_confirm"],
+    }
+
+
+class TestDetectCandidates:
+    async def test_three_similar_same_category_form_one_candidate(self):
+        findings = [
+            _finding(1, "security", "eval on user input"),
+            _finding(2, "security", "eval of request body"),
+            _finding(3, "security", "eval of untrusted str"),
+        ]
+        embedder = _FakeEmbedder({
+            "finding:1": [1.0, 0.0],
+            "finding:2": [0.99, 0.01],
+            "finding:3": [0.98, 0.02],
+        })
+        cands = await detect_candidates(findings, embedder, similarity_threshold=0.9)
+        assert len(cands) == 1
+        c = cands[0]
+        assert isinstance(c, Candidate)
+        assert c.category == "security"
+        assert sorted(c.finding_ids) == [1, 2, 3]
+        assert c.size == 3
+
+    async def test_two_corroborated_below_threshold_count(self):
+        """Only two distinct findings in a shape → below the >=3 threshold."""
+        findings = [
+            _finding(1, "security", "eval one"),
+            _finding(2, "security", "eval two"),
+        ]
+        embedder = _FakeEmbedder({"finding:1": [1.0, 0.0], "finding:2": [1.0, 0.0]})
+        cands = await detect_candidates(findings, embedder, similarity_threshold=0.9)
+        assert cands == []
+
+    async def test_single_finding_many_incidents_not_a_candidate(self):
+        """Distinct *findings* drive the threshold, not incident count."""
+        f = _finding(1, "security", "eval once")
+        f["confirming_signals"] = ["test_failure", "manual_confirm", "fix_commit"]
+        embedder = _FakeEmbedder({"finding:1": [1.0, 0.0]})
+        cands = await detect_candidates([f], embedder, similarity_threshold=0.9)
+        assert cands == []
+
+    async def test_same_category_dissimilar_no_candidate(self):
+        findings = [
+            _finding(1, "security", "eval"),
+            _finding(2, "security", "weak hash"),
+            _finding(3, "security", "open redirect"),
+        ]
+        embedder = _FakeEmbedder({
+            "finding:1": [1.0, 0.0, 0.0],
+            "finding:2": [0.0, 1.0, 0.0],
+            "finding:3": [0.0, 0.0, 1.0],
+        })
+        cands = await detect_candidates(findings, embedder, similarity_threshold=0.9)
+        assert cands == []
+
+    async def test_cross_category_not_merged(self):
+        """Identical embeddings across categories do not merge into one shape."""
+        findings = [
+            _finding(1, "security", "eval a"),
+            _finding(2, "security", "eval b"),
+            _finding(3, "perf", "n^2 loop"),
+        ]
+        embedder = _FakeEmbedder({
+            "finding:1": [1.0, 0.0],
+            "finding:2": [1.0, 0.0],
+            "finding:3": [1.0, 0.0],  # same vector, different category
+        })
+        cands = await detect_candidates(findings, embedder, similarity_threshold=0.9)
+        # security cluster = 2 (<3), perf cluster = 1 → no candidate.
+        assert cands == []
+
+    async def test_candidate_carries_member_metadata(self):
+        findings = [
+            _finding(1, "bug", "off by one", file_path="src/a.py"),
+            _finding(2, "bug", "off by one too", file_path="src/b.py"),
+            _finding(3, "bug", "another off by one", file_path="src/c.py"),
+        ]
+        embedder = _FakeEmbedder({
+            "finding:1": [1.0, 0.0],
+            "finding:2": [1.0, 0.0],
+            "finding:3": [1.0, 0.0],
+        })
+        cands = await detect_candidates(findings, embedder, similarity_threshold=0.9)
+        assert len(cands) == 1
+        c = cands[0]
+        assert set(c.descriptions) == {"off by one", "off by one too", "another off by one"}
+        assert set(c.file_paths) == {"src/a.py", "src/b.py", "src/c.py"}
+
+    async def test_embedding_unavailable_finding_is_skipped(self):
+        """A finding the embedder can't embed drops out, not crashes the run."""
+        findings = [
+            _finding(1, "security", "eval a"),
+            _finding(2, "security", "eval b"),
+            _finding(3, "security", "eval c"),  # unmapped → skipped
+        ]
+        embedder = _FakeEmbedder({
+            "finding:1": [1.0, 0.0],
+            "finding:2": [1.0, 0.0],
+            # finding:3 missing → EmbeddingUnavailable
+        })
+        cands = await detect_candidates(findings, embedder, similarity_threshold=0.9)
+        # Only 2 embeddable findings remain → below threshold.
+        assert cands == []
+
+    async def test_empty_input_returns_empty(self):
+        embedder = _FakeEmbedder({})
+        assert await detect_candidates([], embedder) == []

--- a/tests/test_violation_db.py
+++ b/tests/test_violation_db.py
@@ -1226,6 +1226,60 @@ class TestGuardrailCRUD:
             db.close()
 
 
+class TestGetCorroboratedFindings:
+    """U6 — read selector for clustering: findings with >=1 incident + signals."""
+
+    def test_only_corroborated_findings_returned(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            with_inc = _seed_finding_id(db, file_path="a.py", line_start=1, line_end=1)
+            _seed_finding_id(db, file_path="a.py", line_start=9, line_end=9)  # no incident
+            db.persist_incident(_make_incident(with_inc))
+
+            rows = db.get_corroborated_findings()
+            assert [r["id"] for r in rows] == [with_inc]
+        finally:
+            db.close()
+
+    def test_distinct_findings_not_incident_count(self, tmp_path):
+        """One finding with three incidents is a single row (distinct findings)."""
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            fid = _seed_finding_id(db)
+            for sig in ("test_failure", "manual_confirm", "fix_commit"):
+                db.persist_incident(_make_incident(fid, confirming_signal=sig,
+                                                   confirming_artifact=sig))
+            rows = db.get_corroborated_findings()
+            assert len(rows) == 1
+            assert rows[0]["id"] == fid
+            assert set(rows[0]["confirming_signals"]) == {
+                "test_failure", "manual_confirm", "fix_commit",
+            }
+        finally:
+            db.close()
+
+    def test_carries_guardrail_provenance(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            gid = db.create_guardrail(_make_guardrail())
+            db.persist_findings(
+                "a.py", [_make_finding(file_path="a.py", guardrail_id=gid)],
+            )
+            fid = db.get_unresolved("a.py")[0]["id"]
+            db.persist_incident(_make_incident(fid))
+            rows = db.get_corroborated_findings()
+            assert rows[0]["guardrail_id"] == gid
+        finally:
+            db.close()
+
+    def test_empty_db_returns_empty(self, tmp_path):
+        db = ViolationDB(str(tmp_path / "v.db"))
+        try:
+            assert db.get_corroborated_findings() == []
+        finally:
+            db.close()
+
+
 class TestGuardrailTableMigration:
     def test_guardrails_table_created_on_init(self, tmp_path):
         db = ViolationDB(str(tmp_path / "v.db"))


### PR DESCRIPTION
First unit of **Phase 2** (auto-promotion) of the Pattern-promotion plan. **Stacked on #41 (U5)** — the full Phase-1 stack precedes it. Implements **R3** (auto-promotion candidate from ≥3 distinct corroborated findings).

Phase 2 layers auto-detection on top of Phase 1's manual-authoring artifact: recurring corroborated failures of the same shape surface as **candidates** the developer can promote (U7) — gated for evidence integrity (U8).

## Changes
**`violation_db.py` — `get_corroborated_findings()`** (read-only): one row per distinct finding with ≥1 incident, across all files, each carrying a `confirming_signals` list (distinct incident signals) and its `guardrail_id` provenance. One query serves both clustering (U6) and the integrity gate (U8).

**`ollama_sentinel/guardrails.py` (new leaf module)** — `Candidate` dataclass + async `detect_candidates(findings, embedder, *, similarity_threshold=0.85, min_distinct=3)`:
- Groups corroborated findings by category, then clusters within category by embedding cosine (greedy seed clustering) via the injected async embedder.
- Emits a `Candidate` per cluster of ≥`min_distinct` **distinct** findings.
- **Cross-category findings never merge** (grouping precedes clustering); the threshold counts **distinct findings, not incidents**.
- Runs **on demand**, never on the review hot path (KTD4). A finding the embedder can't embed is dropped, not fatal. Deterministic (id-ordered).

## Tests (12)
**8 detect** (`test_guardrails.py`, new): 3-similar→one candidate; 2-below-threshold→none; single finding with 3 incidents→none (distinct findings, not incident count); same-category-dissimilar→none; cross-category not merged; member metadata carried; embed-unavailable skipped; empty input.
**4 selector** (`test_violation_db.py`): only-corroborated returned; distinct-findings-not-incident-count with full signal set; provenance carried; empty DB.

Full suite: **772 passed / 16 skipped**. U7 (surfacing + curation) and U8 (integrity gate) follow.