### PR TITLE
feat(guardrails): U8 — evidence-integrity gate on self-caused findings

### DIFF
--- a/ollama_sentinel/guardrails.py
+++ b/ollama_sentinel/guardrails.py
@@ -68,6 +68,26 @@ async def _embed_findings(findings: List[dict], embedder):
     return [p for p in pairs if p is not None]
 
 
+_HARD_SIGNALS = frozenset({"test_failure", "fix_commit"})
+
+
+def counts_toward_strength(finding: dict) -> bool:
+    """Evidence-integrity gate (U8): may this finding count toward a candidate?
+
+    A finding with no guardrail provenance (independently discovered) always
+    counts. A *self-caused* finding — one carrying the ``guardrail_id`` of a
+    guardrail that flagged it (U4) — counts only when corroborated by a **hard**
+    signal (``test_failure`` or ``fix_commit``). Soft-only (``manual_confirm``)
+    or uncorroborated self-caused findings are excluded, so an active guardrail
+    cannot manufacture its own re-promotion (the Pattern-tier echo). A missing
+    provenance link therefore fails safe: the finding just counts as independent.
+    """
+    if finding.get("guardrail_id") is None:
+        return True
+    signals = finding.get("confirming_signals") or []
+    return any(s in _HARD_SIGNALS for s in signals)
+
+
 def _cluster(pairs, threshold: float):
     """Greedy seed clustering.
 
@@ -106,7 +126,16 @@ async def detect_candidates(
     ``embed(text, *, cache_key=None)``), so a fake embedder drives the tests and
     the real ``OllamaEmbedder`` drives production. Deterministic: findings are
     processed in id order.
+
+    The evidence-integrity gate (``counts_toward_strength``) pre-filters the
+    findings so a guardrail's own soft-corroborated findings never reinforce a
+    candidate — only independently-discovered or hard-corroborated findings
+    contribute to a shape's strength.
     """
+    if not findings:
+        return []
+
+    findings = [f for f in findings if counts_toward_strength(f)]
     if not findings:
         return []
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -238,3 +238,86 @@ class TestFilterSuppressed:
     def test_no_dismissed_keeps_all(self):
         cs = [_candidate(category="a"), _candidate(category="b")]
         assert filter_suppressed(cs, set()) == cs
+
+
+# ---------------------------------------------------------------------------
+# U8 — evidence-integrity gate
+# ---------------------------------------------------------------------------
+
+from ollama_sentinel.guardrails import counts_toward_strength
+
+
+class TestCountsTowardStrength:
+    def test_independent_finding_counts(self):
+        assert counts_toward_strength(
+            {"guardrail_id": None, "confirming_signals": ["manual_confirm"]}
+        ) is True
+
+    def test_independent_with_no_signals_counts(self):
+        assert counts_toward_strength(
+            {"guardrail_id": None, "confirming_signals": []}
+        ) is True
+
+    def test_self_caused_with_test_failure_counts(self):
+        assert counts_toward_strength(
+            {"guardrail_id": 5, "confirming_signals": ["test_failure"]}
+        ) is True
+
+    def test_self_caused_with_fix_commit_counts(self):
+        assert counts_toward_strength(
+            {"guardrail_id": 5, "confirming_signals": ["fix_commit"]}
+        ) is True
+
+    def test_self_caused_with_only_manual_confirm_excluded(self):
+        assert counts_toward_strength(
+            {"guardrail_id": 5, "confirming_signals": ["manual_confirm"]}
+        ) is False
+
+    def test_self_caused_with_no_signals_excluded(self):
+        assert counts_toward_strength(
+            {"guardrail_id": 5, "confirming_signals": []}
+        ) is False
+
+    def test_self_caused_mixed_signals_with_hard_counts(self):
+        assert counts_toward_strength(
+            {"guardrail_id": 5, "confirming_signals": ["manual_confirm", "fix_commit"]}
+        ) is True
+
+
+class TestGateAppliedInDetectCandidates:
+    async def test_self_caused_soft_excluded_from_strength(self):
+        """A self-caused finding with only soft corroboration drops below the
+        threshold — the guardrail cannot manufacture its own re-promotion."""
+        f1 = _finding(1, "security", "eval a")   # independent (helper: guardrail_id None)
+        f2 = _finding(2, "security", "eval b")   # independent
+        soft = _finding(3, "security", "eval c")
+        soft["guardrail_id"] = 99
+        soft["confirming_signals"] = ["manual_confirm"]  # self-caused, soft → gated out
+        embedder = _FakeEmbedder({
+            "finding:1": [1.0, 0.0], "finding:2": [1.0, 0.0], "finding:3": [1.0, 0.0],
+        })
+        cands = await detect_candidates([f1, f2, soft], embedder, similarity_threshold=0.9)
+        assert cands == []  # only 2 eligible → below the 3-distinct threshold
+
+    async def test_self_caused_hard_counts_toward_shape(self):
+        """A self-caused finding with a hard signal counts normally."""
+        f1 = _finding(1, "security", "eval a")
+        f2 = _finding(2, "security", "eval b")
+        hard = _finding(3, "security", "eval c")
+        hard["guardrail_id"] = 99
+        hard["confirming_signals"] = ["test_failure"]  # self-caused, hard → counts
+        embedder = _FakeEmbedder({
+            "finding:1": [1.0, 0.0], "finding:2": [1.0, 0.0], "finding:3": [1.0, 0.0],
+        })
+        cands = await detect_candidates([f1, f2, hard], embedder, similarity_threshold=0.9)
+        assert len(cands) == 1
+        assert sorted(cands[0].finding_ids) == [1, 2, 3]
+
+    async def test_independent_findings_unaffected_by_gate(self):
+        """Findings with no provenance always count, whatever their signal."""
+        findings = [_finding(i, "bug", f"off by one {i}") for i in (1, 2, 3)]
+        for f in findings:
+            f["confirming_signals"] = ["manual_confirm"]  # soft, but independent
+        embedder = _FakeEmbedder({f"finding:{i}": [1.0, 0.0] for i in (1, 2, 3)})
+        cands = await detect_candidates(findings, embedder, similarity_threshold=0.9)
+        assert len(cands) == 1


### PR DESCRIPTION
Final Phase-2 unit. **Stacked on #43 (U7)**. Implements **R8** — the integrity heart that makes auto-promotion safe.

Without this gate, an active guardrail would flag findings (provenance tagged by U4), those findings would get corroborated, and they'd cluster back into a candidate re-proposing the *same* guardrail — a self-reinforcing **Pattern-tier echo** where a rule manufactures its own evidence. U8 closes that loop.

## `guardrails.py`
- **`counts_toward_strength(finding)`** — pure predicate:
  - No `guardrail_id` provenance (independently discovered) → **always counts**.
  - Self-caused (carries the provenance of a guardrail that flagged it, U4) → counts **only** with a **hard** signal (`test_failure` or `fix_commit`). Soft-only (`manual_confirm`) or uncorroborated self-caused findings are **excluded**.
  - A missing provenance link **fails safe** — the finding just counts as independent.
- **`detect_candidates`** pre-filters findings through the gate before clustering, so gated-out findings never contribute to a shape's distinct-finding count.

## Tests (10, test-first per the plan's execution note)
**7 predicate**: independent counts; independent-no-signals counts; self-caused +`test_failure` / +`fix_commit` count; self-caused +`manual_confirm` / +none excluded; mixed-with-hard counts.
**3 through `detect_candidates`**: a self-caused-soft finding drops a shape below the 3-distinct threshold; a self-caused-hard finding counts toward the shape; independent findings are unaffected by the gate.

Full suite: **803 passed / 16 skipped**.

---
### Phase 2 complete
Closes the Phase-2 stack (#42 → #43 → #44): U6 clustering, U7 surfacing+curation, U8 integrity gate. Together with Phase 1 (#37–#41), the full **Finding → Incident → Pattern** rung from `docs/VISION.md` now ships: recurring corroborated failures auto-surface as candidates, the developer curates them into guardrails, and a guardrail's own findings can't echo it back into existence.