### PR TITLE
docs: Pattern-promotion guardrails shipped — full doc sweep (README, GUIDE, VISION, index.html, CLAUDE.md, plan, handoff)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,15 @@ ollama-sentinel dismiss 31          # close Finding 31 as false-positive (resolu
 ollama-sentinel fix 42              # localized fix for Finding 42: preview diff, write on confirm, resolve (fixed)
 ollama-sentinel prune               # close findings whose flagged code is gone (preview + confirm, resolution='stale')
 
+# Guardrails (project rules injected into reviews; Finding->Incident->Pattern rung)
+ollama-sentinel guardrail add no-eval -a "Never call eval on untrusted input." --category security --path "src/*.py"
+ollama-sentinel guardrail list      # active guardrails (--all / --status; -f json)
+ollama-sentinel guardrail edit 3 --assertion "..."   # edit name/assertion/scope
+ollama-sentinel guardrail disable 3 # disable | enable | dismiss (lifecycle)
+ollama-sentinel guardrail candidates # detect recurring shapes (>=3 corroborated) w/ drafted assertion (on-demand)
+ollama-sentinel guardrail promote 1 # confirm candidate #1 -> active guardrail (source=promoted)
+ollama-sentinel guardrail reject 1  # dismiss candidate #1 so its shape isn't re-proposed
+
 python -m research_agent.main query "question" --context file.py --output result.md
 python -m research_agent.main interactive
 python -m research_agent.main setup
@@ -74,19 +83,43 @@ CLI (Typer) -> FileSentinel -> awatch loop (debounce)
                              |- _get_ranked_prior_violations()
                              |    semantic: ViolationDB.get_neighbors_by_similarity()
                              |    fallback:  ViolationDB.get_unresolved(path)
+                             |- _get_active_guardrails() (active project rules)
                              |- format_prompt() -> build_review_context() recipe
                              |    MUST_FIT: active file / diff block
+                             |    OPTIONAL: PROJECT GUARDRAILS (scope-filtered, ranked)
                              |    OPTIONAL: PRIOR UNRESOLVED (retriever-ranked)
                              |- chunk_content() -> chunk_by_lines (token-aware)
                              |- OllamaClient.generate_review() (httpx, tenacity retry)
                                  |
                            extract_findings() (LLM JSON + regex fallback)
+                             |- attribute_guardrail_provenance() (best-effort: finding -> guardrail)
                              |- ViolationDB.persist_findings() (SQLite upsert,
-                                populates embed_text for semantic recall)
+                                populates embed_text + guardrail_id provenance)
                                  |
                            FileProcessor.save_review()
                              |- versioned output with history cleanup
 ```
+
+### Guardrails (v0.3: Finding -> Incident -> Pattern)
+
+Guardrails are curated, named NL rules the review model checks explicitly. They
+are born two ways and converge on one active artifact (the Pattern rung from
+`docs/VISION.md`):
+
+```
+   Developer authors directly ----------------------------\
+   (guardrail add)                                          v
+                                                      active guardrail
+   >=3 distinct corroborated findings of one shape          ^   |
+     -> guardrail candidates (on-demand clustering)         |   |- injected into reviews
+        -> LLM-drafted assertion                            |   |     (scope filter + rank + budget)
+        -> guardrail promote (confirm) ---------------------/   |- flagged findings carry provenance
+        -> guardrail reject (suppress shape)                    v
+                                                          ViolationDB.guardrails table
+   evidence-integrity gate (counts_toward_strength): a guardrail's own findings
+   reinforce a candidate only via a hard signal (test_failure/fix_commit) -> no echo
+```
+
 
 ### Incident corroboration (v0.2: Finding -> Incident)
 
@@ -127,15 +160,16 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 | Module | Purpose |
 |--------|---------|
 | `ollama_sentinel/processor.py` | FileProcessor, OllamaClient, async prompt formatting via recipe, review generation |
-| `ollama_sentinel/violation_db.py` | SQLite-backed Finding persistence with upsert, `embed_text` column, and `get_neighbors_by_similarity` |
+| `ollama_sentinel/violation_db.py` | SQLite-backed Finding persistence with upsert, `embed_text` column, `get_neighbors_by_similarity`; `guardrails` table + CRUD (`Guardrail`); finding `guardrail_id` provenance; `get_corroborated_findings` (clustering selector) |
+| `ollama_sentinel/guardrails.py` | Guardrail shape clustering + candidate detection (leaf): `Candidate`, async `detect_candidates`, `draft_assertion`, `derive_scope`, `candidate_signature`/`filter_suppressed`, and the `counts_toward_strength` evidence-integrity gate |
 | `ollama_sentinel/extractor.py` | LLM JSON extraction + regex fallback for parsing review findings |
 | `ollama_sentinel/watcher.py` | FileSentinel, file watching, ignore logic, pipeline orchestration |
 | `ollama_sentinel/models.py` | Pydantic v2 config models: Ollama/Embedding/Memory/Processing with validators |
-| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss, fix, prune |
+| `ollama_sentinel/cli.py` | Typer CLI: run, review, init, report, triage, dashboard, confirm, incidents, install-hooks, record-commit, surface, findings, resolve, dismiss, fix, prune + `guardrail` sub-app (add/list/edit/disable/enable/dismiss, candidates/promote/reject) |
 | `ollama_sentinel/remediate.py` | Localized fix generation for `fix <id>`: `splice_lines`/`parse_fix_response`/`build_fix_prompt` (pure) + `propose_fix` (I/O); bounds the model edit to the finding's exact whole-line span |
 | `ollama_sentinel/pytest_plugin.py` | Opt-in pytest plugin: matches test failures to open Findings, records `test_failure` Incidents (`pytest11` entry point) |
 | `ollama_sentinel/hooks.py` | Git post-commit hook installer + `record_commit` (links commits to open Findings) |
-| `ollama_sentinel/dashboard.py` | Live Rich TUI for `ollama-sentinel dashboard` — polls reviews dir + ViolationDB read-only |
+| `ollama_sentinel/dashboard.py` | Live Rich TUI for `ollama-sentinel dashboard` — polls reviews dir + ViolationDB read-only; includes a read-only active-guardrails panel (`active_guardrails`/`_guardrails_panel`) |
 | `ollama_sentinel/sarif.py` | SARIF 2.1.0 surface: excerpt-based `relocate_finding`, `build_sarif` document, `generate_sarif_file` (read-only orchestration) — backs the `surface` command + watcher auto-refresh; `collect_stale_findings` (read-only) backs `prune` |
 | `ollama_sentinel/context/assembler.py` | `Section` / `Priority` / `ContextItem` dataclasses + `assemble()` + `chunk_by_lines` — pure, token-budgeted |
 | `ollama_sentinel/context/tokens.py` | `TokenCounter` (tiktoken `cl100k_base` with char-based fallback) |
@@ -203,22 +237,25 @@ Click CLI -> ResearchAgent -> LangGraph StateGraph
 ### Resume here next time
 
 1. **Sanity check.** `pytest tests/ -q` should be green (run it for the live
-   count; ~699 / 15 skip after OP-1 landed — do not trust this number, it drifts).
-2. **The "make findings actionable" arc is complete** (stale-prune `prune`
-   merged via PR #29, 2026-06-05). No arc work left.
-3. **The deferred DX tail is now closed:** OP-1 SIGHUP hot-reload SHIPPED
-   (PR #32, 2026-06-07); CB-1 formatter dedupe verified already-done (drift
-   correction, 2026-06-07). See `docs/superpowers/followups.md`.
+   count; ~803 / 16 skip on the guardrails stack tip — do not trust this number,
+   it drifts).
+2. **Pattern promotion → project guardrails is BUILT** (the north-star v0.3
+   feature). All 8 plan units U1–U8 ship as a linear stacked-PR chain
+   **#37→#38→#39→#40→#41→#42→#43→#44** (base master). **Not yet merged** — review
+   and merge bottom-up; GitHub auto-retargets each child to master as its parent
+   lands. The independent salvage fix is **PR #36**. This docs PR rides the tip.
+3. **The "make findings actionable" arc is complete** (PR #29, 2026-06-05).
+   OP-1 SIGHUP hot-reload (#32) and CB-1 (#33) also done. See
+   `docs/superpowers/followups.md`.
 
 ### Pickable next moves (ordered by leverage)
 
-The small-DX backlog is drained (OP-1, CB-1, and the impact_scan integration
-test all landed 2026-06-07). What's left is the v0.3 product leap.
+The v0.3 Pattern-promotion leap is **built** (#37–#44, pending merge). What's left:
 
 | # | Item | Effort | Risk | Notes |
 |---|---|---|---|---|
-| 1 | **Pattern promotion** — the Finding→Incident→**Pattern** rung (≥3 incidents of the same shape → project-specific guardrail). The north-star payoff. | L | med | Design-heavy — start with `/ce-brainstorm` (shape-detection, storage, feedback into review context). Not yet started. |
-| 2 | **v0.3 shared substrate** — lift `ImportResolver` to shared infra, unify `Finding`/`ImpactItem`, bidirectional impact↔incident flow. | L | med | The moat play (see `docs/VISION.md`). Larger/architectural; can follow Pattern. |
+| 1 | **Merge the guardrails stack** (#37→#44 bottom-up) + #36. Then the two transparent scope deferrals: (a) the *live dashboard pending-candidate view* (skipped in U7 to honor KTD4 — on-demand clustering only; a cached/slow-cadence panel would re-enable it); (b) confirm whether U8's *global* self-caused-soft exclusion should become *scoped-to-originating-guardrail* (stricter-is-safe today). | S–M | low | Both noted in the U7/U8 PR bodies. |
+| 2 | **v0.3 shared substrate** — lift `ImportResolver` to shared infra, unify `Finding`/`ImpactItem`, bidirectional impact↔incident flow. | L | med | The moat play (see `docs/VISION.md`). Architectural; follows guardrails. |
 
 Skip TR-3 — deliberate spec deviation, documented in followups.md. Qwen3
 Phases B/C stay parked (no demand; the Phase-A plan forbids pulling the models
@@ -252,6 +289,24 @@ speculatively).
 
 ### Recent landings
 
+- 2026-06-13: **v0.3 Pattern promotion → project guardrails BUILT (8-PR stack,
+  pending merge).** Executed the `docs/plans/2026-06-08-001-...-plan.md` plan
+  end-to-end via `/ce-work`, TDD per unit, one stacked PR each off master:
+  **Phase 1** — U1 storage+provenance (#37: `guardrails` table + CRUD + finding
+  `guardrail_id` via additive migration), U2 CLI authoring/lifecycle (#38:
+  `guardrail add/list/edit/disable/enable/dismiss` sub-app), U3 relevance-scoped
+  injection (#39: `PROJECT GUARDRAILS` section above PRIOR UNRESOLVED, scope
+  filter + rank + budget), U4 best-effort provenance capture (#40), U5 dashboard
+  panel (#41). **Phase 2** — U6 on-demand shape clustering (#42:
+  `ollama_sentinel/guardrails.py` + `get_corroborated_findings`), U7 candidate
+  surfacing+curation (#43: `guardrail candidates/promote/reject` w/ LLM-drafted
+  assertions + signature suppression), U8 evidence-integrity gate (#44:
+  `counts_toward_strength` — self-caused findings reinforce only via
+  test_failure/fix_commit, no echo). Suite 699→803 passed / 16 skip. Two
+  transparent deferrals: live dashboard *pending*-candidate view (KTD4: clustering
+  on-demand only) and U8 scoped-vs-global gate — both flagged in the PR bodies.
+  Also salvaged-truncated-grounded-review fix as independent **PR #36**. Merge
+  bottom-up #37→#44 (+ #36).
 - 2026-06-08: **Small-DX backlog drained + v0.3 Pattern-promotion planned.**
   Shipped OP-1 SIGHUP hot-reload (PR #32), the impact_scan integration test
   (PR #34), and salvaged grounding P1–P4 positives (PR #31); closed CB-1 as

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A local AI development companion that remembers.
 
-**The sentinel** watches your code directory, reviews every change with a local Ollama model, and builds a cumulative violation database that tracks recurring issues across your codebase. After a week it knows your blind spots. After a month it's indispensable.
+**The sentinel** watches your code directory, reviews every change with a local Ollama model, and builds a cumulative violation database that tracks recurring issues across your codebase. After a week it knows your blind spots. After a month it's indispensable. It also turns recurring confirmed failures into **guardrails** — named rules the reviewer checks on every future change, either authored by you or auto-promoted from a shape it has flagged and corroborated three or more times.
 
 **The research agent** produces dependency-aware impact analysis for library migrations, CVEs, and API changes -- not generic essays, but ranked lists of every call site in YOUR code that breaks, with severity and suggested fixes.
 
@@ -67,11 +67,40 @@ This is the primary product surface. Everything the sentinel knows is visible he
 
 > **Hot-reload (POSIX).** Edit the YAML while the watcher is running and send `kill -HUP <pid>` — the sentinel reloads model and `request_timeout` settings in place without dropping the watch. (Changing `watch.directory` still needs a restart; it's warned-and-skipped on reload.)
 
+## Project guardrails
+
+A **guardrail** is a named, natural-language rule the reviewer checks explicitly on every relevant change — your codebase's hard-won lessons, made durable. Guardrails live in the same memory DB (no YAML), so authoring one works on a fresh setup with no Ollama running:
+
+```bash
+ollama-sentinel guardrail add no-eval \
+  -a "Never call eval/exec on untrusted input." \
+  --category security --path "src/*.py"     # scope is optional
+ollama-sentinel guardrail list              # active rules (--all for disabled/dismissed)
+```
+
+From then on, when you `review`/`run`, each active guardrail whose scope matches the file under review is injected into the prompt (relevance-ranked, token-budgeted), and any finding it produces is tagged with that guardrail's provenance. Disable, re-enable, edit, or dismiss a guardrail at any time:
+
+```bash
+ollama-sentinel guardrail edit 1 --assertion "..."   # change name / assertion / scope
+ollama-sentinel guardrail disable 1   #  / enable 1  / dismiss 1
+```
+
+**Auto-promotion.** Guardrails also grow on their own. Once a shape has been flagged and **corroborated three or more times** (distinct findings, each with a test failure / fix-commit / confirmation), it surfaces as a *candidate* with an LLM-drafted assertion you edit and confirm:
+
+```bash
+ollama-sentinel guardrail candidates   # needs the embedder; on-demand only
+ollama-sentinel guardrail promote 1    # confirm candidate #1 → active guardrail
+ollama-sentinel guardrail reject 1     # not a rule → suppress this shape
+```
+
+Nothing becomes an enforced rule without your explicit `promote`, and a guardrail's own flagged findings only reinforce a candidate via a *hard* signal (a test failure or a fix commit, never a bare model opinion) — so a rule can't manufacture its own re-promotion. This is the **Finding → Incident → Pattern** loop: model opinion → corroborated event → durable project rule.
+
 ## Documentation
 
 See **[docs/GUIDE.md](docs/GUIDE.md)** for the full user guide covering:
 - Sentinel setup, commands, and configuration
 - Violation memory and the `report` command
+- Project guardrails — authoring, lifecycle, and auto-promotion
 - Research agent installation and usage
 - Impact analysis output format
 - Project philosophy and architecture
@@ -98,11 +127,15 @@ The "I always forget what to run" table.
 | Prune stale findings | `ollama-sentinel prune` / `… --yes` | Previews the open findings whose flagged code is gone (file deleted or excerpt no longer locatable) and, on confirmation, closes them with `resolution='stale'`. Read-only on source; no Incident; still-locatable findings are left open |
 | Link commits to findings | `ollama-sentinel install-hooks` | Installs a git post-commit hook that records which commit touched each open Finding |
 | Auto-link test failures | add `ollama_sentinel = true` to your pytest config | A failing test on a flagged line becomes a `test_failure` Incident |
+| Author a guardrail | `ollama-sentinel guardrail add no-eval -a "Never eval untrusted input." --category security --path "src/*.py"` | A named rule the reviewer checks on matching files; active immediately, no Ollama needed to create it |
+| List / curate guardrails | `ollama-sentinel guardrail list`<br>`… edit/disable/enable/dismiss <id>` | `list` shows active rules (`--all`, `-f json`); the others manage the lifecycle |
+| See auto-detected candidates | `ollama-sentinel guardrail candidates` | Recurring shapes (≥3 corroborated findings) with an LLM-drafted assertion; on-demand, needs the embedder |
+| Promote / reject a candidate | `ollama-sentinel guardrail promote 1` / `… reject 1` | `promote` confirms it into an active guardrail (`source=promoted`); `reject` suppresses that shape |
 | Create a config file | `ollama-sentinel init` | Writes `ollama-sentinel.yaml` in the current dir |
 | Research a question | `ollama-sentinel research "is SQLAlchemy 2.0 safe to upgrade?"` | Synthesized answer with confidence score, persisted to Control Center |
 | Research with code context | `ollama-sentinel research "what breaks?" --context src/db.py` | Answer grounded in your actual code |
 | Interactive research | `ollama-sentinel research -i` | REPL prompt — ask follow-up questions in the same session |
-| Run all tests | `pytest tests/ -q` | `529 passed, 15 skipped` (the 15 skips are intentional — fallback paths covered by the other CI runner) |
+| Run all tests | `pytest tests/ -q` | Green (run it for the live count — it drifts as tests land; the skips are intentional, exercised by the `[dev,research]` CI runner) |
 
 ## When something looks wrong
 
@@ -113,6 +146,7 @@ The "I always forget what to run" table.
 | `/api/chat` `ReadTimeout` after a long wait | The review model is taking longer than `ollama.request_timeout`. For thinking cloud models, set `think: false` under the model role; for any slow model, lower `max_tokens` or use a faster local model |
 | Sentinel uses the wrong model / config | You have multiple `ollama-sentinel.yaml` files. The one in cwd wins. Either `cd` to the right directory or pass `--config <abs-path-to-ollama-sentinel.yaml>` |
 | `EmbeddingUnavailable` in logs | `ollama pull qwen3-embedding:4b` (or set `memory.semantic_recall: false` in the YAML) |
+| `guardrail candidates` shows nothing | Auto-promotion needs ≥3 *distinct corroborated* findings of one shape, plus the embedder. On a fresh DB there's no history yet — author guardrails by hand (`guardrail add`) and let candidates accrue. Requires `embedding.enabled` and `ollama pull qwen3-embedding:4b` |
 | `EmbeddingUnavailable` only on the first review after Ollama restart | Cold-load timeout. Bump `embedding.timeout_seconds` in the YAML (default 30s, sized against ~6.4s realistic idle cold-load on M-series) |
 | `ValidationError: extra fields not permitted` on config load | YAML typo — error names the offending field; fix the spelling. Applies to top-level fields AND role names inside `embedding.models` |
 | `ValidationError: ... must include a 'hot' role` | YAML's `embedding:` block is missing `models.hot`. Add `embedding: { models: { hot: qwen3-embedding:4b } }` |
@@ -130,7 +164,7 @@ The "I always forget what to run" table.
 
 ```bash
 pip install -e ".[dev]"
-pytest tests/ -q   # 378 passed, 15 skipped, ~2-3 seconds
+pytest tests/ -q   # green in ~10s; run it for the live pass/skip count (it drifts as tests land)
 ```
 
 CI runs both `[dev]` and `[dev,research]` matrix runners on every push and PR — the second one exercises the 15 tests skipped on `[dev]`-only.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -10,6 +10,8 @@ Most AI code review tools see your code once -- when you open a PR. Then they fo
 
 Ollama Sentinel is different. It watches every save. It remembers every finding. After a week, it knows that you keep forgetting to close database connections in `repositories/`. After a month, it knows that nullable returns in your auth flow have been flagged five times and never fixed. It tells your Ollama model about these patterns, and the model escalates them.
 
+And once a pattern is confirmed often enough, it hardens into a **guardrail** — a named rule the reviewer checks on every future change. You can author guardrails by hand, or let the sentinel propose them from shapes it has flagged and corroborated three or more times. That's the compounding payoff: the codebase's failure history stops being a log you read and becomes a rulebook the model enforces.
+
 The research agent does the same thing for library migrations. Instead of a generic essay about "what changed in SQLAlchemy 2.0," it scans your actual codebase, finds the 14 call sites that break, ranks them by severity, and tells you which file to fix first.
 
 Both tools are local. Your code never leaves your machine. The memory they build is yours.
@@ -83,6 +85,8 @@ The Control Center is a full-screen read-only TUI with three main areas:
 
 **Patterns** (right) — recurring violations ranked by frequency. These are the issues the model keeps flagging across multiple reviews. If something shows up here repeatedly, it needs real attention.
 
+**Guardrails** (right, below Recent Reviews) — your active project rules, with their scope and source (✎ authored by hand, `auto` promoted from a pattern). Read-only here; curate them with the `guardrail` commands below.
+
 ### Status Indicators
 
 The header shows:
@@ -123,11 +127,12 @@ The focused panel has a bright cyan border. The selected row is highlighted with
 1. You save a file
 2. The watcher detects the change (with debounce to avoid reviewing mid-keystroke)
 3. The file content is read (or git diff, if configured)
-4. If violation memory is enabled, prior unresolved findings for this file are fetched from the SQLite database and injected into the prompt
-5. The content + prior findings are sent to your Ollama model
-6. The model returns a review
-7. Findings are extracted from the review (LLM JSON parsing with regex fallback) and persisted to the database
-8. The review is saved as a versioned markdown file
+4. If violation memory is enabled, prior unresolved findings for this file are fetched from the SQLite database
+5. Active guardrails whose scope matches the file are loaded and (with the prior findings) injected into the prompt — relevance-ranked and token-budgeted
+6. The content + guardrails + prior findings are sent to your Ollama model
+7. The model returns a review
+8. Findings are extracted (LLM JSON parsing with regex fallback), best-effort tagged with the guardrail that produced them, and persisted to the database
+9. The review is saved as a versioned markdown file
 
 Every review makes the next one smarter.
 
@@ -163,6 +168,27 @@ ollama-sentinel triage error.log --context src/foo.py:42  # add explicit context
 ollama-sentinel                                      # default: opens Control Center
 ollama-sentinel dashboard                            # same thing, explicit command
 ollama-sentinel dashboard -r 0.5 -n 3                # half-second refresh, min count 3
+
+# Findings lifecycle
+ollama-sentinel findings                             # list open findings with ids (--severity / --file / -f json)
+ollama-sentinel resolve 42                           # close as fixed
+ollama-sentinel dismiss 31                           # close as false-positive
+ollama-sentinel fix 42                               # localized model fix → preview diff → write on confirm (--yes)
+ollama-sentinel surface                              # emit open findings to .ollama_reviews/findings.sarif (editor + CI)
+ollama-sentinel prune                                # close findings whose flagged code is gone
+
+# Incidents (corroborated events)
+ollama-sentinel confirm 42                           # manual corroboration → manual_confirm Incident (finding stays open)
+ollama-sentinel incidents                            # list corroborated events (table / -f json)
+ollama-sentinel install-hooks                        # git post-commit hook: link commits to open findings
+
+# Guardrails (project rules — see the section below)
+ollama-sentinel guardrail add no-eval -a "Never eval untrusted input." --category security --path "src/*.py"
+ollama-sentinel guardrail list                       # active rules (--all / --status / -f json)
+ollama-sentinel guardrail edit 1 --assertion "..."   # disable / enable / dismiss <id> manage lifecycle
+ollama-sentinel guardrail candidates                 # auto-detected recurring shapes (on-demand)
+ollama-sentinel guardrail promote 1                  # confirm candidate → active guardrail
+ollama-sentinel guardrail reject 1                   # suppress a candidate shape
 ```
 
 ### The Report
@@ -247,6 +273,77 @@ ollama-sentinel review src/payment.py -m security
 ```
 
 The `-m` flag selects which model role to use. Define as many as you need in the YAML under `ollama.models`.
+
+---
+
+## Project Guardrails
+
+A **guardrail** is a named, natural-language rule the reviewer checks explicitly on every relevant change — `"Never call eval/exec on untrusted input."`, `"Database sessions must be closed in a finally block."`, `"Don't log request bodies."` Where prior-violation memory reminds the model what it *has* flagged, a guardrail tells it what to *always* check. It's the codebase's hard-won lessons, made durable and enforced.
+
+Guardrails are stored in the same memory DB (no YAML), so they survive restarts and authoring one needs neither Ollama nor a prior review.
+
+### Two ways a guardrail is born
+
+```
+   You author one directly  ─────────────────────────────╮
+   (guardrail add)                                        ▼
+                                                   active guardrail ──► injected into every
+   ≥3 distinct corroborated findings of one shape         ▲            matching review
+     ─► guardrail candidates (on-demand clustering)       │
+        ─► LLM-drafted assertion                          │
+        ─► guardrail promote  (you confirm) ──────────────╯
+        ─► guardrail reject   (suppress this shape)
+```
+
+Both paths converge on one active artifact. Manual authoring gives value on day one with zero history; auto-promotion compounds on top once a shape has recurred enough to be trustworthy.
+
+### Authoring and lifecycle
+
+```bash
+# Create — active immediately. Scope is optional; omit it to apply broadly.
+ollama-sentinel guardrail add no-eval \
+  -a "Never call eval/exec on untrusted input." \
+  --category security \        # scope to one finding category (optional)
+  --path "src/*.py"            # scope to a path glob (optional)
+
+ollama-sentinel guardrail list            # active rules
+ollama-sentinel guardrail list --all      # include disabled/dismissed
+ollama-sentinel guardrail list -f json    # machine-readable
+
+ollama-sentinel guardrail edit 1 --assertion "..." --category bug   # change any field
+ollama-sentinel guardrail disable 1       # stop injecting it (reversible)
+ollama-sentinel guardrail enable 1        # bring it back
+ollama-sentinel guardrail dismiss 1       # terminal — never injected again
+```
+
+A guardrail's **scope** decides which files it applies to. A `--path` glob is matched segment-precisely against the file under review (`src/*.py` admits `src/app.py`, not `src/sub/app.py`); an absent glob applies broadly. The `--category` is carried for attribution and clustering — it doesn't restrict which files the rule appears in (a file has no category until it's reviewed).
+
+### How guardrails shape a review
+
+When you `review` or `run`, the reviewer loads every **active** guardrail whose scope matches the file, ranks them by relevance to the file's contents, and injects the top ones into the prompt under a `PROJECT GUARDRAILS — check explicitly` heading — capped by a token budget so a growing rulebook never floods the prompt. Disabled and dismissed guardrails are never injected. When the model then flags something, that finding is best-effort tagged with the guardrail that produced it (its *provenance*), which feeds the auto-promotion integrity gate below.
+
+### Auto-promotion: from pattern to rule
+
+Authoring is the day-one path; the compounding layer is promotion. Run on demand:
+
+```bash
+ollama-sentinel guardrail candidates       # detect recurring shapes (table or -f json)
+```
+
+This selects findings that have been **corroborated** (≥1 Incident — a test failure, a fix commit, or a manual confirmation), groups them by category, and clusters them by semantic similarity. A shape with **three or more distinct corroborated findings** becomes a *candidate*, each presented with a one-line assertion drafted by your local model (with a deterministic fallback if the model is unavailable). You then decide:
+
+```bash
+ollama-sentinel guardrail promote 1        # confirm candidate #1 → active guardrail (source=promoted)
+ollama-sentinel guardrail promote 1 --assertion "..." --name my-rule   # edit at confirm time
+ollama-sentinel guardrail reject 1         # not a real rule → suppress this shape from future runs
+```
+
+Two safeguards keep this honest:
+
+- **Nothing enforces without your confirm.** A candidate is a proposal; only `promote` turns it into an injected rule. `reject` records the shape so it isn't re-proposed.
+- **A rule can't manufacture its own evidence.** A guardrail flags findings (tagged with its provenance). Those findings could, in principle, cluster back into a candidate that re-proposes the *same* rule — a self-reinforcing echo. The **evidence-integrity gate** blocks that: a guardrail's own findings count toward a candidate only when corroborated by a *hard* signal (a `test_failure` or `fix_commit` Incident), never by a bare `manual_confirm` or an uncorroborated opinion. Independently-discovered findings always count.
+
+**Prerequisites for candidates:** the embedding model (`ollama pull qwen3-embedding:4b`) and `embedding.enabled` in your config, plus real incident history. Clustering runs *only* in the `candidates`/`promote`/`reject` commands — never on the watcher or dashboard loop — so it never taxes live review latency. On a fresh DB there's nothing to detect yet; author guardrails by hand and let candidates accrue.
 
 ---
 
@@ -350,14 +447,23 @@ The switching cost is real. After three months, the violation database knows thi
 ```
 ollama-sentinel/
   ollama_sentinel/           # sentinel module
-    cli.py                   # Typer CLI (run, review, init, report, triage, dashboard)
+    cli.py                   # Typer CLI (run, review, init, report, triage, dashboard,
+                             #   findings lifecycle, incidents, guardrail sub-app)
     config.py                # YAML config loading
     models.py                # Pydantic v2 config models
-    processor.py             # FileProcessor, OllamaClient, async prompt formatting
+    processor.py             # FileProcessor, OllamaClient, async prompt formatting,
+                             #   guardrail loading + provenance attribution
     watcher.py               # FileSentinel, file watching, pipeline orchestration
-    violation_db.py          # SQLite violation memory + semantic recall (embed_text)
+    violation_db.py          # SQLite memory: findings + incidents + guardrails tables,
+                             #   semantic recall (embed_text), corroborated-findings selector
+    guardrails.py            # Guardrail shape clustering, candidate detection,
+                             #   assertion drafting, evidence-integrity gate
     extractor.py             # Finding extraction (LLM + regex fallback)
-    dashboard.py             # Live TUI (Rich) for reviews + recurring violations
+    dashboard.py             # Live TUI (Rich): reviews + recurring violations + guardrails
+    sarif.py                 # SARIF surface (`surface`) + stale-prune selector (`prune`)
+    remediate.py             # Localized model fix for `fix <id>` (excerpt-bounded, atomic)
+    hooks.py                 # Git post-commit hook installer + record_commit
+    pytest_plugin.py         # Opt-in plugin: test failure → test_failure Incident
     utils.py                 # safe_read, chunking, diff, compression
     context/                 # token-budgeted prompt assembly + semantic retrieval
       assembler.py           # Section / Priority / ContextItem + assemble + chunk_by_lines
@@ -394,10 +500,12 @@ ollama-sentinel/
       history.py             # Interactive REPL history
       interface.py           # Interactive REPL UI
 
-  tests/                     # 336 tests, ~3 seconds
+  tests/                     # run `pytest tests/ -q` for the live count (~10s)
   docs/
     plans/                   # implementation plans
     superpowers/             # specs, plans, and follow-ups for landed features
+    VISION.md                # product vision + roadmap
+    index.html               # single-page visual guide (canonical pitch surface)
     GUIDE.md                 # this file
   _archive/                  # superseded snapshots (do not import; see _archive/README.md)
   ollama-sentinel.yaml       # example config

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -11,7 +11,9 @@ schema substrate.
 **Sentinel** — file watcher. On file save, sends the change to a local Ollama
 model, parses the model's findings into structured rows, and persists them in
 a SQLite memory with three layered recall strategies (semantic, structural,
-single-file). The memory is the product, not the model.
+single-file). It also carries a **guardrail** layer — curated, named rules
+injected into every relevant review, authored directly or auto-promoted from
+recurring corroborated failures. The memory is the product, not the model.
 
 **Research agent** — multi-step LangGraph workflow for dependency migrations,
 CVEs, and API impact analysis. Produces ranked, file-and-line-specific impact
@@ -23,9 +25,9 @@ that the research agent does call OpenAI when invoked).
 ## Where it is now
 
 Shipped, public on GitHub. The suite is healthy — run `pytest tests/ -q` for
-the live number (as of 2026-06-07: 689 passed / 15 skipped in ~9s; quote the
+the live number (as of 2026-06-13: 803 passed / 16 skipped in ~10s; quote the
 command, not a frozen count). The product has moved well past the v0.1 "model
-that comments on your code" stage. Three things are true today that were
+that comments on your code" stage. Four things are true today that were
 aspirational a few months ago:
 
 - **The memory is layered and grounded.** Prior-violation recall is semantic
@@ -42,6 +44,12 @@ aspirational a few months ago:
   It can surface in your editor and CI, be auto-fixed, be triaged from tool
   output, and be pruned when the code it flagged is gone. (The "make findings
   actionable" arc, below.)
+- **Failure history becomes a rulebook.** The Finding → Incident → **Pattern**
+  rung is closed: recurring corroborated failures harden into **guardrails** —
+  named rules the reviewer checks on every future change — either authored by
+  hand or auto-promoted from a shape seen ≥3 times. The north star below is no
+  longer aspirational; injection is how "every future diff is reviewed with that
+  history as context" actually happens. (Detailed below.)
 
 **Phase A — hot-path embedding swap (shipped 2026-05-01).** The semantic
 recall embedder moved from `nomic-embed-text` to `qwen3-embedding:4b`.
@@ -84,8 +92,8 @@ Finding (model opinion)
    ↓ [post-commit hook: link the commit to open Findings in touched files]
    ↓ [manual: ollama-sentinel confirm <finding_id>]
 Incident (corroborated event)        ← inspect with `ollama-sentinel incidents`
-   ↓ [≥3 incidents with same shape]
-Pattern (project-specific guardrail) ← still aspirational (v0.3)
+   ↓ [≥3 distinct corroborated findings of the same shape, you confirm]
+Pattern (project-specific guardrail) ← shipped v0.3; `ollama-sentinel guardrail …`
 ```
 
 What shipped in v0.2:
@@ -110,8 +118,9 @@ memory too. The file watcher remains for streaming commentary as you type.
 pivot was near zero.
 
 Deferred past v0.2: `pre-commit` surfacing of incidents on staged files
-(v0.2.1), reverse import-graph blame traversal beyond the simple
-`suspect_commits` heuristic (v0.2.1), and ≥3-incident Pattern promotion (v0.3).
+(v0.2.1) and reverse import-graph blame traversal beyond the simple
+`suspect_commits` heuristic (v0.2.1). The third deferral — ≥3-incident Pattern
+promotion — **shipped in v0.3** (the guardrail layer, below).
 
 ## Making findings actionable (shipped)
 
@@ -146,6 +155,52 @@ The throughline: a Finding now has a full lifecycle — proposed by the model,
 corroborated by events, surfaced where you work, acted on, and retired — rather
 than accumulating as inert rows.
 
+## From event to rule — the guardrail layer (v0.3, shipped)
+
+Corroboration (v0.2) told the memory what *objectively happened*. The guardrail
+layer closes the loop: it turns a recurring corroborated failure into a
+**durable, forward-looking rule** that shapes every future review. This is the
+**Pattern** rung of Finding → Incident → Pattern, and it's the compounding
+payoff the whole schema was built toward.
+
+A **guardrail** is a curated, named natural-language assertion (`"Never call
+eval/exec on untrusted input."`) with optional scope (a finding category and/or
+a path glob). It is *checked by the review model against the code* — there is no
+deterministic regex/AST engine, which keeps the matcher flexible. Guardrails are
+born two ways and converge on one active artifact:
+
+- **Manual authoring (the day-one path).** `guardrail add` creates an active
+  rule immediately, with zero incident history. Pure auto-promotion stalls
+  because corroborated incidents accrue slowly, so manual authoring is
+  first-class — the value loop works on a fresh DB.
+- **Auto-promotion (the compounding layer).** On demand, `guardrail candidates`
+  selects corroborated findings, clusters them by category and embedding
+  similarity, and surfaces any shape with ≥3 distinct corroborated findings as a
+  candidate with an LLM-drafted assertion. `guardrail promote` confirms it into
+  an active rule; `guardrail reject` suppresses the shape. Clustering reuses the
+  existing `qwen3-embedding:4b` hot-path embedder and runs **only** in these
+  commands — never on the watcher or dashboard loop, so it never taxes review
+  latency.
+
+Active guardrails are scope-filtered and relevance-ranked into the review prompt
+(reusing the token-budgeted context assembler, alongside prior-violation recall),
+and findings they produce carry the originating guardrail's **provenance**.
+
+Two integrity properties make this safe rather than nagware:
+
+- **Curation gates enforcement.** Nothing becomes an enforced rule without an
+  explicit human confirm. A candidate is a proposal.
+- **No self-manufactured evidence.** A guardrail flags findings tagged with its
+  provenance; those findings could otherwise cluster back into a candidate that
+  re-proposes the same rule — a Pattern-tier echo. The **evidence-integrity
+  gate** blocks it: a guardrail's own findings reinforce a candidate only via a
+  *hard* signal (a `test_failure` or `fix_commit` Incident), never a bare
+  opinion or a manual confirmation. Independently-discovered findings count
+  normally, and a missing provenance link fails safe (counts as independent).
+
+The result: the codebase's failure history stops being a log you read and
+becomes a rulebook the model enforces — exactly the north star below.
+
 ## What's still aspirational — v0.3: shared substrate between modules
 
 Today the two modules are architecturally independent. That was the right v0.1
@@ -173,8 +228,10 @@ tools that share a process becomes one thing that has no external equivalent.
 ## Explicit non-goals
 
 - **No fine-tuning.** The leverage is in schema, not model.
-- **No autonomous agent guardrails until v0.3+.** The substrate is too thin
-  today; auto-intervention would be nagware.
+- **No *autonomous* enforcement.** The shipped guardrails (above) are **curated**
+  — nothing becomes an enforced rule without a human confirm, and a guardrail
+  surfaces concerns into the review, it does not block, rewrite, or act on its
+  own. Auto-intervention without curation would be nagware; that line stays.
 - **No multi-language for now.** Adding TypeScript/JS multiplies the AST
   surface 5x without enough Python signal yet to justify it.
 - **No web UI.** Rich TUI is the right surface for a tool that lives on a

--- a/docs/index.html
+++ b/docs/index.html
@@ -543,11 +543,12 @@
     <a href="#start"    class="tick" data-i="2"><span class="dot"></span><span>t+5s</span></a>
     <a href="#loop"     class="tick" data-i="3"><span class="dot"></span><span>t+30s</span></a>
     <a href="#cmds"     class="tick" data-i="4"><span class="dot"></span><span>t+1m</span></a>
-    <a href="#report"   class="tick" data-i="5"><span class="dot"></span><span>t+1d</span></a>
-    <a href="#thesis"   class="tick" data-i="6"><span class="dot"></span><span>t+1w</span></a>
-    <a href="#research" class="tick" data-i="7"><span class="dot"></span><span>t+1mo</span></a>
-    <a href="#dash"     class="tick" data-i="8"><span class="dot"></span><span>live</span></a>
-    <a href="#cfg"      class="tick" data-i="9"><span class="dot"></span><span>cfg</span></a>
+    <a href="#report"     class="tick" data-i="5"><span class="dot"></span><span>t+1d</span></a>
+    <a href="#guardrails" class="tick" data-i="6"><span class="dot"></span><span>t+1w</span></a>
+    <a href="#thesis"     class="tick" data-i="7"><span class="dot"></span><span>t+2w</span></a>
+    <a href="#research"   class="tick" data-i="8"><span class="dot"></span><span>t+1mo</span></a>
+    <a href="#dash"       class="tick" data-i="9"><span class="dot"></span><span>live</span></a>
+    <a href="#cfg"        class="tick" data-i="10"><span class="dot"></span><span>cfg</span></a>
   </div>
   <div class="meta">v0.1 · MIT · LOCAL</div>
 </aside>
@@ -570,8 +571,9 @@
       <div>
         <p class="lead" style="margin-top: 2rem;">
           A local AI development companion that watches every save, learns your blind
-          spots, and produces dependency-aware impact analysis. Two tools, one
-          loop, your machine. Your code never leaves it.
+          spots, hardens recurring failures into project guardrails, and produces
+          dependency-aware impact analysis. Two tools, one loop, your machine. Your
+          code never leaves it.
         </p>
         <div class="hero-cta">
           <a href="#start" class="btn primary">Get started <span>↓</span></a>
@@ -811,8 +813,10 @@ ollama-sentinel run">copy</button></pre>
         The dashed feedback arc is the whole point. Each saved finding becomes
         retrievable context for the <b>next</b> review of any related file.
         Embedding-ranked, token-budgeted, and capped so the prompt stays useful
-        instead of overflowing. Best-effort everywhere — extraction failure
-        never blocks the review save.
+        instead of overflowing. Active <b>project guardrails</b> ride the same
+        injection path — scope-filtered into every matching review — and findings
+        they produce carry their provenance. Best-effort everywhere — extraction
+        failure never blocks the review save.
       </p>
     </div>
   </div>
@@ -824,8 +828,12 @@ ollama-sentinel run">copy</button></pre>
 <section id="cmds">
   <div class="wrap">
     <div class="stamp"><span class="t">t+1m</span><span>SURFACE AREA</span></div>
-    <h2>Six commands. That's the whole CLI.</h2>
-    <p class="lead">Each one fits on one line. Defaults are sensible. Flags exist when you need them.</p>
+    <h2>Seven moves cover the daily loop.</h2>
+    <p class="lead">Each fits on one line; defaults are sensible. A fuller surface sits behind them —
+      a findings lifecycle (<code>findings</code>, <code>resolve</code>, <code>fix</code>,
+      <code>surface</code>, <code>prune</code>), corroboration (<code>confirm</code>,
+      <code>incidents</code>, <code>install-hooks</code>), and the <code>guardrail</code>
+      sub-app — but you can go a long way on these.</p>
 
     <div class="cmds reveal">
       <div class="cmd">
@@ -863,6 +871,12 @@ ollama-sentinel run">copy</button></pre>
         <div class="name">init</div>
         <div class="desc">Drop a sane <code>ollama-sentinel.yaml</code> in the current directory.</div>
         <div class="ex"><span class="pr">$</span> ollama-sentinel init</div>
+      </div>
+      <div class="cmd">
+        <div class="glyph">·──── 07</div>
+        <div class="name">guardrail</div>
+        <div class="desc">Author project rules the reviewer checks every time — or promote ones it proposes from recurring patterns.</div>
+        <div class="ex"><span class="pr">$</span> ollama-sentinel guardrail add no-eval -a "Never eval untrusted input."</div>
       </div>
     </div>
   </div>
@@ -903,11 +917,54 @@ ollama-sentinel run">copy</button></pre>
 </section>
 
 <!-- ========================================================================
+     GUARDRAILS — from pattern to rule
+     ======================================================================== -->
+<section id="guardrails">
+  <div class="wrap">
+    <div class="stamp"><span class="t">t+1w</span><span>FROM PATTERN TO RULE</span></div>
+    <h2>The patterns become rules the model enforces.</h2>
+    <p class="lead">A recurring pattern is a log entry. A <b>guardrail</b> is a named rule the reviewer
+      checks on <em>every</em> future change. Author one by hand on day one — or let the sentinel
+      propose them from shapes it has flagged and corroborated three or more times. This is the
+      <code>Finding → Incident → Pattern</code> rung, closed.</p>
+
+    <div class="terminal reveal">
+      <div class="bar">
+        <span class="dots"><i></i><i></i><i></i></span>
+        <span class="ttl">~/proj  ·  ollama-sentinel guardrail candidates</span>
+      </div>
+<pre>             <span class="h">Guardrail candidates (2)</span>
+<span class="mute">┌───┬──────────┬───┬─────────────────────────────────────────────┐</span>
+<span class="mute">│</span> # <span class="mute">│</span> Category <span class="mute">│</span> N <span class="mute">│</span> Drafted assertion (editable)                <span class="mute">│</span>
+<span class="mute">├───┼──────────┼───┼─────────────────────────────────────────────┤</span>
+<span class="mute">│</span> <span class="em">1</span> <span class="mute">│</span> <span class="crit">security</span> <span class="mute">│</span> <span class="em">4</span> <span class="mute">│</span> Never pass request data into eval/exec.     <span class="mute">│</span>
+<span class="mute">│</span> <span class="em">2</span> <span class="mute">│</span> <span class="warn">bug</span>      <span class="mute">│</span> <span class="em">3</span> <span class="mute">│</span> Close database sessions in a finally block. <span class="mute">│</span>
+<span class="mute">└───┴──────────┴───┴─────────────────────────────────────────────┘</span>
+<span class="mute">  Promote with `guardrail promote &lt;#&gt;` or reject with `guardrail reject &lt;#&gt;`.</span>
+
+<span class="pr">$</span> ollama-sentinel guardrail promote 1
+<span class="mute">  Promoted candidate 1 → guardrail 5: security-pattern (active, source=promoted).</span>
+<span class="mute">  → injected into every matching review from now on.</span></pre>
+    </div>
+
+    <p class="loop-cap">
+      Two guarantees keep it honest, not nagware. <b>Curation gates enforcement</b> —
+      nothing becomes a rule without your <code>promote</code>; a candidate is only a
+      proposal. And <b>a rule can't manufacture its own evidence</b>: a guardrail's own
+      flagged findings reinforce a candidate only when backed by a <em>hard</em> signal
+      (a test failure or a fix commit), never a bare opinion — so a rule can't echo itself
+      back into existence. Clustering runs only when you ask for candidates, never on the
+      review path.
+    </p>
+  </div>
+</section>
+
+<!-- ========================================================================
      MEMORY COMPOUNDS — thesis
      ======================================================================== -->
 <section id="thesis">
   <div class="wrap">
-    <div class="stamp"><span class="t">t+1w</span><span>WHY THIS WORKS</span></div>
+    <div class="stamp"><span class="t">t+2w</span><span>WHY THIS WORKS</span></div>
     <h2>Memory compounds.</h2>
 
     <div class="thesis reveal">
@@ -1163,13 +1220,14 @@ ollama-sentinel run">copy</button></pre>
           <li><b>·</b> Ollama (sentinel)</li>
           <li><b>·</b> OPENAI_API_KEY (research)</li>
           <li><b>·</b> ~30 MB RAM, ≪ 1 s reviews</li>
-          <li><b>·</b> 336 tests · ~3 s</li>
+          <li><b>·</b> 800+ tests · ~10 s</li>
         </ul>
       </div>
       <div>
         <h3 class="eyebrow" style="font-size: 0.78rem; margin-bottom: 1rem;">Read more</h3>
         <ul>
           <li><a href="GUIDE.md">→ GUIDE.md</a></li>
+          <li><a href="VISION.md">→ VISION.md</a></li>
           <li><a href="../README.md">→ README.md</a></li>
           <li><a href="../CLAUDE.md">→ CLAUDE.md</a></li>
           <li><a href="superpowers/followups.md">→ open follow-ups</a></li>
@@ -1217,7 +1275,7 @@ ollama-sentinel run">copy</button></pre>
 
   // Active rail tick on scroll
   (function () {
-    const sections = ['hero','tools','start','loop','cmds','report','thesis','research','dash','cfg']
+    const sections = ['hero','tools','start','loop','cmds','report','guardrails','thesis','research','dash','cfg']
       .map(id => document.getElementById(id))
       .filter(Boolean);
     const ticks = document.querySelectorAll('.rail .tick');

--- a/docs/plans/2026-06-08-001-feat-pattern-promotion-guardrails-plan.md
+++ b/docs/plans/2026-06-08-001-feat-pattern-promotion-guardrails-plan.md
@@ -1,13 +1,23 @@
 ---
 title: "feat: Pattern promotion → project guardrails"
 type: feat
-status: active
+status: implemented
 date: 2026-06-08
+implemented: 2026-06-13
 depth: deep
 origin: docs/brainstorms/2026-06-08-pattern-promotion-guardrails-requirements.md
 ---
 
 # feat: Pattern promotion → project guardrails
+
+> **Status: Implemented (2026-06-13).** All 8 units shipped as a linear
+> stacked-PR chain off master: Phase 1 — U1 #37, U2 #38, U3 #39, U4 #40, U5 #41;
+> Phase 2 — U6 #42, U7 #43, U8 #44. TDD per unit; suite 699→803 passed / 16 skip.
+> Two transparent deferrals (flagged in the PR bodies): the live *dashboard*
+> pending-candidate view (skipped to honor KTD4 — clustering is on-demand only),
+> and U8's gate is implemented as a *global* self-caused-soft exclusion rather
+> than *scoped-to-originating-guardrail* (the stricter, safe direction; satisfies
+> every plan scenario). Pending merge bottom-up #37→#44.
 
 ## Summary
 

--- a/docs/session-notes/2026-06-13-guardrails-built-8pr-stack-handoff.md
+++ b/docs/session-notes/2026-06-13-guardrails-built-8pr-stack-handoff.md
@@ -1,0 +1,59 @@
+# Session handoff — 2026-06-13: Pattern promotion → project guardrails BUILT
+
+## What happened
+
+Executed the **Pattern promotion → project guardrails** plan
+(`docs/plans/2026-06-08-001-feat-pattern-promotion-guardrails-plan.md`)
+end-to-end via `/ce-work` — all 8 units, TDD per unit, one stacked PR each.
+This is the v0.3 north-star feature: the **Finding → Incident → Pattern** rung
+from `docs/VISION.md`.
+
+Also shipped the independent **truncated-grounded-review salvage** fix as
+**PR #36** (was committed-but-unshipped at session start).
+
+## The stack (pending merge, bottom → top, base master)
+
+| PR | Unit | Summary | Files |
+|----|------|---------|-------|
+| #37 | U1 storage + provenance | `guardrails` table + CRUD + `Guardrail`; finding `guardrail_id` via additive `_migrate` | `violation_db.py` |
+| #38 | U2 CLI authoring/lifecycle | `guardrail add/list/edit/disable/enable/dismiss` sub-app | `cli.py` |
+| #39 | U3 relevance-scoped injection | `PROJECT GUARDRAILS` section above PRIOR UNRESOLVED; scope filter + retriever rank + soft_budget | `context/recipes.py`, `processor.py` |
+| #40 | U4 provenance capture | best-effort `attribute_guardrail_provenance`; watcher wiring | `processor.py`, `watcher.py` |
+| #41 | U5 dashboard panel | read-only active-guardrails panel | `dashboard.py` |
+| #42 | U6 shape clustering | `get_corroborated_findings` selector + new `guardrails.py` (`detect_candidates`) | `violation_db.py`, `guardrails.py` |
+| #43 | U7 candidate surfacing/curation | `guardrail candidates/promote/reject`; LLM `draft_assertion` + fallback; signature suppression | `cli.py`, `guardrails.py` |
+| #44 | U8 evidence-integrity gate | `counts_toward_strength` (self-caused → hard signal only); pre-filters `detect_candidates` | `guardrails.py` |
+
+Suite: **699 → 803 passed / 16 skipped**, green at every commit. The U8 tip
+(all 8 units combined) is green. This docs PR (`docs/guardrails-shipped`) rides
+the tip.
+
+## Merge order
+
+Bottom-up: **#37 → #38 → #39 → #40 → #41 → #42 → #43 → #44 → (this docs PR)**.
+GitHub auto-retargets each child to master as its parent merges. **#36** (salvage)
+is independent — merge anytime.
+
+## Two transparent deferrals (flagged in PR bodies)
+
+1. **Live dashboard *pending*-candidate view** — intentionally NOT built in U7.
+   Running `detect_candidates` on the dashboard's 1s poll loop would violate
+   **KTD4** (clustering is on-demand only). Confirmed candidates already show in
+   the U5 panel as `source=promoted` ("auto"). A cached / slow-cadence panel
+   would re-enable a live view — clean follow-up.
+2. **U8 gate scope** — implemented as a *global* exclusion of self-caused-soft
+   findings, not *scoped-to-originating-guardrail*. This is the stricter, safe
+   direction (cannot create false candidates) and satisfies every plan scenario.
+   Revisit only if it proves too aggressive in practice.
+
+## Resume next time
+
+1. Merge the stack (#37→#44, then #36).
+2. Optionally pick up the two deferrals above.
+3. Then the **v0.3 shared substrate** moat play (lift `ImportResolver`, unify
+   `Finding`/`ImpactItem`, bidirectional impact↔incident) — see `docs/VISION.md`.
+
+## Minor cleanup noted
+
+`tests/test_cli.py` carries one cosmetic unused `Guardrail` import (introduced in
+U2, Pyright-only lint, no test impact) — fold into whatever next touches that file.


### PR DESCRIPTION
Closes out the v0.3 **Pattern promotion → project guardrails** arc (U1–U8, PRs #37–#44) in the docs that travel with the feature. **Stacked on #44 (U8)** so it carries full context; merges last. Docs-only — suite unchanged (803 passed / 16 skipped).

## Changes
- **CLAUDE.md**
  - Build & Run: the `guardrail` CLI verbs (authoring `add/list/edit/disable/enable/dismiss` + `candidates/promote/reject`).
  - Architecture: guardrail injection + provenance in the sentinel data flow; a new Finding→Incident→**Pattern** guardrail-lifecycle diagram.
  - Key modules: add `guardrails.py`; refresh `violation_db.py` / `cli.py` / `dashboard.py` rows.
  - Breadcrumbs: refreshed Resume + Pickable-next-moves; a 2026-06-13 Recent-landings entry.
- **Plan** marked `status: implemented` with a dated note, per-unit PR map, and the two transparent deferrals.
- **New handoff:** `docs/session-notes/2026-06-13-guardrails-built-8pr-stack-handoff.md`.

## Per PR-hygiene
Docs are isolated from the feature PRs (no feature code rides here). This is the only docs change for the arc.