### PR TITLE
feat(init): auto-detect installed Ollama model instead of hardcoding gemma3:4b

### DIFF
--- a/ollama_sentinel/cli.py
+++ b/ollama_sentinel/cli.py
@@ -13,7 +13,11 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 from . import __version__
-from .config import create_default_config
+from .config import (
+    create_default_config,
+    list_installed_models,
+    select_reviewer_model,
+)
 from .processor import FileChange
 from .watcher import FileSentinel
 from watchfiles import Change
@@ -214,13 +218,30 @@ def init(
         overwrite = typer.confirm(f"{config_path} already exists. Overwrite?")
         if not overwrite:
             raise typer.Exit()
-    
-    # Create a basic configuration
-    config = create_default_config(directory, output)
-    
+
+    # Auto-detect a reviewer model from the local Ollama install so the
+    # generated config points at a model that actually exists. Falls back to
+    # the hardcoded default when Ollama is unreachable.
+    host = "http://localhost:11434"
+    installed = list_installed_models(host)
+    reviewer_model = select_reviewer_model(installed)
+    if installed:
+        log.info(
+            f"Detected {len(installed)} installed Ollama model(s); "
+            f"selected reviewer model '{reviewer_model}'."
+        )
+    else:
+        log.warning(
+            f"Could not reach Ollama at {host} to detect models; defaulting "
+            f"reviewer to '{reviewer_model}'. Pull it (`ollama pull "
+            f"{reviewer_model}`) or edit the model name in {config_path}."
+        )
+
+    config = create_default_config(directory, output, reviewer_model=reviewer_model)
+
     with open(config_path, "w") as f:
         yaml.dump(config, f, sort_keys=False, default_flow_style=False)
-    
+
     log.info(f"Created configuration file: {config_path}")
 
 

--- a/ollama_sentinel/config.py
+++ b/ollama_sentinel/config.py
@@ -3,14 +3,95 @@ Configuration management for Ollama Sentinel.
 """
 import logging
 import pathlib
-from typing import Optional
+from typing import List, Optional, Sequence
 
+import httpx
 import yaml
 
 from .models import SentinelConfig
 from .triage.runner import TRIAGE_SYSTEM_PROMPT
 
 log = logging.getLogger("ollama-sentinel")
+
+# The reviewer model written into a fresh config when no installed model can be
+# detected (Ollama unreachable, or only embedding models present). It is a
+# small, broadly-available default; the user can `ollama pull` it or edit it.
+DEFAULT_REVIEWER_MODEL = "gemma3:4b"
+
+# Code-review quality preferences, applied only to break ties among installed
+# chat models. Coder models first; among the rest, known general-purpose
+# families before unknowns; clinical/specialist models last.
+_PREFERRED_FAMILIES = (
+    "qwen",
+    "llama",
+    "gemma",
+    "mistral",
+    "devstral",
+    "deepseek",
+    "codestral",
+    "phi",
+)
+# Specific fragments (not bare "med", which would match "medium") that mark a
+# domain-specialist model unsuited to general code review.
+_DISFAVORED_KEYWORDS = (
+    "meditron",
+    "medllama",
+    "medgemma",
+    "biomistral",
+    "clinical",
+)
+
+
+def list_installed_models(
+    host: str = "http://localhost:11434", timeout: float = 5.0
+) -> List[str]:
+    """Return the names of models installed in Ollama via ``GET /api/tags``.
+
+    Best-effort: returns an empty list on any failure (Ollama unreachable,
+    timeout, non-200, malformed payload) so callers never break.
+    """
+    url = host.rstrip("/") + "/api/tags"
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(url)
+            response.raise_for_status()
+            data = response.json()
+        return [m["name"] for m in data.get("models", []) if m.get("name")]
+    except Exception as e:  # noqa: BLE001 — detection must never break init
+        log.debug("Could not list installed Ollama models from %s: %s", url, e)
+        return []
+
+
+def select_reviewer_model(
+    installed: Sequence[str], fallback: str = DEFAULT_REVIEWER_MODEL
+) -> str:
+    """Pick the best reviewer model from ``installed`` names.
+
+    Heuristic (local-first): exclude embedding models, then prefer local over
+    cloud, coder models over general, general-purpose families over unknowns,
+    and clinical/specialist models last. Returns ``fallback`` when no
+    chat-capable model is installed.
+    """
+    candidates = [name for name in installed if "embed" not in name.lower()]
+    if not candidates:
+        return fallback
+
+    def rank(item):
+        idx, name = item
+        n = name.lower()
+        is_cloud = "cloud" in n
+        is_coder = "coder" in n or "-code" in n or n.startswith("code")
+        is_disfavored = any(k in n for k in _DISFAVORED_KEYWORDS)
+        is_preferred = any(k in n for k in _PREFERRED_FAMILIES)
+        return (
+            1 if is_cloud else 0,       # local before cloud (local-first)
+            0 if is_coder else 1,       # coder models preferred for review
+            1 if is_disfavored else 0,  # clinical/specialist models last
+            0 if is_preferred else 1,   # known families before unknowns
+            idx,                        # stable: preserve /api/tags order
+        )
+
+    return min(enumerate(candidates), key=rank)[1]
 
 
 def load_config(config_path: pathlib.Path) -> Optional[SentinelConfig]:
@@ -40,14 +121,20 @@ def load_config(config_path: pathlib.Path) -> Optional[SentinelConfig]:
     return None
 
 
-def create_default_config(directory: str, output_dir: str = ".ollama_reviews") -> dict:
+def create_default_config(
+    directory: str,
+    output_dir: str = ".ollama_reviews",
+    reviewer_model: str = DEFAULT_REVIEWER_MODEL,
+) -> dict:
     """
     Create a default configuration dictionary.
-    
+
     Args:
         directory: Directory to watch
         output_dir: Directory to store reviews
-        
+        reviewer_model: Ollama model name for the ``default`` and ``triage``
+            roles (typically auto-detected from installed models)
+
     Returns:
         Default configuration dictionary
     """
@@ -71,7 +158,7 @@ def create_default_config(directory: str, output_dir: str = ".ollama_reviews") -
             "request_timeout": 180,
             "models": {
                 "default": {
-                    "name": "gemma3:4b",
+                    "name": reviewer_model,
                     "system_prompt": (
                         "You are a senior code reviewer. Return constructive, actionable feedback "
                         "for each file: identify bugs (with line numbers), design smells, and "
@@ -83,7 +170,7 @@ def create_default_config(directory: str, output_dir: str = ".ollama_reviews") -
                     "output_reserve_tokens": 2000,
                 },
                 "triage": {
-                    "name": "gemma3:4b",
+                    "name": reviewer_model,
                     "system_prompt": TRIAGE_SYSTEM_PROMPT,
                     "context_window": 8192,
                     "output_reserve_tokens": 2000,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,15 @@ runner = CliRunner()
 class TestInitCommand:
     """Tests for 'ollama-sentinel init'."""
 
+    @staticmethod
+    def _stub_installed(monkeypatch, models):
+        """Make init's model detection deterministic (no live Ollama)."""
+        monkeypatch.setattr(
+            "ollama_sentinel.cli.list_installed_models", lambda *a, **k: models
+        )
+
     def test_creates_config_file(self, tmp_path, monkeypatch):
+        self._stub_installed(monkeypatch, [])
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, ["init", str(tmp_path)])
         assert result.exit_code == 0
@@ -22,6 +30,7 @@ class TestInitCommand:
         assert config_path.exists()
 
     def test_created_config_is_valid_yaml(self, tmp_path, monkeypatch):
+        self._stub_installed(monkeypatch, [])
         monkeypatch.chdir(tmp_path)
         runner.invoke(app, ["init", str(tmp_path)])
         config_path = tmp_path / "ollama-sentinel.yaml"
@@ -31,7 +40,20 @@ class TestInitCommand:
         assert "ollama" in config
         assert "default" in config["ollama"]["models"]
 
-    def test_created_config_uses_gemma3(self, tmp_path, monkeypatch):
+    def test_init_uses_detected_coder_model(self, tmp_path, monkeypatch):
+        self._stub_installed(monkeypatch, ["qwen3.6:35b", "qwen3-coder:30b"])
+        monkeypatch.chdir(tmp_path)
+        runner.invoke(app, ["init", str(tmp_path)])
+        config_path = tmp_path / "ollama-sentinel.yaml"
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+        assert config["ollama"]["models"]["default"]["name"] == "qwen3-coder:30b"
+        assert config["ollama"]["models"]["triage"]["name"] == "qwen3-coder:30b"
+
+    def test_init_falls_back_to_gemma3_when_ollama_unreachable(
+        self, tmp_path, monkeypatch
+    ):
+        self._stub_installed(monkeypatch, [])
         monkeypatch.chdir(tmp_path)
         runner.invoke(app, ["init", str(tmp_path)])
         config_path = tmp_path / "ollama-sentinel.yaml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,16 @@
 """Tests for ollama_sentinel config loading and default generation."""
 import pathlib
 
+import httpx
 import pytest
 import yaml
 
-from ollama_sentinel.config import create_default_config, load_config
+from ollama_sentinel.config import (
+    create_default_config,
+    list_installed_models,
+    load_config,
+    select_reviewer_model,
+)
 
 
 class TestLoadConfig:
@@ -67,6 +73,12 @@ class TestCreateDefaultConfig:
     def test_default_model_is_gemma3(self):
         config = create_default_config(".")
         assert config["ollama"]["models"]["default"]["name"] == "gemma3:4b"
+
+    def test_reviewer_model_param_overrides_default_and_triage(self):
+        config = create_default_config(".", reviewer_model="qwen3-coder:30b")
+        models = config["ollama"]["models"]
+        assert models["default"]["name"] == "qwen3-coder:30b"
+        assert models["triage"]["name"] == "qwen3-coder:30b"
 
     def test_default_has_required_model_key(self):
         config = create_default_config(".")
@@ -137,3 +149,75 @@ class TestCreateDefaultConfig:
         assert "DIAGNOSIS" in triage["system_prompt"]
         assert triage["context_window"] == 8192
         assert triage["output_reserve_tokens"] == 2000
+
+
+class TestSelectReviewerModel:
+    """Tests for select_reviewer_model() — pure model-selection heuristic."""
+
+    def test_empty_list_returns_fallback(self):
+        assert select_reviewer_model([]) == "gemma3:4b"
+
+    def test_custom_fallback_is_used_when_empty(self):
+        assert select_reviewer_model([], fallback="llama3:8b") == "llama3:8b"
+
+    def test_prefers_coder_model(self):
+        installed = ["qwen3.6:35b", "qwen3-coder:30b", "gemma3:4b"]
+        assert select_reviewer_model(installed) == "qwen3-coder:30b"
+
+    def test_excludes_embedding_models(self):
+        # An embedding model can't do chat review; never select it.
+        installed = ["qwen3-embedding:4b", "qwen3.6:35b"]
+        assert select_reviewer_model(installed) == "qwen3.6:35b"
+
+    def test_only_embedding_models_returns_fallback(self):
+        installed = ["qwen3-embedding:4b", "qwen3-embedding:8b"]
+        assert select_reviewer_model(installed) == "gemma3:4b"
+
+    def test_prefers_local_over_cloud(self):
+        # Local-first: a local chat model beats a cloud coder model.
+        installed = ["deepseek-v4-pro:cloud", "qwen3.6:35b"]
+        assert select_reviewer_model(installed) == "qwen3.6:35b"
+
+    def test_deprioritizes_medical_specialist_models(self):
+        # A general model is a better default reviewer than a clinical model,
+        # even though "medllama2" contains the preferred "llama" family token.
+        installed = ["medllama2:latest", "meditron:latest", "qwen3.6:35b"]
+        assert select_reviewer_model(installed) == "qwen3.6:35b"
+
+    def test_real_world_zoo_picks_coder(self):
+        installed = [
+            "qwen3-coder:30b",
+            "qwen3.6:35b",
+            "qwen3-embedding:4b",
+            "deepseek-v4-pro:cloud",
+            "devstral-2:123b-cloud",
+            "hf.co/MaziyarPanahi/BioMistral-Clinical-7B-GGUF:latest",
+            "medgemma1.5:4b",
+            "meditron:latest",
+            "medllama2:latest",
+        ]
+        assert select_reviewer_model(installed) == "qwen3-coder:30b"
+
+
+class TestListInstalledModels:
+    """Tests for list_installed_models() — best-effort /api/tags query."""
+
+    def test_returns_model_names_on_success(self, httpx_mock):
+        httpx_mock.add_response(
+            url="http://localhost:11434/api/tags",
+            json={"models": [{"name": "qwen3-coder:30b"}, {"name": "qwen3.6:35b"}]},
+        )
+        assert list_installed_models("http://localhost:11434") == [
+            "qwen3-coder:30b",
+            "qwen3.6:35b",
+        ]
+
+    def test_returns_empty_list_on_http_error(self, httpx_mock):
+        httpx_mock.add_response(
+            url="http://localhost:11434/api/tags", status_code=404
+        )
+        assert list_installed_models("http://localhost:11434") == []
+
+    def test_returns_empty_list_on_connection_error(self, httpx_mock):
+        httpx_mock.add_exception(httpx.ConnectError("connection refused"))
+        assert list_installed_models("http://localhost:11434") == []


### PR DESCRIPTION
## Problem

`ollama-sentinel init` wrote a config hardcoded to `gemma3:4b` for the `default` and `triage` roles (`config.py` `create_default_config`). On any machine without that model pulled, every review then 404s on `POST /api/chat` (Ollama's "model not found") — the cwd-shadowed config drift that silently broke fresh projects.

## Change

`init` now queries Ollama's `/api/tags` and writes the best **installed** model:

- **`list_installed_models(host, timeout)`** — best-effort `GET /api/tags`; returns `[]` on any failure (unreachable / timeout / non-200 / bad JSON) so detection never breaks `init`.
- **`select_reviewer_model(installed, fallback)`** — pure, **local-first** heuristic: exclude embedding models → prefer local over cloud → coder models over general → known families over unknowns → clinical/specialist models last → stable by `/api/tags` order. Falls back to `gemma3:4b` when nothing chat-capable is installed.
- **`create_default_config(..., reviewer_model=...)`** — `gemma3:4b` is now the offline-fallback constant only.
- **`cli.init`** composes them, logs the selected model, or warns to `ollama pull` when Ollama is unreachable.

### Design note
Ranking is **local-first** (a local model always beats a `:cloud` one), not "frontier cloud first" — the project is explicitly local-first and `:cloud` models ignore the format schema and degrade to the regex extractor (see PR #12).

## Tests
- 13 new tests (pure selection heuristic, `/api/tags` lister via `httpx_mock`, the `reviewer_model` param, two CLI `init` cases with detection stubbed for determinism).
- Suite **813 → 826 passed / 16 skipped**.
- Verified live: a 9-model install (coder + general + embedder + 2 cloud + 4 medical) selects `qwen3-coder:30b`.