### PR TITLE
feat(guardrails): U7 — candidate surfacing + curation

### DIFF
--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -1218,6 +1218,260 @@ def guardrail_dismiss(
     )
 
 
+# --- Candidate surfacing + curation (U7) ----------------------------------
+
+def _build_embedder(config):
+    """Construct the hot-path embedder for on-demand clustering, or None.
+
+    Module-level so tests can monkeypatch it with a fake embedder.
+    """
+    from .context import OllamaEmbedder
+    try:
+        return OllamaEmbedder(
+            host=config.ollama.host,
+            model=config.embedding.models["hot"],
+            timeout_seconds=float(config.embedding.timeout_seconds),
+        )
+    except Exception:
+        return None
+
+
+async def _cli_candidates(config, db, *, threshold: float):
+    """Detect + suppress guardrail candidates (no drafting). Returns the list,
+    ordered deterministically so a 1-based index is stable between list/promote/
+    reject on unchanged data. Runs on demand only (KTD4)."""
+    from .guardrails import detect_candidates, filter_suppressed
+
+    findings = await asyncio.to_thread(db.get_corroborated_findings)
+    if not findings:
+        return []
+    embedder = _build_embedder(config)
+    if embedder is None:
+        return []
+    try:
+        cands = await detect_candidates(findings, embedder, similarity_threshold=threshold)
+    finally:
+        await embedder.close()
+    # Suppress shapes already rejected: dismissed promoted guardrails store the
+    # candidate signature in their assertion (see `reject`). A confirmed-then-
+    # dismissed real guardrail won't match (different text format), so it never
+    # falsely suppresses.
+    dismissed = [
+        g["assertion"]
+        for g in db.list_guardrails(status="dismissed", source="promoted")
+    ]
+    return filter_suppressed(cands, dismissed)
+
+
+def _model_caller(client, config):
+    """An async (prompt)->str callable bound to the configured default model."""
+    model_cfg = config.ollama.models.get("default")
+
+    async def _call(prompt: str) -> str:
+        return await client.generate_with_model(model_cfg, prompt)
+
+    return _call
+
+
+@guardrail_app.command("candidates")
+def guardrail_candidates(
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="Output format: table or json",
+    ),
+    threshold: float = typer.Option(
+        0.85, "--threshold", help="Embedding-similarity threshold for clustering",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """List detected guardrail candidates — recurring corroborated shapes.
+
+    A candidate is >=3 distinct corroborated findings sharing a semantic shape,
+    each shown with an LLM-drafted assertion you can edit at `guardrail promote`.
+    On-demand only: clustering runs here, never on the watcher/dashboard loop.
+    """
+    import json as json_mod
+
+    from rich.table import Table
+
+    from .guardrails import draft_assertion
+    from .processor import OllamaClient
+    from .violation_db import ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    if not config.embedding.enabled:
+        console.print(
+            "[yellow]Candidate detection needs the embedding model "
+            "(set embedding.enabled in your config).[/yellow]"
+        )
+        raise typer.Exit()
+    db_path = _guardrail_db_path(config_path)
+    if not db_path.exists():
+        console.print("[green]No candidates — no violation database yet.[/green]")
+        raise typer.Exit()
+
+    async def _run():
+        db = ViolationDB(str(db_path))
+        client = OllamaClient(config.ollama.model_dump())
+        call = _model_caller(client, config)
+        try:
+            cands = await _cli_candidates(config, db, threshold=threshold)
+            return [(c, await draft_assertion(c, call)) for c in cands]
+        finally:
+            await client.close()
+            db.close()
+
+    drafted = asyncio.run(_run())
+
+    # JSON output is always valid JSON, even when empty (`[]`) — it may be piped.
+    if output_format == "json":
+        console.print(json_mod.dumps([
+            {"index": i, "category": c.category, "size": c.size,
+             "finding_ids": c.finding_ids, "assertion": a}
+            for i, (c, a) in enumerate(drafted, 1)
+        ], indent=2))
+        return
+
+    if not drafted:
+        console.print("[green]No guardrail candidates detected.[/green]")
+        raise typer.Exit()
+
+    table = Table(title=f"Guardrail candidates ({len(drafted)})")
+    table.add_column("#", style="bold", width=3)
+    table.add_column("Category", width=12)
+    table.add_column("N", justify="right", width=3)
+    table.add_column("Drafted assertion (editable)")
+    for i, (c, a) in enumerate(drafted, 1):
+        table.add_row(str(i), c.category, str(c.size), a)
+    console.print(table)
+    console.print(
+        "[dim]Promote with `guardrail promote <#>` or reject with "
+        "`guardrail reject <#>`.[/dim]"
+    )
+
+
+@guardrail_app.command("promote")
+def guardrail_promote(
+    index: int = typer.Argument(..., help="1-based index from `guardrail candidates`"),
+    name: Optional[str] = typer.Option(None, "--name", help="Guardrail name"),
+    assertion: Optional[str] = typer.Option(
+        None, "--assertion", "-a", help="Override the drafted assertion",
+    ),
+    threshold: float = typer.Option(
+        0.85, "--threshold", help="Must match the value used to list candidates",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Confirm a candidate into an active guardrail (source=promoted).
+
+    Nothing is enforced until this confirm step — a candidate never becomes
+    active on its own. The assertion is seeded from the draft (or --assertion)
+    and remains editable via `guardrail edit`.
+    """
+    from .guardrails import derive_scope, draft_assertion
+    from .processor import OllamaClient
+    from .violation_db import Guardrail, ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    db_path = _guardrail_db_path(config_path)
+    if not db_path.exists():
+        console.print(f"[red]No candidate at index {index}.[/red]")
+        raise typer.Exit(code=1)
+
+    async def _run():
+        db = ViolationDB(str(db_path))
+        client = OllamaClient(config.ollama.model_dump())
+        try:
+            cands = await _cli_candidates(config, db, threshold=threshold)
+            if index < 1 or index > len(cands):
+                return None
+            c = cands[index - 1]
+            text = assertion
+            if text is None:
+                text = await draft_assertion(c, _model_caller(client, config))
+            cat, glob = derive_scope(c)
+            gname = name or f"{c.category}-pattern"
+            gid = db.create_guardrail(Guardrail(
+                name=gname, assertion=text,
+                scope_category=cat, scope_path_glob=glob,
+                source="promoted",
+            ))
+            return gid, gname
+        finally:
+            await client.close()
+            db.close()
+
+    result = asyncio.run(_run())
+    if result is None:
+        console.print(
+            f"[red]No candidate at index {index}; run `guardrail candidates`.[/red]"
+        )
+        raise typer.Exit(code=1)
+    gid, gname = result
+    console.print(
+        f"[green]Promoted candidate {index} → guardrail {gid}: {gname} "
+        f"(active, source=promoted). Edit with `guardrail edit {gid}`.[/green]"
+    )
+
+
+@guardrail_app.command("reject")
+def guardrail_reject(
+    index: int = typer.Argument(..., help="1-based index from `guardrail candidates`"),
+    threshold: float = typer.Option(
+        0.85, "--threshold", help="Must match the value used to list candidates",
+    ),
+    config_path: str = typer.Option(
+        "ollama-sentinel.yaml", "--config", "-c",
+        help="Path to configuration file",
+    ),
+):
+    """Reject a candidate so its shape is not re-proposed on the next run."""
+    from .guardrails import candidate_signature
+    from .violation_db import Guardrail, ViolationDB
+
+    config = _load_config_or_exit(config_path)
+    db_path = _guardrail_db_path(config_path)
+    if not db_path.exists():
+        console.print(f"[red]No candidate at index {index}.[/red]")
+        raise typer.Exit(code=1)
+
+    async def _run():
+        db = ViolationDB(str(db_path))
+        try:
+            cands = await _cli_candidates(config, db, threshold=threshold)
+            if index < 1 or index > len(cands):
+                return None
+            c = cands[index - 1]
+            # Tombstone: a dismissed promoted guardrail whose assertion is the
+            # candidate signature, so `candidates` suppresses this shape next run.
+            gid = db.create_guardrail(Guardrail(
+                name=f"[rejected] {c.category}",
+                assertion=candidate_signature(c),
+                scope_category=c.category,
+                source="promoted",
+            ))
+            db.set_guardrail_status(gid, "dismissed")
+            return c.category
+        finally:
+            db.close()
+
+    category = asyncio.run(_run())
+    if category is None:
+        console.print(
+            f"[red]No candidate at index {index}; run `guardrail candidates`.[/red]"
+        )
+        raise typer.Exit(code=1)
+    console.print(
+        f"[green]Rejected candidate {index} ({category}); "
+        f"this shape won't be re-proposed.[/green]"
+    )
+
+
 @app.command()
 def triage(
     input_path: Optional[str] = typer.Argument(

--- a/ollama_sentinel/guardrails.py
+++ b/ollama_sentinel/guardrails.py
@@ -127,3 +127,82 @@ async def detect_candidates(
                     file_paths=[m.get("file_path", "") for m in members],
                 ))
     return candidates
+
+
+# ---------------------------------------------------------------------------
+# Candidate surfacing + curation (U7)
+# ---------------------------------------------------------------------------
+
+
+def candidate_signature(candidate: Candidate) -> str:
+    """A stable, order-independent signature for a candidate's shape.
+
+    Used to suppress re-proposal of a dismissed shape: the same set of member
+    descriptions in the same category yields the same signature regardless of
+    finding order, so a dismissed candidate stays dismissed across runs.
+    """
+    descs = "|".join(sorted(candidate.descriptions))
+    return f"{candidate.category}::{descs}"
+
+
+def derive_scope(candidate: Candidate):
+    """Derive a (scope_category, scope_path_glob) for a promoted guardrail.
+
+    Category is always the cluster's category. A path glob is suggested only
+    when every member shares one top-level directory (e.g. all under ``src/`` →
+    ``src/*``); mixed or root-level files yield no path scope (applies broadly).
+    The developer can edit either at confirmation.
+    """
+    category = candidate.category
+    tops = set()
+    for p in candidate.file_paths:
+        parts = p.replace("\\", "/").split("/")
+        tops.add(parts[0] if len(parts) > 1 else "")
+    if len(tops) == 1:
+        top = next(iter(tops))
+        return category, (f"{top}/*" if top else None)
+    return category, None
+
+
+def _draft_prompt(candidate: Candidate) -> str:
+    examples = "\n".join(f"- {d}" for d in candidate.descriptions[:8])
+    return (
+        f"These recurring {candidate.category} issues were each independently "
+        f"confirmed in this codebase:\n{examples}\n\n"
+        "Write ONE imperative sentence — a project guardrail — that, if followed, "
+        "would prevent this class of issue. Output only the sentence, no preamble."
+    )
+
+
+def _fallback_assertion(candidate: Candidate) -> str:
+    first = candidate.descriptions[0] if candidate.descriptions else candidate.category
+    return f"Avoid recurring {candidate.category} issues such as: {first}"
+
+
+async def draft_assertion(candidate: Candidate, model_call=None) -> str:
+    """Draft a one-line NL assertion for a candidate via the local model.
+
+    ``model_call`` is an async callable ``(prompt: str) -> str`` (the CLI wires
+    it to the configured model). It is best-effort: with no model, a model
+    error, or a blank reply, a deterministic minimal fallback is returned so a
+    candidate always lists with *some* editable assertion (KTD5). The developer
+    edits the result at confirmation regardless.
+    """
+    if model_call is None:
+        return _fallback_assertion(candidate)
+    try:
+        text = await model_call(_draft_prompt(candidate))
+    except Exception:
+        return _fallback_assertion(candidate)
+    text = (text or "").strip()
+    return text or _fallback_assertion(candidate)
+
+
+def filter_suppressed(candidates: List[Candidate], dismissed_signatures) -> List[Candidate]:
+    """Drop candidates whose shape was previously dismissed.
+
+    ``dismissed_signatures`` is the set of ``candidate_signature`` values stored
+    when candidates were rejected, so the same shape is not re-proposed.
+    """
+    sigs = set(dismissed_signatures)
+    return [c for c in candidates if candidate_signature(c) not in sigs]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1432,3 +1432,181 @@ class TestGuardrailCLI:
         r = runner.invoke(app, ["guardrail", "dismiss", "9999", "--config", str(cfg)])
         assert r.exit_code == 1
         assert "No guardrail with id" in r.output
+
+
+# ---------------------------------------------------------------------------
+# U7 — `guardrail candidates` / `promote` / `reject`
+# ---------------------------------------------------------------------------
+
+
+class _ClusterEmbedder:
+    """Fake embedder: everything maps to one vector → same-category findings
+    cluster together (cross-category still split by detect_candidates)."""
+    async def embed(self, text, *, cache_key=None):
+        return [1.0, 0.0]
+
+    async def close(self):
+        pass
+
+
+def _seed_corroborated(db_path, *, n=3, category="security"):
+    """Seed n distinct findings (one file, distinct lines), each with an
+    incident so they are corroborated. Returns their ids."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = ViolationDB(str(db_path))
+    try:
+        for i in range(n):
+            db.persist_findings("src/a.py", [
+                Finding("src/a.py", i + 1, i + 1, category, "high", f"eval case {i}"),
+            ])
+        ids = []
+        for r in db.get_all_unresolved():
+            db.persist_incident(Incident(
+                finding_id=r["id"], confirming_signal="manual_confirm",
+                confirming_artifact="seed",
+            ))
+            ids.append(r["id"])
+    finally:
+        db.close()
+    return ids
+
+
+def _patch_candidate_infra(monkeypatch, *, draft="Never call eval on input.", raise_draft=False):
+    """Patch the embedder builder + the draft model call so candidate commands
+    run without Ollama."""
+    monkeypatch.setattr(
+        "ollama_sentinel.cli._build_embedder", lambda config: _ClusterEmbedder(),
+    )
+    import ollama_sentinel.processor as proc
+
+    async def _fake_generate(self, model_config, prompt, **kw):
+        if raise_draft:
+            raise RuntimeError("model down")
+        return draft
+
+    monkeypatch.setattr(proc.OllamaClient, "generate_with_model", _fake_generate)
+
+
+class TestGuardrailCandidatesCLI:
+    """Tests for `guardrail candidates` / `promote` / `reject` (U7)."""
+
+    def test_candidates_lists_with_drafted_assertion(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_corroborated(db_path)
+        _patch_candidate_infra(monkeypatch, draft="Never call eval on input.")
+
+        r = runner.invoke(app, ["guardrail", "candidates", "--config", str(cfg), "-f", "json"])
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)
+        assert len(data) == 1
+        assert data[0]["category"] == "security"
+        assert data[0]["size"] == 3
+        assert data[0]["assertion"] == "Never call eval on input."
+
+    def test_candidates_model_unavailable_uses_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_corroborated(db_path)
+        _patch_candidate_infra(monkeypatch, raise_draft=True)
+
+        r = runner.invoke(app, ["guardrail", "candidates", "--config", str(cfg), "-f", "json"])
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)
+        assert len(data) == 1
+        # Fallback assertion mentions the category — no crash.
+        assert "security" in data[0]["assertion"]
+
+    def test_candidates_empty_when_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        ViolationDB(str(db_path)).close()
+        _patch_candidate_infra(monkeypatch)
+        r = runner.invoke(app, ["guardrail", "candidates", "--config", str(cfg)])
+        assert r.exit_code == 0
+        assert "No guardrail candidates" in r.output
+
+    def test_promote_creates_active_promoted_guardrail(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_corroborated(db_path)
+        _patch_candidate_infra(monkeypatch)
+
+        r = runner.invoke(app, [
+            "guardrail", "promote", "1", "--assertion", "Do not eval.",
+            "--name", "no-eval", "--config", str(cfg),
+        ])
+        assert r.exit_code == 0, r.output
+
+        db = ViolationDB(str(db_path))
+        try:
+            actives = db.get_active_guardrails()
+            assert len(actives) == 1
+            g = actives[0]
+            assert g["name"] == "no-eval"
+            assert g["assertion"] == "Do not eval."
+            assert g["source"] == "promoted"
+            assert g["scope_category"] == "security"
+        finally:
+            db.close()
+
+    def test_promote_seeds_drafted_assertion_when_not_overridden(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_corroborated(db_path)
+        _patch_candidate_infra(monkeypatch, draft="Drafted rule text.")
+
+        r = runner.invoke(app, ["guardrail", "promote", "1", "--config", str(cfg)])
+        assert r.exit_code == 0, r.output
+        db = ViolationDB(str(db_path))
+        try:
+            assert db.get_active_guardrails()[0]["assertion"] == "Drafted rule text."
+        finally:
+            db.close()
+
+    def test_promote_out_of_range_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_corroborated(db_path)
+        _patch_candidate_infra(monkeypatch)
+        r = runner.invoke(app, ["guardrail", "promote", "9", "--config", str(cfg)])
+        assert r.exit_code == 1
+        assert "No candidate at index" in r.output
+
+    def test_reject_suppresses_next_candidates_run(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_corroborated(db_path)
+        _patch_candidate_infra(monkeypatch)
+
+        # The shape is detected first…
+        before = runner.invoke(app, ["guardrail", "candidates", "--config", str(cfg), "-f", "json"])
+        assert len(json.loads(before.output)) == 1
+
+        rej = runner.invoke(app, ["guardrail", "reject", "1", "--config", str(cfg)])
+        assert rej.exit_code == 0, rej.output
+
+        # …and suppressed on the next run.
+        after = runner.invoke(app, ["guardrail", "candidates", "--config", str(cfg), "-f", "json"])
+        assert json.loads(after.output) == []
+
+    def test_reject_then_promote_is_consistent(self, tmp_path, monkeypatch):
+        """A rejected candidate is gone, so promoting index 1 afterward errors."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _make_report_config(tmp_path)
+        db_path = tmp_path / ".ollama_reviews" / "memory.db"
+        _seed_corroborated(db_path)
+        _patch_candidate_infra(monkeypatch)
+
+        runner.invoke(app, ["guardrail", "reject", "1", "--config", str(cfg)])
+        r = runner.invoke(app, ["guardrail", "promote", "1", "--config", str(cfg)])
+        assert r.exit_code == 1
+        assert "No candidate at index" in r.output

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -140,3 +140,101 @@ class TestDetectCandidates:
     async def test_empty_input_returns_empty(self):
         embedder = _FakeEmbedder({})
         assert await detect_candidates([], embedder) == []
+
+
+# ---------------------------------------------------------------------------
+# U7 — candidate surfacing helpers (signature, draft, scope, suppression)
+# ---------------------------------------------------------------------------
+
+from ollama_sentinel.guardrails import (
+    candidate_signature,
+    derive_scope,
+    draft_assertion,
+    filter_suppressed,
+)
+
+
+def _candidate(category="security", ids=(1, 2, 3),
+               descriptions=("eval a", "eval b", "eval c"),
+               file_paths=("src/a.py", "src/b.py", "src/c.py")):
+    return Candidate(
+        category=category,
+        finding_ids=list(ids),
+        descriptions=list(descriptions),
+        file_paths=list(file_paths),
+    )
+
+
+class TestCandidateSignature:
+    def test_stable_regardless_of_description_order(self):
+        a = _candidate(descriptions=("x", "y", "z"))
+        b = _candidate(descriptions=("z", "x", "y"))
+        assert candidate_signature(a) == candidate_signature(b)
+
+    def test_category_distinguishes(self):
+        a = _candidate(category="security")
+        b = _candidate(category="perf")
+        assert candidate_signature(a) != candidate_signature(b)
+
+
+class TestDeriveScope:
+    def test_category_always_returned(self):
+        cat, _glob = derive_scope(_candidate(category="bug"))
+        assert cat == "bug"
+
+    def test_common_top_dir_becomes_path_glob(self):
+        _cat, glob = derive_scope(_candidate(
+            file_paths=("src/a.py", "src/b.py", "src/c.py")))
+        assert glob == "src/*"
+
+    def test_mixed_dirs_no_path_glob(self):
+        _cat, glob = derive_scope(_candidate(
+            file_paths=("src/a.py", "lib/b.py", "src/c.py")))
+        assert glob is None
+
+    def test_root_files_no_path_glob(self):
+        _cat, glob = derive_scope(_candidate(file_paths=("a.py", "b.py", "c.py")))
+        assert glob is None
+
+
+class TestDraftAssertion:
+    async def test_uses_model_output_when_available(self):
+        async def _call(prompt):
+            assert "security" in prompt  # the cluster category is in the prompt
+            return "  Never call eval on untrusted input.  "
+        out = await draft_assertion(_candidate(), _call)
+        assert out == "Never call eval on untrusted input."
+
+    async def test_falls_back_when_no_model(self):
+        out = await draft_assertion(_candidate(category="bug",
+                                               descriptions=("off by one",)))
+        assert "bug" in out
+        assert "off by one" in out
+
+    async def test_falls_back_when_model_raises(self):
+        async def _boom(prompt):
+            raise RuntimeError("model down")
+        out = await draft_assertion(_candidate(category="perf",
+                                               descriptions=("n^2 loop",)), _boom)
+        assert "perf" in out and "n^2 loop" in out
+
+    async def test_falls_back_when_model_returns_blank(self):
+        async def _blank(prompt):
+            return "   "
+        out = await draft_assertion(_candidate(), _blank)
+        assert out  # non-empty fallback
+
+
+class TestFilterSuppressed:
+    def test_dismissed_signature_is_dropped(self):
+        c = _candidate()
+        sig = candidate_signature(c)
+        assert filter_suppressed([c], {sig}) == []
+
+    def test_unrelated_signature_kept(self):
+        c = _candidate()
+        assert filter_suppressed([c], {"other::sig"}) == [c]
+
+    def test_no_dismissed_keeps_all(self):
+        cs = [_candidate(category="a"), _candidate(category="b")]
+        assert filter_suppressed(cs, set()) == cs


### PR DESCRIPTION
Second Phase-2 unit. **Stacked on #42 (U6)**. Implements **R3** (candidate from ≥3 corroborated findings), **R4** (curation: nothing enforces without confirm), **R9** (CLI surfacing).

Turns U6's detected shapes into an actionable curation loop: list candidates with a drafted rule, then promote one into an active guardrail or reject it.

## `guardrails.py`
- `candidate_signature()` — stable, order-independent shape signature (suppression key).
- `draft_assertion(candidate, model_call)` — async; summarizes a cluster into one imperative sentence via an injected model callable, with a **deterministic minimal fallback** on no-model / error / blank reply (KTD5). Always returns an editable assertion.
- `derive_scope()` — `(category, optional path glob)`: category always; a path glob only when all members share one top dir (`src/*`).
- `filter_suppressed()` — drops candidates whose signature was previously rejected.

## `cli.py` — three `guardrail` sub-verbs (named distinctly from U2's lifecycle verbs)
- **`candidates [-f json] [--threshold]`** — detect (on demand) + suppress + draft; stable 1-based indices. JSON always valid (`[]` when empty).
- **`promote <#> [--name] [--assertion]`** — confirm a candidate into an **active `source=promoted`** guardrail, seeded with the editable draft + derived scope. Nothing becomes active without this explicit confirm (R4).
- **`reject <#>`** — tombstone the shape (a dismissed promoted guardrail whose assertion is the candidate signature) so `candidates` suppresses it next run.

Clustering runs **only** in these on-demand commands, never on the watcher/dashboard loop (**KTD4**). `_build_embedder` is module-level for test injection.

## Scope note — dashboard deferred (transparent)
The live *dashboard* pending-candidate view is **intentionally not** added here: running clustering on the 1s poll loop would violate KTD4. Confirmed candidates already surface in the U5 guardrails panel (`source=promoted` → "auto"). A cached/slow-cadence view is left as follow-up. U7's verification targets `test_cli.py` + `test_guardrails.py`, both fully covered.

## Tests (21)
**13 guardrails**: signature stability, scope derivation (common-dir / mixed / root), draft (model output / fallback / raise / blank), suppression.
**8 CLI**: list with draft; model-unavailable fallback; empty; promote creates active-promoted + seeds draft; out-of-range error; reject suppresses next run; reject→promote consistency.

Full suite: **793 passed / 16 skipped**. U8 (evidence-integrity gate) follows.